### PR TITLE
Export the AppStreamQt target

### DIFF
--- a/qt/AppStreamQtConfig.cmake.in
+++ b/qt/AppStreamQtConfig.cmake.in
@@ -1,5 +1,0 @@
-@PACKAGE_INIT@
-
-check_required_components(Qt5Core)
-
-include("${CMAKE_CURRENT_LIST_DIR}/AppStreamQtTargets.cmake")

--- a/qt/cmake/AppStreamQtConfig.cmake.in
+++ b/qt/cmake/AppStreamQtConfig.cmake.in
@@ -28,6 +28,14 @@ macro(check_required_components _NAME)
   endforeach()
 endmacro()
 
+add_library(AppStreamQt SHARED IMPORTED)
+set_target_properties(AppStreamQt PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include/"
+  INTERFACE_LINK_LIBRARIES "Qt5::Core"
+  IMPORTED_LOCATION_DEBUG "@LIBDIR_FULL@/libAppStreamQt.so.${AppStreamQt_VERSION}"
+  IMPORTED_SONAME_DEBUG "libAppStreamQt.${AppStreamQt_VERSION_MAJOR}"
+)
+
 ####################################################################################
 
 check_required_components(Qt5Core)


### PR DESCRIPTION
Otherwise it only works if it's installed in /usr as a prefix (where it's
a default)