### PR TITLE
Reinitialize the dep11 parser after each file.

### DIFF
--- a/src/as-dep11.c
+++ b/src/as-dep11.c
@@ -811,6 +811,17 @@ as_dep11_parse_data (AsDEP11 *dep11, const gchar *data, GError **error)
 	}
 
 	yaml_parser_delete (&parser);
+	if (priv->origin_name != NULL) {
+		g_free (priv->origin_name);
+		priv->origin_name = NULL;
+	}
+
+	if (priv->media_baseurl != NULL) {
+		g_free (priv->media_baseurl);
+		priv->media_baseurl = NULL;
+	}
+
+	priv->default_priority = 0;
 }
 
 /**


### PR DESCRIPTION
If more than one file is present in the yaml directory, the parsing will fail after the first file.
Added forgotten reinitialization.