### PR TITLE
Implement Appstream::Release for the Qt interface

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -27,6 +27,7 @@ set(APPSTREAMQT_SRC
           image.cpp
           provides.cpp
           screenshot.cpp
+          release.cpp
 )
 
 set(APPSTREAMQT_PUBLIC_HEADERS
@@ -35,6 +36,7 @@ set(APPSTREAMQT_PUBLIC_HEADERS
     image.h
     provides.h
     screenshot.h
+    release.h
 )
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}

--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -19,6 +19,7 @@
 
 #include "component.h"
 #include "screenshot.h"
+#include "release.h"
 #include <QSharedData>
 #include <QStringList>
 #include <QUrl>
@@ -53,6 +54,7 @@ class Appstream::ComponentData : public QSharedData {
         QList<Appstream::Screenshot> m_screenshots;
         QMultiHash<Provides::Kind, Provides> m_provides;
         QHash<Component::BundleKind, QString> m_bundles;
+        QList<Release> m_releases;
         bool operator==(const ComponentData& other) const {
             if(m_categories != other.m_categories) {
                 return false;
@@ -106,6 +108,9 @@ class Appstream::ComponentData : public QSharedData {
                 return false;
             }
             if(m_bundles != other.m_bundles) {
+                return false;
+            }
+            if(m_releases != other.m_releases) {
                 return false;
             }
 
@@ -421,6 +426,16 @@ void Component::setProvides(const QList<Appstream::Provides>& provides) {
     Q_FOREACH(const Appstream::Provides& provide, provides) {
         d->m_provides.insertMulti(provide.kind(), provide);
     }
+}
+
+QList<Appstream::Release> Appstream::Component::releases() const
+{
+    return d->m_releases;
+}
+
+void Appstream::Component::setReleases(const QList<Appstream::Release>& releases)
+{
+    d->m_releases = releases;
 }
 
 bool Component::isValid() const

--- a/qt/component.h
+++ b/qt/component.h
@@ -29,10 +29,10 @@
 #include "appstreamqt_export.h"
 #include "provides.h"
 
-
 namespace Appstream {
 
 class Screenshot;
+class Release;
 
 class ComponentData;
 
@@ -168,6 +168,8 @@ class APPSTREAMQT_EXPORT Component {
         QHash<BundleKind, QString> bundles() const;
         QString bundle(BundleKind kind) const;
 
+        void setReleases(const QList<Appstream::Release> &releases);
+        QList<Appstream::Release> releases() const;
 
         /**
          * \returns whether the component is fully initialized

--- a/qt/database.cpp
+++ b/qt/database.cpp
@@ -34,6 +34,7 @@
 
 #include "image.h"
 #include "screenshot.h"
+#include "release.h"
 
 Q_LOGGING_CATEGORY(APPSTREAMQT_DB, "appstreamqt.database")
 
@@ -112,7 +113,6 @@ QStringList value(GPtrArray *array) {
 
 Component convertAsComponent(AsComponent *cpt) {
     Component component;
-    std::string str;
 
     // kind
     QString kindString = value (as_component_kind_to_string (as_component_get_kind (cpt)));
@@ -275,7 +275,13 @@ Component convertAsComponent(AsComponent *cpt) {
     component.setDeveloperName(developerName);
 
     // Releases
-      // TODO
+    QList<Release> releases;
+    auto releaseArray = as_component_get_releases(cpt);
+    for (uint i = 0; i < releaseArray->len; i++) {
+        auto release = AS_RELEASE (g_ptr_array_index (releaseArray, i));
+        releases += Release(release);
+    }
+    component.setReleases(releases);
 
     return component;
 }

--- a/qt/release.cpp
+++ b/qt/release.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2016 Aleix Pol Gonzalez <aleixpol@kde.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "appstream.h"
+
+#include "release.h"
+
+#include <QDateTime>
+#include <QDebug>
+#include <QUrl>
+
+using namespace Appstream;
+
+class Appstream::ReleaseData : public QSharedData {
+public:
+    ReleaseData(AsRelease* rel) : m_release(rel)
+    {
+        g_object_ref(m_release);
+    }
+
+    ~ReleaseData()
+    {
+        g_object_unref(m_release);
+    }
+
+    bool operator==(const ReleaseData& rd) const
+    {
+        return rd.m_release == m_release;
+    }
+
+    AsRelease* m_release;
+};
+
+Release::Release(_AsRelease* release)
+    : d(new ReleaseData(release))
+{}
+
+Release::Release(const Release &release) = default;
+
+Release::~Release() = default;
+
+Release& Release::operator=(const Release &release) = default;
+
+bool Release::operator==(const Release &other) const
+{
+    if(this->d == other.d) {
+        return true;
+    }
+    if(this->d && other.d) {
+        return *(this->d) == *other.d;
+    }
+    return false;
+}
+
+QString Release::version() const
+{
+    return QString::fromUtf8(as_release_get_version(d->m_release));
+}
+
+QDateTime Release::timestamp() const
+{
+    return QDateTime::fromTime_t(as_release_get_timestamp(d->m_release));
+}
+
+QString Release::description() const
+{
+    return QString::fromUtf8(as_release_get_description(d->m_release));
+}
+
+QString Release::activeLocale() const
+{
+    return QString::fromUtf8(as_release_get_active_locale(d->m_release));
+}
+
+QList<QUrl> Release::locations() const
+{
+    auto urls = as_release_get_locations(d->m_release);
+    QList<QUrl> ret;
+    ret.reserve(urls->len);
+    for(uint i = 0; i<urls->len; ++i) {
+        auto strval = (const gchar*) g_ptr_array_index (urls, i);
+        ret << QUrl(QString::fromUtf8(strval));
+    }
+    return ret;
+}
+
+Checksum Release::checksum() const
+{
+    {
+        auto cs = as_release_get_checksum(d->m_release, AS_CHECKSUM_KIND_SHA256);
+        if (cs)
+            return Checksum { Checksum::Sha256Checksum, QByteArray(cs) };
+    }
+
+    {
+        auto cs = as_release_get_checksum(d->m_release, AS_CHECKSUM_KIND_SHA1);
+        if (cs)
+            return Checksum { Checksum::Sha1Checksum, QByteArray(cs) };
+    }
+    return Checksum { Checksum::NoneChecksum, "" };
+}
+
+QHash<Release::SizeKind, quint64> Release::sizes() const
+{
+    return {
+        { InstalledSize, as_release_get_size(d->m_release, AS_SIZE_KIND_INSTALLED) },
+        { DownloadSize, as_release_get_size(d->m_release, AS_SIZE_KIND_DOWNLOAD) }
+    };
+}
+
+Release::UrgencyKind Release::urgency() const
+{
+    return Release::UrgencyKind(as_release_get_urgency(d->m_release));
+}
+
+QDebug operator<<(QDebug s, const Appstream::Release& release)
+{
+    s.nospace() << "Appstream::Release(" << release.version() << ": " << release.description() << ")";
+    return s.space();
+}

--- a/qt/release.h
+++ b/qt/release.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016 Aleix Pol Gonzalez <aleixpol@kde.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#ifndef APPSTREAMQT_RELEASE_H
+#define APPSTREAMQT_RELEASE_H
+
+#include <QSharedDataPointer>
+#include <QString>
+#include <QObject>
+#include <QCryptographicHash>
+#include "appstreamqt_export.h"
+
+struct _AsRelease;
+
+namespace Appstream {
+
+class ReleaseData;
+
+struct Checksum {
+    enum ChecksumKind {
+        NoneChecksum,
+        Sha256Checksum,
+        Sha1Checksum,
+        LastChecksum
+    };
+    const ChecksumKind kind;
+    const QByteArray data;
+};
+
+class APPSTREAMQT_EXPORT Release {
+    Q_GADGET
+    public:
+        Release(_AsRelease* release);
+        Release(const Release& release);
+        ~Release();
+
+        Release& operator=(const Release& release);
+        bool operator==(const Release& r) const;
+
+        enum SizeKind {
+            UnknownSize,
+            DownloadSize,
+            InstalledSize,
+            LastSize
+        };
+        Q_ENUM(SizeKind)
+
+        enum UrgencyKind {
+            UnknownUrgency,
+            LowUrgency,
+            MediumUrgency,
+            HighUrgency,
+            CriticalUrgency,
+            LastUrgency
+        };
+        Q_ENUM(UrgencyKind)
+
+        QString version() const;
+
+        QDateTime timestamp() const;
+
+        QString description() const;
+
+        QString activeLocale() const;
+
+        QList<QUrl> locations() const;
+
+        Checksum checksum() const;
+
+        QHash<SizeKind, quint64> sizes() const;
+
+        UrgencyKind urgency() const;
+
+    private:
+        QSharedDataPointer<ReleaseData> d;
+};
+}
+
+APPSTREAMQT_EXPORT QDebug operator<<(QDebug s, const Appstream::Release& release);
+
+#endif // APPSTREAMQT_RELEASE_H


### PR DESCRIPTION
This way we can access release information when using libappstreamqt