### PR TITLE
Polishing of the Qt interface

### DIFF
--- a/qt/database.cpp
+++ b/qt/database.cpp
@@ -229,6 +229,7 @@ Component xapianDocToComponent(Xapian::Document document) {
 
             images.append(image);
         }
+        scr.setImages(images);
 
         screenshots.append(scr);
     }

--- a/qt/database.cpp
+++ b/qt/database.cpp
@@ -201,16 +201,18 @@ Component xapianDocToComponent(Xapian::Document document) {
     str = document.get_value (XapianValues::SCREENSHOTS);
     pb_scrs.ParseFromString (str);
     QList<Appstream::Screenshot> screenshots;
+    screenshots.reserve(pb_scrs.screenshot_size ());
     for (int i = 0; i < pb_scrs.screenshot_size (); i++) {
         const Screenshots_Screenshot& pb_scr = pb_scrs.screenshot (i);
         Appstream::Screenshot scr;
-        QList<Appstream::Image> images;
 
         if (pb_scr.primary())
             scr.setDefault(true);
         if (pb_scr.has_caption())
             scr.setCaption(QString::fromStdString(pb_scr.caption()));
 
+        QList<Appstream::Image> images;
+        images.reserve(pb_scr.image_size());
         for (int j = 0; j < pb_scr.image_size(); j++) {
             const Screenshots_Image& pb_img = pb_scr.image(j);
             Appstream::Image image;
@@ -259,6 +261,7 @@ Component xapianDocToComponent(Xapian::Document document) {
 
 QList<Component> parseSearchResults(Xapian::MSet matches) {
     QList<Component> components;
+    components.reserve(matches.size());
     for (Xapian::MSetIterator it = matches.begin(); it != matches.end(); ++it) {
         Xapian::Document document = it.get_document ();
         components << xapianDocToComponent(document);
@@ -268,6 +271,7 @@ QList<Component> parseSearchResults(Xapian::MSet matches) {
 
 QList< Component > Database::allComponents() const {
     QList<Component> components;
+    components.reserve(d->m_db.get_termfreq(std::string()));
 
     // Iterate through all Xapian documents
     Xapian::PostingIterator it = d->m_db.postlist_begin (std::string());


### PR DESCRIPTION
Don't forget about screenshots.
Allocate before populating for better performance (reduced allocations).