### PR TITLE
50appstream: Only run as root

### DIFF
--- a/contrib/apt-conf/50appstream
+++ b/contrib/apt-conf/50appstream
@@ -44,5 +44,5 @@ Acquire::IndexTargets {
 
 # Refresh AppStream cache when APT's cache is updated (i.e. apt-cache update)
 APT::Update::Post-Invoke-Success {
-    "if /usr/bin/test -e /usr/bin/appstreamcli; then appstreamcli refresh > /dev/null; fi";
+    "if /usr/bin/test $(id -u) -eq 0 -a -e /usr/bin/appstreamcli; then appstreamcli refresh > /dev/null; fi";
 };


### PR DESCRIPTION
'appstreamcli refresh' only works when you are root. If you are running
'apt update' as a normal user (for example some sandboxed tools do
this), then the failure of this Post-Invoke-Success hook causes the
update to fail.

```
E: Problem executing scripts APT::Update::Post-Invoke-Success 'if /usr/bin/test -e /usr/bin/appstreamcli; then appstreamcli refresh > /dev/null; fi'
E: Sub-process returned an error code
```

You could do this in some other ways too - adding `|| true` to allow the refresh to fail or making appstreamcli exit 0 in this case.