### PR TITLE
Directly offer a QIcon from the component

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CMakePackageConfigHelpers)
 include(GenerateExportHeader)
 add_compiler_export_flags()
 
-find_package(Qt5 REQUIRED COMPONENTS Core)
+find_package(Qt5 REQUIRED COMPONENTS Gui)
 pkg_check_modules(GLIB2 REQUIRED glib-2.0>=2.46)
 include(GNUInstallDirs)
 
@@ -50,7 +50,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_library(AppStreamQt SHARED ${APPSTREAMQT_SRC})
-target_link_libraries(AppStreamQt PUBLIC Qt5::Core
+target_link_libraries(AppStreamQt PUBLIC Qt5::Gui
                                   PRIVATE appstream
                                           ${GLIB2_LIBRARIES}
                                           ${SANITIZER_LIBS})

--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -25,6 +25,8 @@
 #include <QUrl>
 #include <QMap>
 #include <QMultiHash>
+#include <QDebug>
+#include <QIcon>
 #include "chelpers.h"
 #include "screenshot.h"
 #include "release.h"
@@ -356,4 +358,32 @@ Bundle Component::bundle(Bundle::Kind kind) const
     if (bundle == NULL)
         return nullptr;
     return bundle;
+}
+
+QIcon AppStream::Component::icon() const
+{
+    QIcon ret;
+    auto icons = as_component_get_icons(m_cpt);
+    for (int i = 0; i < icons->len; i++) {
+        AsIcon *icon = AS_ICON (g_ptr_array_index (icons, i));
+        const QSize size(as_icon_get_width(icon), as_icon_get_height(icon));
+
+        switch (as_icon_get_kind (icon)) {
+            case AS_ICON_KIND_LOCAL:
+                ret.addFile(as_icon_get_filename(icon), size);
+                break;
+            case AS_ICON_KIND_CACHED:
+                ret.addFile(as_icon_get_filename(icon), size);
+                break;
+            case AS_ICON_KIND_STOCK:
+                if (ret.isNull())
+                    ret = QIcon::fromTheme(as_icon_get_name(icon));
+                break;
+            default:
+            case AS_ICON_KIND_REMOTE:
+                qWarning() << "Unsupported remote icons";
+                break;
+        }
+    }
+    return ret;
 }

--- a/qt/component.h
+++ b/qt/component.h
@@ -143,6 +143,11 @@ Q_GADGET
         QList<AppStream::Bundle> bundles() const;
         AppStream::Bundle bundle(Bundle::Kind kind) const;
 
+        /**
+         * \returns an icon that represents the component
+         */
+        QIcon icon() const;
+
     private:
         _AsComponent *m_cpt;
 };


### PR DESCRIPTION
Instead of giving the different pieces (which could also be accessible
through the API)