### PR TITLE
as_flags_value is broken

### DIFF
--- a/src/as-component.c
+++ b/src/as-component.c
@@ -2426,7 +2426,7 @@ as_component_set_token_cache_valid (AsComponent *cpt, gboolean valid)
 /**
  * as_component_set_value_flags
  * @cpt: a #AsComponent instance.
- * @flag: #AsValueFlags to set on @cpt.
+ * @flags: #AsValueFlags to set on @cpt.
  *
  */
 void

--- a/src/as-enums.h
+++ b/src/as-enums.h
@@ -30,7 +30,7 @@ G_BEGIN_DECLS
 #define as_flags_remove(bitfield,enum)		do { ((bitfield) &= ~(as_flags_value(enum))); } while (0)
 #define as_flags_invert(bitfield,enum)		do { ((bitfield) ^= (as_flags_value(enum))); } while (0)
 #define as_flags_contains(bitfield,enum)	(((bitfield) & (as_flags_value(enum))) > 0)
-#define as_flags_value(enum)			((guint64) 1 << (enum))
+#define as_flags_value(enum)			((guint64) (enum))
 
 /**
  * AsUrlKind:


### PR DESCRIPTION
Not sure what you intended here - but the test case doesn't pass, and it doesn't work in asgen either. The values get shifted twice, which means the test never works.

This fixes it for me, but if you had something else in mind then please do that instead. The second commit is just a typo fix.