### PR TITLE
[WIP] Allow AppStream to parse recommendations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ set(APPSTREAM_LIB_SRC
 		as-validator-issue.c
 		as-icon.c
 		as-translation.c
+		as-suggested.c
 )
 
 set(APPSTREAM_LIB_PUBLIC_HEADERS
@@ -84,6 +85,7 @@ set(APPSTREAM_LIB_PUBLIC_HEADERS
 		as-validator-issue.h
 		as-icon.h
 		as-translation.h
+		as-suggested.h
 )
 
 set(APPSTREAM_LIB_PRIVATE_HEADERS

--- a/src/appstream.h
+++ b/src/appstream.h
@@ -37,6 +37,7 @@ extern "C" {
 #include <as-distro-details.h>
 #include <as-icon.h>
 #include <as-screenshot.h>
+#include <as-suggested.h>
 #include <as-image.h>
 
 #include <as-validator.h>

--- a/src/as-component.c
+++ b/src/as-component.c
@@ -143,6 +143,7 @@ as_component_kind_get_type (void)
 					{AS_COMPONENT_KIND_INPUTMETHOD, "AS_COMPONENT_KIND_INPUTMETHOD", "inputmethod"},
 					{AS_COMPONENT_KIND_ADDON, "AS_COMPONENT_KIND_ADDON", "addon"},
 					{AS_COMPONENT_KIND_FIRMWARE, "AS_COMPONENT_KIND_FIRMWARE", "firmware"},
+					{AS_COMPONENT_KIND_MERGE, "AS_COMPONENT_KIND_MERGE", "merge"},
 					{AS_COMPONENT_KIND_LAST, "AS_COMPONENT_KIND_LAST", "last"},
 					{0, NULL, NULL}
 		};
@@ -178,6 +179,8 @@ as_component_kind_to_string (AsComponentKind kind)
 		return "addon";
 	if (kind == AS_COMPONENT_KIND_FIRMWARE)
 		return "firmware";
+	if (kind == AS_COMPONENT_KIND_MERGE)
+		return "merge";
 	return "unknown";
 }
 
@@ -206,6 +209,8 @@ as_component_kind_from_string (const gchar *kind_str)
 		return AS_COMPONENT_KIND_ADDON;
 	if (g_strcmp0 (kind_str, "firmware") == 0)
 		return AS_COMPONENT_KIND_FIRMWARE;
+	if (g_strcmp0 (kind_str, "merge") == 0)
+		return AS_COMPONENT_KIND_MERGE;
 	return AS_COMPONENT_KIND_UNKNOWN;
 }
 

--- a/src/as-component.c
+++ b/src/as-component.c
@@ -70,6 +70,7 @@ typedef struct
 	GPtrArray		*extensions; /* of string */
 	GPtrArray		*screenshots; /* of AsScreenshot elements */
 	GPtrArray		*releases; /* of AsRelease elements */
+	GPtrArray		*suggestions; /* of AsSuggested elements */
 
 	GHashTable		*provided; /* of int:object */
 	GHashTable		*urls; /* of int:utf8 */
@@ -119,7 +120,8 @@ enum  {
 	AS_COMPONENT_PROJECT_LICENSE,
 	AS_COMPONENT_PROJECT_GROUP,
 	AS_COMPONENT_DEVELOPER_NAME,
-	AS_COMPONENT_SCREENSHOTS
+	AS_COMPONENT_SCREENSHOTS,
+	AS_COMPONENT_SUGGESTIONS
 };
 
 /**
@@ -227,6 +229,7 @@ as_component_init (AsComponent *cpt)
 
 	priv->screenshots = g_ptr_array_new_with_free_func (g_object_unref);
 	priv->releases = g_ptr_array_new_with_free_func (g_object_unref);
+	priv->suggestions = g_ptr_array_new_with_free_func (g_object_unref);
 
 	priv->icons = g_ptr_array_new_with_free_func (g_object_unref);
 	priv->icons_sizetab = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
@@ -268,6 +271,7 @@ as_component_finalize (GObject* object)
 
 	g_ptr_array_unref (priv->screenshots);
 	g_ptr_array_unref (priv->releases);
+	g_ptr_array_unref (priv->suggestions);
 	g_hash_table_unref (priv->provided);
 	g_hash_table_unref (priv->urls);
 	g_hash_table_unref (priv->languages);
@@ -399,6 +403,22 @@ as_component_add_release (AsComponent *cpt, AsRelease* release)
 
 	releases = as_component_get_releases (cpt);
 	g_ptr_array_add (releases, g_object_ref (release));
+}
+
+/**
+ * as_component_add_suggestion:
+ * @cpt: a #AsComponent instance.
+ * @suggested: The #AsSuggested to add
+ *
+ * Add an #AsSuggested to this component.
+ **/
+void
+as_component_add_suggestion (AsComponent *cpt, AsSuggested* suggested)
+{
+	GPtrArray* suggestions;
+
+	suggestions = as_component_get_suggestions (cpt);
+	g_ptr_array_add (suggestions, g_object_ref (suggested));
 }
 
 /**
@@ -1361,6 +1381,22 @@ as_component_get_compulsory_for_desktops (AsComponent *cpt)
 }
 
 /**
+ * as_component_get_suggestions:
+ * @cpt: a #AsComponent instance.
+ *
+ * Get a list of associated suggestions.
+ *
+ * Returns: (element-type AsSuggested) (transfer none): an array of #AsSuggested instances
+ */
+GPtrArray*
+as_component_get_suggestions (AsComponent *cpt)
+{
+	AsComponentPrivate *priv = GET_PRIVATE (cpt);
+
+	return priv->suggestions;
+}
+
+/**
  * as_component_set_compulsory_for_desktops:
  * @cpt: a #AsComponent instance.
  * @value: (array zero-terminated=1): the array of desktop ids.
@@ -2234,6 +2270,9 @@ as_component_get_property (GObject * object, guint property_id, GValue * value, 
 		case AS_COMPONENT_SCREENSHOTS:
 			g_value_set_boxed (value, as_component_get_screenshots (cpt));
 			break;
+		case AS_COMPONENT_SUGGESTIONS:
+			g_value_set_boxed (value, as_component_get_suggestions (cpt));
+			break;
 		default:
 			G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
 			break;
@@ -2411,6 +2450,14 @@ as_component_class_init (AsComponentClass * klass)
 	g_object_class_install_property (object_class,
 					AS_COMPONENT_SCREENSHOTS,
 					g_param_spec_boxed ("screenshots", "screenshots", "screenshots", G_TYPE_PTR_ARRAY, G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB | G_PARAM_READABLE));
+	/**
+	 * AsComponent:suggestions: (type GPtrArray(AsSuggested)):
+	 *
+	 * An array of #AsSuggested instances
+	 */
+	g_object_class_install_property (object_class,
+					AS_COMPONENT_SUGGESTIONS,
+					g_param_spec_boxed ("suggestions", "suggestions", "suggestions", G_TYPE_PTR_ARRAY, G_PARAM_STATIC_NAME | G_PARAM_STATIC_NICK | G_PARAM_STATIC_BLURB | G_PARAM_READABLE));
 }
 
 /**

--- a/src/as-component.h
+++ b/src/as-component.h
@@ -32,6 +32,7 @@
 #include "as-screenshot.h"
 #include "as-release.h"
 #include "as-translation.h"
+#include "as-suggested.h"
 
 G_BEGIN_DECLS
 
@@ -154,6 +155,10 @@ gboolean		as_component_has_category (AsComponent *cpt,
 GPtrArray		*as_component_get_screenshots (AsComponent *cpt);
 void			as_component_add_screenshot (AsComponent *cpt,
 							AsScreenshot *sshot);
+
+GPtrArray		*as_component_get_suggestions (AsComponent *cpt);
+void			as_component_add_suggestion (AsComponent *cpt,
+							AsSuggested *suggested);
 
 gchar			**as_component_get_keywords (AsComponent *cpt);
 void			as_component_set_keywords (AsComponent *cpt,

--- a/src/as-component.h
+++ b/src/as-component.h
@@ -61,6 +61,7 @@ struct _AsComponentClass
  * @AS_COMPONENT_KIND_INPUTMETHOD:	An input-method provider
  * @AS_COMPONENT_KIND_ADDON:		An extension of existing software, which does not run standalone
  * @AS_COMPONENT_KIND_FIRMWARE:		Firmware
+ * @AS_COMPONENT_KIND_MERGE:		A component used to provide additional information to an existing component
  *
  * The type of an #AsComponent.
  **/
@@ -73,6 +74,7 @@ typedef enum  {
 	AS_COMPONENT_KIND_INPUTMETHOD,
 	AS_COMPONENT_KIND_ADDON,
 	AS_COMPONENT_KIND_FIRMWARE,
+	AS_COMPONENT_KIND_MERGE,
 	/*< private >*/
 	AS_COMPONENT_KIND_LAST
 } AsComponentKind;

--- a/src/as-data-pool.c
+++ b/src/as-data-pool.c
@@ -215,6 +215,7 @@ as_data_pool_merge_components (AsDataPool *dpool, AsComponent *src_cpt, AsCompon
 	guint i;
 	gchar **cats;
 	gchar **pkgnames;
+	GPtrArray* suggestions;
 
 	/* FIXME: We only do this for GNOME Software compatibility. In future, we need better rules on what to merge how, and
 	 * whether we want to merge stuff at all. */
@@ -242,6 +243,12 @@ as_data_pool_merge_components (AsDataPool *dpool, AsComponent *src_cpt, AsCompon
 	pkgnames = as_component_get_pkgnames (src_cpt);
 	if ((pkgnames != NULL) && (pkgnames[0] != '\0'))
 		as_component_set_pkgnames (dest_cpt, as_component_get_pkgnames (src_cpt));
+
+	suggestions = as_component_get_suggestions (src_cpt);
+	if (suggestions != NULL) {
+		for (i = 0; i < suggestions->len; i++)
+			as_component_add_suggestion (dest_cpt, g_ptr_array_index (suggestions, i));
+	}
 
 	if (as_component_has_bundle (src_cpt))
 		as_component_set_bundles_table (dest_cpt, as_component_get_bundles_table (src_cpt));

--- a/src/as-data-pool.c
+++ b/src/as-data-pool.c
@@ -216,9 +216,15 @@ as_data_pool_merge_components (AsDataPool *dpool, AsComponent *src_cpt, AsCompon
 	gchar **cats;
 	gchar **pkgnames;
 	GPtrArray* suggestions;
+	AsComponentKind src_kind;
 
 	/* FIXME: We only do this for GNOME Software compatibility. In future, we need better rules on what to merge how, and
 	 * whether we want to merge stuff at all. */
+
+	src_kind = as_component_get_kind (src_cpt);
+	
+	if (src_kind != AS_COMPONENT_KIND_MERGE)
+		return;
 
 	cats = as_component_get_categories (src_cpt);
 	if (cats != NULL) {

--- a/src/as-suggested.c
+++ b/src/as-suggested.c
@@ -1,0 +1,214 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2016 Lucas Moura <lucas.moura128@gmail.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * SECTION: as-suggested
+ * @short_description: Descibe which componentes were responsible for
+ *					   a given package recommendation.
+ * @include: appstream.h
+ */
+
+#include "config.h"
+
+#include "as-suggested.h"
+
+typedef struct
+{
+	AsSuggestedKind	kind;
+	GPtrArray		*cpts_id; /* of string */
+} AsSuggestedPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (AsSuggested, as_suggested, G_TYPE_OBJECT)
+#define GET_PRIVATE(o) (as_suggested_get_instance_private (o))
+
+/**
+ * as_suggested_kind_to_string:
+ * @kind: the %AsSuggestedKind.
+ *
+ * Converts the enumerated value to an text representation.
+ *
+ * Returns: string version of @kind
+ **/
+const gchar*
+as_suggested_kind_to_string (AsSuggestedKind kind)
+{
+	if (kind == AS_SUGGESTED_KIND_HEURISTIC)
+		return "heuristic";
+	if (kind == AS_SUGGESTED_KIND_UPSTREAM)
+		return "upstream";
+
+	return "unknown";
+}
+
+/**
+ * as_suggested_kind_from_string:
+ * @kind_str: the string.
+ *
+ * Converts the text representation to an enumerated value.
+ *
+ * Returns: a #AsSuggestedKind or %AS_SUGGESTED_KIND_UNKNOWN for unknown
+ **/
+AsSuggestedKind
+as_suggested_kind_from_string (const gchar *kind_str)
+{
+	if (g_strcmp0 (kind_str, "heuristic") == 0)
+		return AS_SUGGESTED_KIND_HEURISTIC;
+	if (g_strcmp0 (kind_str, "upstream") == 0)
+		return AS_SUGGESTED_KIND_UPSTREAM;
+
+	return AS_SUGGESTED_KIND_UNKNOWN;
+}
+
+/**
+ * as_suggested_finalize:
+ **/
+static void
+as_suggested_finalize (GObject *object)
+{
+	AsSuggested *suggested = AS_SUGGESTED (object);
+	AsSuggestedPrivate *priv = GET_PRIVATE (suggested);
+
+	g_ptr_array_unref (priv->cpts_id);
+
+	G_OBJECT_CLASS (as_suggested_parent_class)->finalize (object);
+}
+
+/**
+ * as_suggested_init:
+ **/
+static void
+as_suggested_init (AsSuggested *suggested)
+{
+	AsSuggestedPrivate *priv = GET_PRIVATE (suggested);
+
+	priv->cpts_id = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+}
+
+/**
+ * as_suggested_new:
+ *
+ * Creates a new #AsSuggested.
+ *
+ * Returns: (transfer full): a new #AsSuggested
+ **/
+AsSuggested*
+as_suggested_new (void)
+{
+	AsSuggested *suggested;
+	suggested = g_object_new (AS_TYPE_SUGGESTED, NULL);
+	return AS_SUGGESTED (suggested);
+}
+
+/**
+ * as_suggested_class_init:
+ **/
+static void
+as_suggested_class_init (AsSuggestedClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = as_suggested_finalize;
+}
+
+/**
+ * as_suggested_get_kind:
+ * @suggested: a #AsSuggested instance.
+ *
+ * Gets the suggested kind.
+ *
+ * Returns: the #AssuggestedKind
+ **/
+AsSuggestedKind
+as_suggested_get_kind (AsSuggested *suggested)
+{
+	AsSuggestedPrivate *priv = GET_PRIVATE (suggested);
+	return priv->kind;
+}
+
+/**
+ * as_suggested_set_kind:
+ * @suggested: a #AsSuggested instance.
+ * @kind: the #AsSuggestedKind, e.g. %AS_SUGGESTED_KIND_HEURISTIC.
+ *
+ * Sets the suggested kind.
+ **/
+void
+as_suggested_set_kind (AsSuggested *suggested, AsSuggestedKind kind)
+{
+	AsSuggestedPrivate *priv = GET_PRIVATE (suggested);
+	priv->kind = kind;
+}
+
+/**
+ * as_suggested_get_components_id:
+ * @suggested: a #AsSuggested instance.
+ *
+ * Get a list of components id that generated the suggestion
+ *
+ * Returns: an array of components id
+ */
+GPtrArray*
+as_suggested_get_components_id (AsSuggested* suggested)
+{
+	AsSuggestedPrivate *priv = GET_PRIVATE (suggested);
+
+	return priv->cpts_id;
+}
+
+
+/**
+ * as_suggested_add_component_id:
+ * @suggested: a #AsSuggested instance.
+ * @cpt_id: The component id to add
+ *
+ * Add a component id to this suggested object.
+ **/
+void
+as_suggested_add_component_id (AsSuggested *suggested, gchar* cpt_id)
+{
+	AsSuggestedPrivate *priv = GET_PRIVATE (suggested);
+	g_ptr_array_add (priv->cpts_id, cpt_id);
+}
+
+/**
+ * as_suggested_is_valid:
+ * @suggested: a #AsSuggested instance.
+ *
+ * Check if the essential properties of this suggestion are
+ * populated with useful data.
+ *
+ * Returns: TRUE if the suggestion data was validated successfully.
+ */
+gboolean
+as_suggested_is_valid (AsSuggested *suggested)
+{
+	gboolean ret = FALSE;
+	AsSuggestedKind stype;
+
+	AsSuggestedPrivate *priv = GET_PRIVATE (suggested);
+
+	stype = priv->kind;
+	if (stype == AS_SUGGESTED_KIND_UNKNOWN)
+		return FALSE;
+
+	if (priv->cpts_id->len != 0)
+		ret = TRUE;
+
+	return ret;
+}

--- a/src/as-suggested.h
+++ b/src/as-suggested.h
@@ -1,0 +1,79 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2016 Lucas Moura <lucas.moura128@gmail.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined (__APPSTREAM_H) && !defined (AS_COMPILATION)
+#error "Only <appstream.h> can be included directly."
+#endif
+
+#ifndef __AS_SUGGESTED_H
+#define __AS_SUGGESTED_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define AS_TYPE_SUGGESTED (as_suggested_get_type ())
+G_DECLARE_DERIVABLE_TYPE (AsSuggested, as_suggested, AS, SUGGESTED, GObject)
+
+struct _AsSuggestedClass
+{
+	GObjectClass		parent_class;
+	/*< private >*/
+	void (*_as_reserved1)	(void);
+	void (*_as_reserved2)	(void);
+	void (*_as_reserved3)	(void);
+	void (*_as_reserved4)	(void);
+	void (*_as_reserved5)	(void);
+	void (*_as_reserved6)	(void);
+};
+
+/**
+ * AsSuggestedKind:
+ * @as_suggested_KIND_UNKNOWN:	Unknown suggested kind
+ * @AS_SUGGESTED_KIND_HEURISTIC: suggested created by a recommender application
+ *
+ * The suggested type.
+ **/
+typedef enum  {
+	AS_SUGGESTED_KIND_UNKNOWN,
+	AS_SUGGESTED_KIND_HEURISTIC,
+	AS_SUGGESTED_KIND_UPSTREAM,
+	/*< private >*/
+	AS_SUGGESTED_KIND_LAST
+} AsSuggestedKind;
+
+AsSuggestedKind		as_suggested_kind_from_string (const gchar *kind_str);
+const gchar			*as_suggested_kind_to_string (AsSuggestedKind kind);
+
+AsSuggested			*as_suggested_new (void);
+
+AsSuggestedKind     as_suggested_get_kind (AsSuggested *suggested);
+void				as_suggested_set_kind (AsSuggested *suggested,
+						AsSuggestedKind kind);
+
+GPtrArray*			as_suggested_get_components_id (AsSuggested *suggested);
+void				as_suggested_add_component_id (AsSuggested *suggested, gchar* cpt_id);
+
+gboolean			as_suggested_is_valid (AsSuggested *suggested);
+
+
+G_END_DECLS
+
+#endif /* __AS_SUGGESTED_H */

--- a/src/as-xmldata.c
+++ b/src/as-xmldata.c
@@ -443,6 +443,50 @@ as_xmldata_process_screenshots_tag (AsXMLData *xdt, xmlNode* node, AsComponent* 
 }
 
 /**
+ * as_xmldata_process_suggests_tag:
+ */
+static void
+as_xmldata_process_suggests_tag (AsXMLData *xdt, xmlNode* node, AsComponent* cpt)
+{
+	xmlNode *iter;
+	AsSuggested *suggested = NULL;
+	AsSuggestedKind suggested_kind;
+	gchar *node_name;
+	gchar *type_str;
+	gchar *content;
+
+	g_return_if_fail (xdt != NULL);
+	g_return_if_fail (cpt != NULL);
+
+	suggested = as_suggested_new ();
+	type_str = (gchar*) xmlGetProp (node, (xmlChar*) "type");
+
+	if (type_str != NULL) {
+		suggested_kind = as_suggested_kind_from_string (type_str);
+		as_suggested_set_kind (suggested, suggested_kind);
+	}
+
+	for (iter = node->children; iter != NULL; iter = iter->next) {
+		/* discard spaces */
+		if (iter->type != XML_ELEMENT_NODE)
+			continue;
+
+		node_name = (gchar*) iter->name;
+
+		if (g_strcmp0 (node_name, "id") == 0) {
+			content = as_xmldata_get_node_value (xdt, iter);
+
+			if (content != NULL)
+				as_suggested_add_component_id (suggested, content);
+		}
+
+		if (as_suggested_is_valid (suggested))
+			as_component_add_suggestion (cpt, suggested);
+
+	}
+}
+
+/**
  * as_xmldata_upstream_description_to_cpt:
  *
  * Helper function for GHashTable
@@ -940,6 +984,8 @@ as_xmldata_parse_component_node (AsXMLData *xdt, xmlNode* node, AsComponent *cpt
 			as_xmldata_process_provides (xdt, iter, cpt);
 		} else if (g_strcmp0 (node_name, "screenshots") == 0) {
 			as_xmldata_process_screenshots_tag (xdt, iter, cpt);
+		} else if (g_strcmp0 (node_name, "suggests") == 0) {
+			as_xmldata_process_suggests_tag (xdt, iter, cpt);
 		} else if (g_strcmp0 (node_name, "project_license") == 0) {
 			if (content != NULL)
 				as_component_set_project_license (cpt, content);

--- a/tests/samples/distro/xmls/suggestions.xml
+++ b/tests/samples/distro/xmls/suggestions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<components version="0.8" origin="jessie">
+  <component type="desktop">
+    <id>test.desktop</id>
+    <pkgname>test</pkgname>
+    <name>Test</name>
+    <suggests type="heuristic">
+      <id>test1.desktop</id>
+      <id>test2.desktop</id>
+    </suggests>
+  </component>
+  <component type="desktop">
+    <id>test1.desktop</id>
+    <pkgname>test</pkgname>
+    <name>Test</name>
+  </component>
+  <component type="desktop">
+    <id>test1.desktop</id>
+    <suggests type="heuristic">
+      <id>test5.desktop</id>
+      <id>test6.desktop</id>
+    </suggests>
+  </component>
+</components>

--- a/tests/samples/distro/xmls/suggestions.xml
+++ b/tests/samples/distro/xmls/suggestions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <components version="0.8" origin="jessie">
-  <component type="desktop">
+  <component type="merge">
     <id>test.desktop</id>
     <pkgname>test</pkgname>
     <name>Test</name>
@@ -9,16 +9,23 @@
       <id>test2.desktop</id>
     </suggests>
   </component>
-  <component type="desktop">
+  <component type="merge">
     <id>test1.desktop</id>
     <pkgname>test</pkgname>
     <name>Test</name>
   </component>
-  <component type="desktop">
+  <component type="merge">
     <id>test1.desktop</id>
     <suggests type="heuristic">
       <id>test5.desktop</id>
       <id>test6.desktop</id>
+    </suggests>
+  </component>
+  <component type="desktop">
+    <id>test1.desktop</id>
+    <suggests type="heuristic">
+      <id>test7.desktop</id>
+      <id>test8.desktop</id>
     </suggests>
   </component>
 </components>


### PR DESCRIPTION
This MR add the feature to AppStream to allow it to parse recommendation files. A recommendation file is defined by a XML document in the following format:

```xml
<?xml version="1.0"?>
    <recommendations>
        <recommendation>
            <id>vim.desktop</id>
            <because>
                <id>emacs.desktop</id>
            </because>
        </recommendation>
        <recommendation>
            <id>ipython.desktop</id>
            <because>
                <id>eric.desktop</id>
                <id>winpdb.desktop</id>
            </because>
        </recommendation>
    </recommendations>
```

Where *id* is the package being recommended and *because* is the user packages that generated this recommendation.

Currently,  it is already working the construction and parsing of a valid XML recommendation, however there are some necessary improvements to be done:

* There is a lot of code that equals the one on the core AppStream modules and a refactoring is necessary to fix that.
* It is necessary to validate a recommendation object, because if the *recommended* package is not indexed by AppStream, the recommendation object should be invalid.
* Add an appstreamcli function to parse and display the recommendations.
* Validate the XML that represents a recommendation.

Therefore, this MR is manly to collect feedback from the AppStream community regarding this feature.