### PR TITLE
Add missing getters/setters for most of the properties in AS::Component

### DIFF
--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -32,6 +32,9 @@ set(APPSTREAMQT_SRC
     release.cpp
     bundle.cpp
     suggested.cpp
+    contentrating.cpp
+    launchable.cpp
+    translation.cpp
 )
 
 set(APPSTREAMQT_PUBLIC_HEADERS
@@ -45,6 +48,9 @@ set(APPSTREAMQT_PUBLIC_HEADERS
     release.h
     bundle.h
     suggested.h
+    contentrating.h
+    launchable.h
+    translation.h
 )
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}

--- a/qt/bundle.cpp
+++ b/qt/bundle.cpp
@@ -60,6 +60,11 @@ public:
         return rd.m_bundle == m_bundle;
     }
 
+    AsBundle *bundle() const
+    {
+        return m_bundle;
+    }
+
     AsBundle* m_bundle;
 };
 
@@ -86,6 +91,11 @@ bool Bundle::operator==(const Bundle &other) const
         return *(this->d) == *other.d;
     }
     return false;
+}
+
+_AsBundle * AppStream::Bundle::asBundle() const
+{
+    return d->bundle();
 }
 
 Bundle::Kind Bundle::kind() const

--- a/qt/category.cpp
+++ b/qt/category.cpp
@@ -42,6 +42,11 @@ public:
         return rd.m_category == m_category;
     }
 
+    AsCategory *category() const
+    {
+        return m_category;
+    }
+
     AsCategory* m_category;
 };
 
@@ -64,6 +69,11 @@ bool Category::operator==(const Category &other) const
         return *(this->d) == *other.d;
     }
     return false;
+}
+
+_AsCategory * AppStream::Category::asCategory() const
+{
+    return d->category();
 }
 
 QString Category::id() const

--- a/qt/category.h
+++ b/qt/category.h
@@ -41,6 +41,11 @@ class APPSTREAMQT_EXPORT Category {
         Category& operator=(const Category& category);
         bool operator==(const Category& r) const;
 
+        /**
+         * \returns the internally stored AsCategory
+         */
+        _AsCategory *asCategory() const;
+
         QString id() const;
         QString name() const;
         QString summary() const;

--- a/qt/chelpers.h
+++ b/qt/chelpers.h
@@ -52,6 +52,29 @@ inline QStringList valueWrap(GPtrArray *array)
     return res;
 }
 
+inline QStringList valueWrap(GList *list)
+{
+    GList *l;
+    QStringList res;
+    res.reserve(g_list_length(list));
+    for (l = list; l != NULL; l = l->next) {
+        auto strval = (const gchar*) l->data;
+        res.append (QString::fromUtf8(strval));
+    }
+    return res;
+}
+
+inline char ** stringListToCharArray(const QStringList& list)
+{
+    char **array = (char**) g_malloc(sizeof(char*) * list.size());
+    for (int i = 0; i < list.size(); ++i) {
+        const QByteArray string = list[i].toLocal8Bit();
+        array[i] = (char*) g_malloc(sizeof(char) * (string.size() + 1));
+        strcpy(array[i], string.constData());
+    }
+    return array;
+}
+
 }
 
 #endif // APPSTREAMQT_CHELPERS_H

--- a/qt/component.h
+++ b/qt/component.h
@@ -28,6 +28,10 @@
 #include "appstreamqt_export.h"
 #include "provided.h"
 #include "bundle.h"
+#include "category.h"
+#include "contentrating.h"
+#include "launchable.h"
+#include "translation.h"
 
 struct _AsComponent;
 namespace AppStream {
@@ -62,6 +66,13 @@ Q_GADGET
         };
         Q_ENUM(Kind)
 
+        enum MergeKind {
+            MergeKindNone,
+            MergeKindReplace,
+            MergeKindAppend
+        };
+        Q_ENUM(MergeKind)
+
         enum UrlKind {
             UrlKindUnknown,
             UrlKindHomepage,
@@ -72,6 +83,13 @@ Q_GADGET
             UrlTranslate
         };
         Q_ENUM(UrlKind)
+
+        enum ValueFlags {
+            FlagNone = 0,
+            FlagDuplicateCheck = 1 << 0,
+            FlagNoTranslationFallback = 1 << 1
+        };
+        Q_ENUM(ValueFlags)
 
         static Kind stringToKind(const QString& kindString);
         static QString kindToString(Kind kind);
@@ -84,8 +102,19 @@ Q_GADGET
         Component(const Component& other);
         ~Component();
 
+        _AsComponent *asComponent() const;
+
+        uint valueFlags() const;
+        void setValueFlags(uint flags);
+
+        QString activeLocale() const;
+        void setActiveLocale(const QString& locale);
+
         Kind kind () const;
         void setKind (Component::Kind kind);
+
+        QString origin() const;
+        void setOrigin(const QString& origin);
 
         QString id() const;
         void setId(const QString& id);
@@ -94,6 +123,10 @@ Q_GADGET
         void setDataId(const QString& cdid);
 
         QStringList packageNames() const;
+        void setPackageNames(const QStringList& list);
+
+        QString sourcePackageName() const;
+        void setSourcePackageName(const QString& sourcePkg);
 
         QString name() const;
         void setName(const QString& name, const QString& lang = {});
@@ -103,6 +136,12 @@ Q_GADGET
 
         QString description() const;
         void setDescription(const QString& description, const QString& lang = {});
+
+        AppStream::Launchable launchable(AppStream::Launchable::Kind kind) const;
+        void addLaunchable(const AppStream::Launchable& launchable);
+
+        QString metadataLicense() const;
+        void setMetadataLicense(const QString& license);
 
         QString projectLicense() const;
         void setProjectLicense(const QString& license);
@@ -114,19 +153,33 @@ Q_GADGET
         void setDeveloperName(const QString& developerName, const QString& lang = {});
 
         QStringList compulsoryForDesktops() const;
+        void setCompulsoryForDesktop(const QString& desktop);
         bool isCompulsoryForDesktop(const QString& desktop) const;
 
         QStringList categories() const;
+        void addCategory(const QString& category);
         bool hasCategory(const QString& category) const;
 
         QStringList extends() const;
         void setExtends(const QStringList& extends);
+        void addExtends(const QString& extend);
+
         QList<AppStream::Component> addons() const;
+        void addAddon(const AppStream::Component& addon);
+
+        QStringList languages() const;
+        int language(const QString& locale) const;
+        void addLanguage(const QString& locale, int percentage);
+
+        QList<AppStream::Translation> translations() const;
+        void addTranslation(const AppStream::Translation& translation);
 
         QUrl url(UrlKind kind) const;
+        void addUrl(UrlKind kind, const QString& url);
 
         QList<AppStream::Icon> icons() const;
         AppStream::Icon icon(const QSize& size) const;
+        void addIcon(const AppStream::Icon& icon);
 
         /**
          * \return the full list of provided entries for all kinds.
@@ -138,20 +191,46 @@ Q_GADGET
          * \return provided items for this \param kind
          */
         AppStream::Provided provided(Provided::Kind kind) const;
+        void addProvided(const AppStream::Provided& provided);
 
         QList<AppStream::Screenshot> screenshots() const;
+        void addScreenshot(const AppStream::Screenshot& screenshot);
 
         QList<AppStream::Release> releases() const;
+        void addRelease(const AppStream::Release& release);
 
+        bool hasBundle() const;
         QList<AppStream::Bundle> bundles() const;
         AppStream::Bundle bundle(Bundle::Kind kind) const;
+        void addBundle(const AppStream::Bundle& bundle) const;
 
         QList<AppStream::Suggested> suggested() const;
+        void addSuggested(const AppStream::Suggested& suggested);
 
+        QStringList searchTokens() const;
+        uint searchMatches(const QString& term) const;
+        uint searchMatchesAll(const QStringList& terms) const;
+
+        MergeKind mergeKind() const;
+        void setMergeKind(MergeKind kind);
+
+        QHash<QString,QString> custom() const;
+        QString customValue(const QString& key);
+        bool insertCustomValue(const QString& key, const QString& value);
+
+        QList<AppStream::ContentRating> contentRatings() const;
+        AppStream::ContentRating contentRating(const QString& kind) const;
+        void addContentRating(const AppStream::ContentRating& contentRating);
+
+        bool isMemberOfCategory(const AppStream::Category& category) const;
+
+        bool isIgnored() const;
         bool isValid() const;
 
-	// DEPRECATED
-	Q_DECL_DEPRECATED QString desktopId() const;
+        QString toString() const;
+
+    // DEPRECATED
+    Q_DECL_DEPRECATED QString desktopId() const;
 
     private:
         _AsComponent *m_cpt;

--- a/qt/contentrating.cpp
+++ b/qt/contentrating.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2017 Jan Grulich <jgrulich@redhat.com>
+ * Copyright (C) 2016 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "appstream.h"
+#include "contentrating.h"
+
+#include <QDebug>
+#include "chelpers.h"
+
+using namespace AppStream;
+
+class AppStream::ContentRatingData : public QSharedData {
+public:
+    ContentRatingData()
+    {
+        m_contentRating = as_content_rating_new();
+    }
+
+    ContentRatingData(AsContentRating* cat) : m_contentRating(cat)
+    {
+        g_object_ref(m_contentRating);
+    }
+
+    ~ContentRatingData()
+    {
+        g_object_unref(m_contentRating);
+    }
+
+    bool operator==(const ContentRatingData& rd) const
+    {
+        return rd.m_contentRating == m_contentRating;
+    }
+
+    AsContentRating *contentRating() const
+    {
+        return m_contentRating;
+    }
+
+    AsContentRating* m_contentRating;
+};
+
+typedef QHash<ContentRating::RatingValue, QString> RatingMap;
+Q_GLOBAL_STATIC_WITH_ARGS(RatingMap, ratingMap, ( {
+    { ContentRating::RatingValueUnknown, QLatin1String("unknown") },
+    { ContentRating::RatingValueNone, QLatin1String("none") },
+    { ContentRating::RatingValueMild, QLatin1String("mild") },
+    { ContentRating::RatingValueModerate, QLatin1String("moderate") },
+    { ContentRating::RatingValueIntense, QLatin1String("intense") }
+    }
+));
+
+AppStream::ContentRating::RatingValue AppStream::ContentRating::stringToRatingValue(const QString& ratingValue)
+{
+    return ratingMap->key(ratingValue, AppStream::ContentRating::RatingValueUnknown);
+}
+
+QString AppStream::ContentRating::ratingValueToString(AppStream::ContentRating::RatingValue ratingValue)
+{
+    return ratingMap->value(ratingValue);
+}
+
+ContentRating::ContentRating()
+    : d(new ContentRatingData)
+{}
+
+ContentRating::ContentRating(_AsContentRating* contentRating)
+    : d(new ContentRatingData(contentRating))
+{}
+
+ContentRating::ContentRating(const ContentRating &contentRating) = default;
+
+ContentRating::~ContentRating() = default;
+
+ContentRating& ContentRating::operator=(const ContentRating &contentRating) = default;
+
+bool ContentRating::operator==(const ContentRating &other) const
+{
+    if(this->d == other.d) {
+        return true;
+    }
+    if(this->d && other.d) {
+        return *(this->d) == *other.d;
+    }
+    return false;
+}
+
+_AsContentRating * AppStream::ContentRating::asContentRating() const
+{
+    return d->contentRating();
+}
+
+QString AppStream::ContentRating::kind() const
+{
+    return valueWrap(as_content_rating_get_kind(d->m_contentRating));
+}
+
+void AppStream::ContentRating::setKind(const QString& kind)
+{
+    as_content_rating_set_kind(d->m_contentRating, qPrintable(kind));
+}
+
+uint AppStream::ContentRating::minimumAge() const
+{
+    return as_content_rating_get_minimum_age(d->m_contentRating);
+}
+
+AppStream::ContentRating::RatingValue AppStream::ContentRating::value(const QString& id) const
+{
+    return static_cast<AppStream::ContentRating::RatingValue>(as_content_rating_get_value(d->m_contentRating, qPrintable(id)));
+}
+
+void AppStream::ContentRating::setValue(const QString& id, AppStream::ContentRating::RatingValue ratingValue)
+{
+    as_content_rating_set_value(d->m_contentRating, qPrintable(id), (AsContentRatingValue) ratingValue);
+}
+
+QDebug operator<<(QDebug s, const AppStream::ContentRating& contentRating)
+{
+    s.nospace() << "AppStream::ContentRating(" << contentRating.kind() << contentRating.minimumAge() << ")";
+    return s.space();
+}
+

--- a/qt/contentrating.h
+++ b/qt/contentrating.h
@@ -1,0 +1,82 @@
+
+/*
+ * Copyright (C) 2017 Jan Grulich <jgrulich@redhat.com>
+ * Copyright (C) 2016 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef APPSTREAMQT_CONTENT_RATING_H
+#define APPSTREAMQT_CONTENT_RATING_H
+
+#include <QSharedDataPointer>
+#include <QString>
+#include <QObject>
+#include "appstreamqt_export.h"
+
+struct _AsContentRating;
+
+namespace AppStream {
+
+class ContentRatingData;
+
+class APPSTREAMQT_EXPORT ContentRating {
+    Q_GADGET
+
+    public:
+        enum RatingValue {
+            RatingValueUnknown,
+            RatingValueNone,
+            RatingValueMild,
+            RatingValueModerate,
+            RatingValueIntense
+        };
+        Q_ENUM(RatingValue)
+
+        ContentRating();
+        ContentRating(_AsContentRating* category);
+        ContentRating(const ContentRating& category);
+        ~ContentRating();
+
+        static RatingValue stringToRatingValue(const QString& ratingValue);
+        static QString ratingValueToString(RatingValue ratingValue);
+
+        ContentRating& operator=(const ContentRating& category);
+        bool operator==(const ContentRating& r) const;
+
+        /**
+         * \returns the internally stored AsContentRating
+         */
+        _AsContentRating *asContentRating() const;
+
+        QString kind() const;
+        void setKind(const QString& kind);
+
+        uint minimumAge() const;
+
+        RatingValue value(const QString& id) const;
+        void setValue(const QString& id, RatingValue ratingValue);
+
+    private:
+        QSharedDataPointer<ContentRatingData> d;
+};
+}
+
+APPSTREAMQT_EXPORT QDebug operator<<(QDebug s, const AppStream::ContentRating& category);
+
+#endif // APPSTREAMQT_CONTENT_RATING_H
+
+

--- a/qt/icon.cpp
+++ b/qt/icon.cpp
@@ -51,6 +51,10 @@ public:
         return rd.m_icon == m_icon;
     }
 
+    AsIcon *icon() const {
+        return m_icon;
+    }
+
     AsIcon *m_icon;
 };
 
@@ -73,6 +77,11 @@ Icon& Icon::operator=(const Icon& other)
 {
     this->d = other.d;
     return *this;
+}
+
+AsIcon * AppStream::Icon::asIcon() const
+{
+    return d->icon();
 }
 
 Icon::Kind Icon::kind() const

--- a/qt/icon.h
+++ b/qt/icon.h
@@ -55,6 +55,11 @@ class APPSTREAMQT_EXPORT Icon {
         Icon& operator=(const Icon& other);
 
         /**
+         * \returns the internally stored AsIcon
+         */
+        _AsIcon *asIcon() const;
+
+        /**
          * \return the kind of icon
          */
         Kind kind() const;

--- a/qt/image.cpp
+++ b/qt/image.cpp
@@ -50,6 +50,11 @@ public:
         return rd.m_img == m_img;
     }
 
+    AsImage *image() const
+    {
+        return m_img;
+    }
+
     AsImage *m_img;
 };
 
@@ -72,6 +77,11 @@ Image& Image::operator=(const Image& other)
 {
     this->d = other.d;
     return *this;
+}
+
+_AsImage * AppStream::Image::asImage() const
+{
+    return d->image();
 }
 
 Image::Kind Image::kind() const

--- a/qt/image.h
+++ b/qt/image.h
@@ -60,6 +60,11 @@ class APPSTREAMQT_EXPORT Image {
         Image& operator=(const Image& other);
 
         /**
+         * \returns the internally stored AsImage
+         */
+        _AsImage *asImage() const;
+
+        /**
          * \return the kind of image
          */
         Kind kind() const;

--- a/qt/launchable.cpp
+++ b/qt/launchable.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2017 Jan Grulich <jgrulich@redhat.com>
+ * Copyright (C) 2016 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "appstream.h"
+#include "launchable.h"
+
+#include <QDebug>
+#include "chelpers.h"
+
+using namespace AppStream;
+
+class AppStream::LaunchableData : public QSharedData {
+public:
+    LaunchableData()
+    {
+        m_launchable = as_launchable_new();
+    }
+
+    LaunchableData(AsLaunchable* cat) : m_launchable(cat)
+    {
+        g_object_ref(m_launchable);
+    }
+
+    ~LaunchableData()
+    {
+        g_object_unref(m_launchable);
+    }
+
+    bool operator==(const LaunchableData& rd) const
+    {
+        return rd.m_launchable == m_launchable;
+    }
+
+    AsLaunchable *launchable() const
+    {
+        return m_launchable;
+    }
+
+    AsLaunchable* m_launchable;
+};
+
+
+AppStream::Launchable::Kind AppStream::Launchable::stringToKind(const QString& kindString)
+{
+    if (kindString == QLatin1String("desktop-id")) {
+        return AppStream::Launchable::KindDesktopId;
+    }
+    return AppStream::Launchable::KindUnknown;
+}
+
+QString AppStream::Launchable::kindToString(AppStream::Launchable::Kind kind)
+{
+    if (kind == AppStream::Launchable::KindDesktopId) {
+        return QLatin1String("desktop-id");
+    }
+    return QLatin1String("unknown");
+}
+
+Launchable::Launchable()
+    : d(new LaunchableData)
+{}
+
+Launchable::Launchable(_AsLaunchable* launchable)
+    : d(new LaunchableData(launchable))
+{}
+
+Launchable::Launchable(const Launchable &launchable) = default;
+
+Launchable::~Launchable() = default;
+
+Launchable& Launchable::operator=(const Launchable &launchable) = default;
+
+bool Launchable::operator==(const Launchable &other) const
+{
+    if(this->d == other.d) {
+        return true;
+    }
+    if(this->d && other.d) {
+        return *(this->d) == *other.d;
+    }
+    return false;
+}
+
+_AsLaunchable * AppStream::Launchable::asLaunchable() const
+{
+    return d->launchable();
+}
+
+AppStream::Launchable::Kind AppStream::Launchable::kind() const
+{
+    return static_cast<AppStream::Launchable::Kind>(as_launchable_get_kind(d->m_launchable));
+}
+
+void AppStream::Launchable::setKind(AppStream::Launchable::Kind kind)
+{
+    as_launchable_set_kind(d->m_launchable, (AsLaunchableKind) kind);
+}
+
+QStringList AppStream::Launchable::entries() const
+{
+    return valueWrap(as_launchable_get_entries(d->m_launchable));
+}
+
+void AppStream::Launchable::addEntry(const QString& entry)
+{
+    as_launchable_add_entry(d->m_launchable, qPrintable(entry));
+}
+
+QDebug operator<<(QDebug s, const AppStream::Launchable& launchable)
+{
+    s.nospace() << "AppStream::Launchable(" << launchable.entries() << ")";
+    return s.space();
+}

--- a/qt/launchable.h
+++ b/qt/launchable.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2017 Jan Grulich <jgrulich@redhat.com>
  * Copyright (C) 2016 Matthias Klumpp <matthias@tenstral.net>
  *
  * Licensed under the GNU Lesser General Public License Version 2.1
@@ -17,66 +18,57 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef APPSTREAMQT_BUNDLE_H
-#define APPSTREAMQT_BUNDLE_H
+#ifndef APPSTREAMQT_LAUNCHABLE_H
+#define APPSTREAMQT_LAUNCHABLE_H
 
 #include <QSharedDataPointer>
 #include <QString>
 #include <QObject>
 #include "appstreamqt_export.h"
 
-struct _AsBundle;
+struct _AsLaunchable;
+
 namespace AppStream {
 
-class BundleData;
-class APPSTREAMQT_EXPORT Bundle {
+class LaunchableData;
+
+class APPSTREAMQT_EXPORT Launchable {
     Q_GADGET
     public:
-        Bundle();
-        Bundle(_AsBundle *bundle);
-        Bundle(const Bundle& bundle);
-        ~Bundle();
-
-        Bundle& operator=(const Bundle& bundle);
-        bool operator==(const Bundle& r) const;
-
-        /**
-         * \returns the internally stored AsBundle
-         */
-        _AsBundle *asBundle() const;
-
         enum Kind {
             KindUnknown,
-            KindPackage,
-            KindLimba,
-            KindFlatpak,
-            KindAppImage,
-            KindSnap
+            KindDesktopId
         };
         Q_ENUM(Kind)
+
+        Launchable();
+        Launchable(_AsLaunchable* category);
+        Launchable(const Launchable& category);
+        ~Launchable();
 
         static Kind stringToKind(const QString& kindString);
         static QString kindToString(Kind kind);
 
+        Launchable& operator=(const Launchable& category);
+        bool operator==(const Launchable& r) const;
+
         /**
-         * \return the bundle kind.
+         * \returns the internally stored AsLaunchable
          */
+        _AsLaunchable *asLaunchable() const;
+
         Kind kind() const;
         void setKind(Kind kind);
 
-        /**
-         * \return the bundle ID.
-         */
-        QString id() const;
-        void setId(const QString& id);
-
-        bool isEmpty() const;
+        QStringList entries() const;
+        void addEntry(const QString& entry);
 
     private:
-        QSharedDataPointer<BundleData> d;
+        QSharedDataPointer<LaunchableData> d;
 };
 }
 
-APPSTREAMQT_EXPORT QDebug operator<<(QDebug s, const AppStream::Bundle& bundle);
+APPSTREAMQT_EXPORT QDebug operator<<(QDebug s, const AppStream::Launchable& category);
 
-#endif // APPSTREAMQT_BUNDLE_H
+#endif // APPSTREAMQT_LAUNCHABLE_H
+

--- a/qt/provided.cpp
+++ b/qt/provided.cpp
@@ -53,6 +53,11 @@ public:
         return rd.m_prov == m_prov;
     }
 
+    AsProvided *provided() const
+    {
+        return m_prov;
+    }
+
     AsProvided *m_prov;
 };
 
@@ -96,6 +101,11 @@ bool Provided::operator==(const Provided& other) const
         return *d == *other.d;
     }
     return false;
+}
+
+_AsProvided * AppStream::Provided::asProvided() const
+{
+    return d->provided();
 }
 
 Provided::Kind Provided::kind() const

--- a/qt/provided.h
+++ b/qt/provided.h
@@ -42,6 +42,11 @@ class APPSTREAMQT_EXPORT Provided {
         Provided& operator=(const Provided& other);
         bool operator==(const Provided& other) const;
 
+        /**
+         * \returns the internally stored AsProvided
+         */
+        _AsProvided *asProvided() const;
+
         enum Kind {
             KindUnknown,
             KindLibrary,

--- a/qt/release.cpp
+++ b/qt/release.cpp
@@ -44,6 +44,11 @@ public:
         return rd.m_release == m_release;
     }
 
+    AsRelease *release() const
+    {
+        return m_release;
+    }
+
     AsRelease* m_release;
 };
 
@@ -66,6 +71,11 @@ bool Release::operator==(const Release &other) const
         return *(this->d) == *other.d;
     }
     return false;
+}
+
+_AsRelease * AppStream::Release::asRelease() const
+{
+    return d->release();
 }
 
 QString Release::version() const

--- a/qt/release.h
+++ b/qt/release.h
@@ -52,6 +52,11 @@ class APPSTREAMQT_EXPORT Release {
         Release& operator=(const Release& release);
         bool operator==(const Release& r) const;
 
+        /**
+         * \returns the internally stored AsRelease
+         */
+        _AsRelease *asRelease() const;
+
         enum SizeKind {
             SizeUnknown,
             SizeDownload,

--- a/qt/screenshot.cpp
+++ b/qt/screenshot.cpp
@@ -51,6 +51,11 @@ public:
         return rd.m_scr == m_scr;
     }
 
+    AsScreenshot *screenshot() const
+    {
+        return m_scr;
+    }
+
     AsScreenshot *m_scr;
 };
 
@@ -73,6 +78,11 @@ Screenshot& Screenshot::operator=(const Screenshot& other)
 {
     d = other.d;
     return *this;
+}
+
+_AsScreenshot * AppStream::Screenshot::asScreenshot() const
+{
+    return d->screenshot();
 }
 
 bool Screenshot::isDefault() const

--- a/qt/screenshot.h
+++ b/qt/screenshot.h
@@ -48,6 +48,11 @@ public:
     Screenshot& operator=(const Screenshot& other);
 
     /**
+     * \returns the internally stored AsScreenshot
+     */
+    _AsScreenshot *asScreenshot() const;
+
+    /**
      * \return true if it is the default screenshot
      * A \ref Component should in general only have one default
      */

--- a/qt/suggested.cpp
+++ b/qt/suggested.cpp
@@ -51,6 +51,11 @@ public:
         return rd.m_suggested == m_suggested;
     }
 
+    AsSuggested *suggested() const
+    {
+        return m_suggested;
+    }
+
     AsSuggested *m_suggested;
 };
 
@@ -73,6 +78,11 @@ Suggested& Suggested::operator=(const Suggested& other)
 {
     this->d = other.d;
     return *this;
+}
+
+_AsSuggested * AppStream::Suggested::suggested() const
+{
+    return d->suggested();
 }
 
 Suggested::Kind Suggested::kind() const

--- a/qt/suggested.h
+++ b/qt/suggested.h
@@ -54,6 +54,11 @@ class APPSTREAMQT_EXPORT Suggested {
         Suggested& operator=(const Suggested& other);
 
         /**
+         * \returns the internally stored AsSuggested
+         */
+        _AsSuggested *suggested() const;
+
+        /**
          * \return the kind of suggestion
          */
         Kind kind() const;

--- a/qt/translation.cpp
+++ b/qt/translation.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2017 Jan Grulich <jgrulich@redhat.com>
+ * Copyright (C) 2016 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "appstream.h"
+#include "translation.h"
+
+#include <QDebug>
+#include "chelpers.h"
+
+using namespace AppStream;
+
+class AppStream::TranslationData : public QSharedData {
+public:
+    TranslationData()
+    {
+        m_translation = as_translation_new();
+    }
+
+    TranslationData(AsTranslation* cat) : m_translation(cat)
+    {
+        g_object_ref(m_translation);
+    }
+
+    ~TranslationData()
+    {
+        g_object_unref(m_translation);
+    }
+
+    bool operator==(const TranslationData& rd) const
+    {
+        return rd.m_translation == m_translation;
+    }
+
+    AsTranslation *translation() const
+    {
+        return m_translation;
+    }
+
+    AsTranslation* m_translation;
+};
+
+AppStream::Translation::Kind AppStream::Translation::stringToKind(const QString& kindString)
+{
+    if (kindString == QLatin1String("gettext")) {
+        return AppStream::Translation::KindGettext;
+    } else if (kindString == QLatin1String("qt")) {
+        return AppStream::Translation::KindQt;
+    }
+    return AppStream::Translation::KindUnknown;
+}
+
+QString AppStream::Translation::kindToString(AppStream::Translation::Kind kind)
+{
+    if (kind == AppStream::Translation::KindGettext) {
+        return QLatin1String("gettext");
+    } else if (kind == AppStream::Translation::KindQt) {
+        return QLatin1String("qt");
+    }
+    return QLatin1String("unknown");
+}
+
+Translation::Translation()
+    : d(new TranslationData)
+{}
+
+Translation::Translation(_AsTranslation* translation)
+    : d(new TranslationData(translation))
+{}
+
+Translation::Translation(const Translation &translation) = default;
+
+Translation::~Translation() = default;
+
+Translation& Translation::operator=(const Translation &translation) = default;
+
+bool Translation::operator==(const Translation &other) const
+{
+    if(this->d == other.d) {
+        return true;
+    }
+    if(this->d && other.d) {
+        return *(this->d) == *other.d;
+    }
+    return false;
+}
+
+_AsTranslation * AppStream::Translation::asTranslation() const
+{
+    return d->translation();
+}
+
+AppStream::Translation::Kind AppStream::Translation::kind() const
+{
+    return static_cast<AppStream::Translation::Kind>(as_translation_get_kind(d->m_translation));
+}
+
+void AppStream::Translation::setKind(AppStream::Translation::Kind kind)
+{
+    as_translation_set_kind(d->m_translation, (AsTranslationKind) kind);
+}
+
+QString AppStream::Translation::id() const
+{
+    return valueWrap(as_translation_get_id(d->m_translation));
+}
+
+void AppStream::Translation::setId(const QString& id)
+{
+    as_translation_set_id(d->m_translation, qPrintable(id));
+}
+
+QDebug operator<<(QDebug s, const AppStream::Translation& translation)
+{
+    s.nospace() << "AppStream::Translation(" << translation.id() << ")";
+    return s.space();
+}

--- a/qt/translation.h
+++ b/qt/translation.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2017 Jan Grulich <jgrulich@redhat.com>
  * Copyright (C) 2016 Matthias Klumpp <matthias@tenstral.net>
  *
  * Licensed under the GNU Lesser General Public License Version 2.1
@@ -17,66 +18,59 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef APPSTREAMQT_BUNDLE_H
-#define APPSTREAMQT_BUNDLE_H
+#ifndef APPSTREAMQT_TRANSLATION_H
+#define APPSTREAMQT_TRANSLATION_H
 
 #include <QSharedDataPointer>
 #include <QString>
 #include <QObject>
 #include "appstreamqt_export.h"
 
-struct _AsBundle;
+struct _AsTranslation;
+
 namespace AppStream {
 
-class BundleData;
-class APPSTREAMQT_EXPORT Bundle {
+class TranslationData;
+
+class APPSTREAMQT_EXPORT Translation {
     Q_GADGET
     public:
-        Bundle();
-        Bundle(_AsBundle *bundle);
-        Bundle(const Bundle& bundle);
-        ~Bundle();
-
-        Bundle& operator=(const Bundle& bundle);
-        bool operator==(const Bundle& r) const;
-
-        /**
-         * \returns the internally stored AsBundle
-         */
-        _AsBundle *asBundle() const;
-
         enum Kind {
             KindUnknown,
-            KindPackage,
-            KindLimba,
-            KindFlatpak,
-            KindAppImage,
-            KindSnap
+            KindGettext,
+            KindQt
         };
         Q_ENUM(Kind)
+
+        Translation();
+        Translation(_AsTranslation* category);
+        Translation(const Translation& category);
+        ~Translation();
 
         static Kind stringToKind(const QString& kindString);
         static QString kindToString(Kind kind);
 
+        Translation& operator=(const Translation& category);
+        bool operator==(const Translation& r) const;
+
         /**
-         * \return the bundle kind.
+         * \returns the internally stored AsTranslation
          */
+        _AsTranslation *asTranslation() const;
+
         Kind kind() const;
         void setKind(Kind kind);
 
-        /**
-         * \return the bundle ID.
-         */
         QString id() const;
         void setId(const QString& id);
 
-        bool isEmpty() const;
-
     private:
-        QSharedDataPointer<BundleData> d;
+        QSharedDataPointer<TranslationData> d;
 };
 }
 
-APPSTREAMQT_EXPORT QDebug operator<<(QDebug s, const AppStream::Bundle& bundle);
+APPSTREAMQT_EXPORT QDebug operator<<(QDebug s, const AppStream::Translation& category);
 
-#endif // APPSTREAMQT_BUNDLE_H
+#endif // APPSTREAMQT_TRANSLATION_H
+
+


### PR DESCRIPTION
Note: only two of them should be missing (launchables and languages), because
we don't have wrappers for them yet