### PR TITLE
Don't crash when an error is found and no error string is passed

### DIFF
--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -73,7 +73,7 @@ bool Pool::load(QString* strerror)
 {
     g_autoptr(GError) error = nullptr;
     bool ret = as_pool_load (d->m_pool, NULL, &error);
-    if (!ret && error) {
+    if (!ret && error && strerror) {
         *strerror = QString::fromUtf8(error->message);
     }
     return ret;


### PR DESCRIPTION
See backtrace:
https://bugs.kde.org/show_bug.cgi?id=382916

I fixed it in Discover, but it shouldn't be crashing anyway.