### PR TITLE
Reduce source incompatibility against last version

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -76,6 +76,9 @@ install(TARGETS AppStreamQt EXPORT AppStreamLibsTarget
 
 install(FILES ${APPSTREAMQT_PUBLIC_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/appstreamqt_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/AppStreamQt")
 
+#deprecated
+install(FILES ${APPSTREAMQT_PUBLIC_HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/appstreamqt_export.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/AppstreamQt")
+
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/AppStreamQt)
 
 configure_file(
@@ -84,10 +87,12 @@ configure_file(
   @ONLY
 )
 
-install(EXPORT AppStreamLibsTarget
-    FILE AppStreamQtTargets.cmake
-    DESTINATION ${ConfigPackageLocation})
-
+install(EXPORT AppStreamLibsTarget FILE AppStreamQtTargets.cmake DESTINATION ${ConfigPackageLocation})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/AppStreamQtConfigVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/AppStreamQtConfig.cmake DESTINATION ${ConfigPackageLocation})
+
+#deprecated
+install(EXPORT AppStreamLibsTarget FILE AppStreamQtTargets.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AppstreamQt)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/AppStreamQtConfigVersion.cmake RENAME AppstreamQtConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AppstreamQt)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/AppStreamQtConfig.cmake RENAME AppstreamQtConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AppstreamQt)
 
 add_subdirectory(tests)

--- a/qt/image.h
+++ b/qt/image.h
@@ -48,7 +48,11 @@ class APPSTREAMQT_EXPORT Image {
         enum Kind {
             KindUnknown,
             KindSource,
-            KindThumbnail
+            KindThumbnail,
+
+            //for backwards compatibility
+            Plain = KindSource,
+            Thumbnail = KindThumbnail
         };
         Q_ENUM(Kind)
 


### PR DESCRIPTION
Makes it possible to have something like this:
https://phabricator.kde.org/D3265
