### PR TITLE
trivial: adjust docs to clearly state that licenses are SPDX expressions

### DIFF
--- a/docs/sources/collection/xmldata.xml
+++ b/docs/sources/collection/xmldata.xml
@@ -168,11 +168,11 @@
 				<listitem>
 					<para>
 						The <code>&lt;project_license/&gt;</code> tag is indicating the license of the component.
-						It should be a string in SPDX format. Licenses may be combined using <emphasis>and</emphasis> and <emphasis>or</emphasis> logic.
+						It should be a <ulink url="https://spdx.org/specifications">SPDX license expression</ulink>.
 						Possible values include:
 						<itemizedlist>
 							<listitem><para>GPL-2.0</para></listitem>
-							<listitem><para>LGPL-3.0+ and GPL-3.0+</para></listitem>
+							<listitem><para>LGPL-3.0+ AND GPL-3.0+</para></listitem>
 							<listitem><para>MIT</para></listitem>
 							<listitem><para>CC-BY-SA-2.0</para></listitem>
 							<listitem><para>...</para></listitem>

--- a/docs/sources/metainfo/component.xml
+++ b/docs/sources/metainfo/component.xml
@@ -521,11 +521,11 @@
 		<listitem>
 			<para>
 			The <code>&lt;project_license/&gt;</code> tag is indicating the license of the component (application/library/addon/font/etc.) described in the metadata document.
-			It should be a string in SPDX format. Licenses may be combined using <emphasis>and</emphasis> and <emphasis>or</emphasis> logic.
+			It should be a <ulink url="https://spdx.org/specifications">SPDX license expression</ulink>.
 			Possible values include:
 			<itemizedlist>
 				<listitem><para><literal>GPL-2.0</literal></para></listitem>
-				<listitem><para><literal>LGPL-3.0+ and GPL-3.0+</literal></para></listitem>
+				<listitem><para><literal>LGPL-3.0+ AND GPL-3.0+</literal></para></listitem>
 				<listitem><para><literal>MIT</literal></para></listitem>
 				<listitem><para><literal>CC-BY-SA-2.0</literal></para></listitem>
 			</itemizedlist>


### PR DESCRIPTION
Previously the doc was a bit ambiguous about the actual format employed
for licenses. The format expectation is the actual SPDX license expression
format as described in the SPDX specification.
Clearly state this and point to the specification URL for reference on the
format.

Additionally, while SPDX must be parsed as case-insensitive it's considered
best practice to use strict-casing in examples, so change to that.

Closes #122