### PR TITLE
spec: Allow <icon> tags in generic components

### DIFF
--- a/docs/sources/collection/xmldata.xml
+++ b/docs/sources/collection/xmldata.xml
@@ -283,8 +283,8 @@
 						This icon type may have <literal>width</literal> and <literal>height</literal> properties.
 					</para>
 					<para>
-						<literal>remote</literal> icons loaded from a remote URL. Currently, at least HTTP urls must be supported.
-						This icon type may have <literal>width</literal> and <literal>height</literal> properties.
+						<literal>remote</literal> icons loaded from a remote URL. Currently, only HTTP urls are supported.
+						This icon type should have <literal>width</literal> and <literal>height</literal> properties.
 					</para>
 					<para>
 						Examples of the different methods to specify an icon:

--- a/docs/sources/metainfo/component.xml
+++ b/docs/sources/metainfo/component.xml
@@ -143,6 +143,30 @@
 		</listitem>
 		</varlistentry>
 
+		<varlistentry id="tag-icon">
+		<term>&lt;icon/&gt;</term>
+		<listitem>
+			<para>
+				The <code>&lt;icon/&gt;</code> tag describes the component icon. It is mostly used for GUI applications (component-type <literal>desktop-application</literal>).
+				It can be of the type <literal>stock</literal>, <literal>local</literal>,
+				or <literal>url</literal>.
+			</para>
+			<para>
+				<literal>stock</literal> icons are loaded from stock. The icon name should never include any file-extension or path.
+			</para>
+			<para>
+				<literal>local</literal> icons are loaded from a file in the filesystem.
+				They should specify a full file path.
+				This icon type may have <literal>width</literal> and <literal>height</literal>
+                                properties.
+			</para>
+			<para>
+				<literal>remote</literal> icons loaded from a remote URL. Currently, only HTTP urls are supported.
+				This icon type should have <literal>width</literal> and <literal>height</literal> properties.
+			</para>
+		</listitem>
+		</varlistentry>
+
 		<varlistentry id="tag-description">
 		<term>&lt;description/&gt;</term>
 		<listitem>


### PR DESCRIPTION
And not just in the collection metadata.  This way, components of type
"service" and any other other component can specify icons upstream in
a standardized way.