### PR TITLE
Replace refresh-index with refresh in help text

### DIFF
--- a/tools/appstream-cli.c
+++ b/tools/appstream-cli.c
@@ -543,7 +543,7 @@ as_client_get_summary ()
 	g_string_append_printf (string, "    %s - %s\n", "VALUE", _("Value of the item that should be found."));
 	g_string_append (string, "\n");
 	g_string_append_printf (string, "  %s - %s\n", "dump COMPONENT-ID", _("Dump raw XML metadata for a component matching the ID."));
-	g_string_append_printf (string, "  %s - %s\n", "refresh          ", _("Rebuild the component metadata cache."));
+	g_string_append_printf (string, "  %s - %s\n", "refresh-cache    ", _("Rebuild the component metadata cache."));
 	g_string_append (string, "\n");
 	g_string_append_printf (string, "  %s - %s\n", "validate FILE          ", _("Validate AppStream XML files for issues."));
 	g_string_append_printf (string, "  %s - %s\n", "validate-tree DIRECTORY", _("Validate an installed file-tree of an application for valid metadata."));

--- a/tools/appstream-cli.c
+++ b/tools/appstream-cli.c
@@ -543,7 +543,7 @@ as_client_get_summary ()
 	g_string_append_printf (string, "    %s - %s\n", "VALUE", _("Value of the item that should be found."));
 	g_string_append (string, "\n");
 	g_string_append_printf (string, "  %s - %s\n", "dump COMPONENT-ID", _("Dump raw XML metadata for a component matching the ID."));
-	g_string_append_printf (string, "  %s - %s\n", "refresh-index    ", _("Rebuild the component metadata cache."));
+	g_string_append_printf (string, "  %s - %s\n", "refresh          ", _("Rebuild the component metadata cache."));
 	g_string_append (string, "\n");
 	g_string_append_printf (string, "  %s - %s\n", "validate FILE          ", _("Validate AppStream XML files for issues."));
 	g_string_append_printf (string, "  %s - %s\n", "validate-tree DIRECTORY", _("Validate an installed file-tree of an application for valid metadata."));


### PR DESCRIPTION
I noticed the "--help" text was no longer accurate in recent versions of appstream. I replaced the "refresh-index" text with the "refresh" command. This could also or alternatively show "refresh-cache" if preferred, but it seems the pattern is to show the basic command in the "help" text and alternatives in the man page.