### PR TITLE
Can't have as a mandatory dependency a deprecated system

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -2,9 +2,10 @@
 
 find_program (XMLTO xmlto)
 mark_as_advanced (XMLTO)
-if (XMLTO STREQUAL "XMLTO-NOTFOUND")
-	message (FATAL_ERROR "Xmlto was not found! Please install it to continue!")
-endif (XMLTO STREQUAL "XMLTO-NOTFOUND")
+if (NOT XMLTO)
+	message (WARNING "Xmlto was not found! Please install it to continue!")
+	return()
+endif ()
 
 include (${CMAKE_SOURCE_DIR}/data/cmake/documentation.cmake)
 


### PR DESCRIPTION
The sources aren't available by the author

fedorahosted is deprecated and there's no alternative offered by upstream.