### PR TITLE
lower cmake requirement to 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists for the AppStream Project
 project(appstream)
-cmake_minimum_required(VERSION 3.2.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 
 set(CMAKE_BUILD_TYPE "Debug")
 


### PR DESCRIPTION
eaf7229d57ccb77ca29efcfa2bf719ba8fbab568 suggests that it was bumped to
3.2 for CMAKE_CXX_STANDARD, this feature was however introduced in 3.1.

lower the cmake requirement from 3.2 to 3.1 to align with the actual
requirements

tested on 3.1.1