### PR TITLE
doc: Add guidelines for distributors

### DIFF
--- a/docs/sources/quickstart/Quickstart.xml
+++ b/docs/sources/quickstart/Quickstart.xml
@@ -14,6 +14,7 @@
 
 	<xi:include href="desktop-apps.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
 	<xi:include href="addons.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
+	<xi:include href="packaging.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
 
 	<xi:include href="translation.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
 	<!-- <xi:include href="buildsystems.xml" xmlns:xi="http://www.w3.org/2001/XInclude" /> -->

--- a/docs/sources/quickstart/addons.xml
+++ b/docs/sources/quickstart/addons.xml
@@ -36,7 +36,7 @@
 		<title>Metadata file contents</title>
 		<para>
 			This is a list of tags you might want to define for your application. For a full list of possible tags, take a look at
-			the definition of a generic component (<xref linkend="spec-component-filespec"/>) and an addon-component (<xref linkend="spec-addondata-filespec"/>).
+			the definition of a generic component (<xref linkend="spec-component-filespec"/>) and an addon component (<xref linkend="spec-addondata-filespec"/>).
 		</para>
 
 		<variablelist>

--- a/docs/sources/quickstart/desktop-apps.xml
+++ b/docs/sources/quickstart/desktop-apps.xml
@@ -14,7 +14,7 @@
 			For most users it allows them to answer the question <quote>Do I want to install this application?</quote>.
 			Traditionally in Linux distributions, we have none of this data for the vast majority of our desktop user-installable applications.
 			The packages-descriptions are describing all contents of a package, and not just a single application. They are also often written in a technical
-<!-- 			language and refer to other packages, which makes it hard for beginners to understand what the application they want to install really does. -->
+			language and refer to other packages, which makes it hard for beginners to understand what the application they want to install really does.
 			Additionally, if you are not using Debian or Ubuntu, the package descriptions are often untranslated.
 			Also, packages do not provide some metadata users might be interested in before installing an application.
 		</para>

--- a/docs/sources/quickstart/packaging.xml
+++ b/docs/sources/quickstart/packaging.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "AppStream.ent">
+%BOOK_ENTITIES;
+]>
+
+<section id="sect-Quickstart-Distros">
+	<title>For distributors packaging Appstream metadata</title>
+
+	<section id="qsr-distro-introduction">
+		<title>Guidelines for distributors</title>
+		<para>
+			Distributors of projects with AppStream metadata perform an important role
+			by making the software available to more people. There are a few guidelines
+			distributors should follow in order for software centers to present
+			the correct information to users.
+		</para>
+	</section>
+
+	<section id="qsr-distro-guidelines">
+		<title>Guidelines for distributors</title>
+		<para>
+			A binary package that contains AppStream desktop metadata  (<xref linkend="sect-Metadata-Application"/>)
+			must also contain both the .desktop file for the application and the application itself.
+		</para>
+		<para>
+			A binary package must not contain more than one AppStream metadata file. The one exception is
+			that it is permissable for a binary package that is extended by addons to include those addons
+			(<xref linkend="sect-Metadata-Addon"/>) and their AppStream metadata files. Note that users
+			will be unable to remove those addons separately.
+		</para>
+		<para>
+			Except for the extended package, no other package may contain more than one Appstream addon metadata file.
+		</para>
+
+	</section>
+
+</section>


### PR DESCRIPTION
Debian and Ubuntu have a usability problem with the GNOME Software app.

1. Removing GNOME Books removes GNOME Documents since they are both included in the same package.

2. Enabling one addon for Eye of GNOME installs all of eog's addons and disabling one addon removes all of eog's addons. (This affects a few other apps too.)

This pull request helps to fix this problem by standardizing a few best practices for distros.

The commented line looks like a typo introduced in https://github.com/ximion/appstream/commit/40431c63e7cd13f1d18f69c69e29cd0fd3f20525 so I fixed that too.