### PR TITLE
Sort search results by highest to lowest match scores

### DIFF
--- a/src/as-pool.c
+++ b/src/as-pool.c
@@ -1045,7 +1045,8 @@ as_pool_build_search_terms (AsPool *pool, const gchar *search)
 /**
  * as_sort_components_by_score_cb:
  *
- * Helper method to sort result arrays by the #AsComponent match score.
+ * Helper method to sort result arrays by the #AsComponent match score
+ * with higher scores appearing higher in the list.
  */
 static gint
 as_sort_components_by_score_cb (gconstpointer a, gconstpointer b)
@@ -1056,9 +1057,9 @@ as_sort_components_by_score_cb (gconstpointer a, gconstpointer b)
 	s1 = as_component_get_sort_score (cpt1);
 	s2 = as_component_get_sort_score (cpt2);
 
-	if (s1 < s2)
-		return -1;
 	if (s1 > s2)
+		return -1;
+	if (s1 < s2)
 		return 1;
 	return 0;
 }
@@ -1069,7 +1070,7 @@ as_sort_components_by_score_cb (gconstpointer a, gconstpointer b)
  * @search: A search string
  *
  * Search for a list of components matching the search terms.
- * The list will be unordered.
+ * The list will be ordered by match score.
  *
  * Returns: (transfer container) (element-type AsComponent): an array of the found #AsComponent objects.
  *


### PR DESCRIPTION
Although the comment header in as_pool_search claims that the results are returned unordered, they are specifically ordered from lowest to highest match score. If search results are going to be sorted, I believe it makes more sense for higher scores to be at the top of the list.

Fixes #77.