### PR TITLE
WIP - Variants

### DIFF
--- a/docs/sources/collection/xmldata.xml
+++ b/docs/sources/collection/xmldata.xml
@@ -543,6 +543,48 @@
 				</listitem>
 			</varlistentry>
 
+                        <varlistentry id="tag-ct-variants">
+                          <term>&lt;variants/&gt;</term>
+                          <listitem>
+                            <para>
+                              This tag lists variants of this
+                              component.  For example, the Modularity
+                              effort of Fedora will provide multiple
+                              'streams' for a given component, where
+                              each stream tracks a different major
+                              version of an upstream project.
+                            </para>
+                            <para>
+                              Variants conflict with each other: At
+                              most one variant can be installed at any
+                              one time.
+                            </para>
+                            <para>
+                              This tag includes one or more
+                              &lt;variant/&gt; tags.  Each of these
+                              children can have the same tags as the
+                              &lt;component/&gt; tag, and provide a
+                              replacement value.  For example, if a
+                              &lt;variant/&gt; has a
+                              &lt;description&gt; tag, this should be
+                              shown instead of the &lt;description&gt;
+                              tag of the component.
+                            </para>
+                            <para>
+                              A &lt;variant/&gt; must include a
+                              &lt;variantsummary&gt;.  This is a short
+                              text that can be displayed in a menu
+                              that allows selection of a variant.
+                            </para>
+                            <para>
+                              If the &lt;variants/&gt tag is present,
+                              it should list all variants, including
+                              the main variant described by the
+                              &lt;component/&gt; tag.
+                            </para>
+                          </listitem>
+                        </varlistentry>
+
 			<varlistentry id="tag-ct-languages">
 				<term>&lt;languages/&gt;</term>
 				<listitem>


### PR DESCRIPTION
Hi!

I am pondering whether to propose adding "variants" to AppStream, and imo pull requests are not the worst medium for discussing ideas, so I have opened this one.

So, the motivation for this is the "Modularity" effort of Fedora: https://docs.pagure.org/modularity/

From the point of view of a Software Center, modularity adds two new concepts: stream and profile.  In addition to deciding which component to install, a user also can decide from which stream to install it, and which of its profiles.  I think we should somehow represent these concepts in AppStream.

A modularity stream follows a major upstream version, such as "nodejs 6" vs "nodejs 8". A modularity profile represents a different "use case" for the component, such as "devel" vs "runtime" where "runtime" doesn't install docs or devel bits.

(Personally, I think there isn't super much experience yet with these concepts.  I can see how streams are useful for applications, but profiles maybe not so much...)

A package repository that is has modularity modules in it might thus have multiple instances of metainfo data for the same id.  One solution would be to allow multiple components in the collection data for the same id, but I think removing such a basic property of the schema is a bit brutal.

So, what about "variants"?

Existing Software Centers can just ignore them.  The AppStream tools that collect data for a Fedora repository would need to be changed to merge multiple metainfo for a single id.

Modularity has two dimensions for variation: stream and profile.  I propose to have only a single dimension of variants, because making this general for N dimensions is just too complex.

For the example, this means we get four variants: "nodejs 6 devel", "nodejs 6 runtime", "nodejs 8 devel", and "nodejs 8 runtime".  I hope we can keep this under control but just not putting AppStream data in different profiles. If profiles turn out to be genuinely great, we can add hints so that the Software Center can factor the variants again into a multidimensional UI.
