### PR TITLE
Make Qt5 default

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(AppstreamQt)
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
-set(APPSTREAM_QT_VERSION "4" CACHE STRING "Used Qt version")
+set(APPSTREAM_QT_VERSION "5" CACHE STRING "Used Qt version")
 
 include(CMakePackageConfigHelpers)
 include(GenerateExportHeader)


### PR DESCRIPTION
After discussing with Ximion it, it looks like nobody is using
Appstream-Qt4, so it's fair to just use by default the most common
one.
At some point it will make sense to make it Qt5 only, to take
advantage of Qt5 features. This is just a first step.