### PR TITLE
Provide an error message as warning output

### DIFF
--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -64,9 +64,19 @@ Pool::~Pool()
     // empty. needed for the scoped pointer for the private pointer
 }
 
-bool Pool::load()
+bool AppStream::Pool::load()
 {
-    return as_pool_load (d->m_pool, NULL, NULL);
+    return load(nullptr);
+}
+
+bool Pool::load(QString* strerror)
+{
+    g_autoptr(GError) error = nullptr;
+    bool ret = as_pool_load (d->m_pool, NULL, &error);
+    if (!ret && error) {
+        *strerror = QString::fromUtf8(error->message);
+    }
+    return ret;
 }
 
 void Pool::clear()

--- a/qt/pool.h
+++ b/qt/pool.h
@@ -77,6 +77,13 @@ Q_OBJECT
         bool load();
 
         /**
+         * \return true on success. False on failure
+         *
+         * In case of failure, @p error will be initialized with the error message
+         */
+        bool load(QString* error);
+
+        /**
          * Remove all software component information from the pool.
          */
         void clear();


### PR DESCRIPTION
As discussed in the issue #97, there's some systems where appstream is
reporting that it doesn't load properly but the users on the platform
don't have information on how to fix it.
With this warning, they will at least have a chance to know.