### PR TITLE
Propose a "type" property to <release/> tag.

### DIFF
--- a/docs/sources/metainfo/component.xml
+++ b/docs/sources/metainfo/component.xml
@@ -368,7 +368,7 @@
 				The <literal>date</literal> property can have any time in <ulink url="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</ulink> format as its value and
 				should be present for every release.
 				The <literal>timestamp</literal> tag contains the release time in the form of a UNIX epoch. This tag should not be used in metainfo files in newly
-				written metadata, but will still be parsed in case it is present. The the <literal>timestamp</literal> property is mainly used in generated distro-metadata.
+				written metadata, but will still be parsed in case it is present. The <literal>timestamp</literal> property is mainly used in generated distro-metadata.
 				In case both release-time tags are present, the <literal>timestamp</literal> tag will take precedence over <literal>date</literal>.
 			</para>
 			<para>

--- a/docs/sources/metainfo/component.xml
+++ b/docs/sources/metainfo/component.xml
@@ -387,6 +387,22 @@
 				The urgency defines how the update will be presented to the user, and sometimes if it will be installed automatically and immediately, or delayed.
 			</para>
 			<para>
+				Finally a <literal>release</literal> tag may have a <literal>type</literal> property
+				to classify releases with one of the following values:
+			</para>
+			<itemizedlist>
+				<listitem><para><literal>stable</literal></para></listitem>
+				<listitem><para><literal>development</literal></para></listitem>
+				<listitem><para><literal>RC</literal></para></listitem>
+			</itemizedlist>
+			<para>
+				By default, if no release type is defined, <code>stable</code> is assumed.
+				A software displaying a listing of releases should only show stable releases and
+				discard any development or release candidate releases if the current version is
+				itself stable. It can show all versions when development or release candidates are
+				also distributed.
+			</para>
+			<para>
 				Each <literal>release</literal> tag may have a <literal>description</literal> tag as child, containing a brief description of what is new in the release.
 				The <literal>description</literal> tag is structured as described in <xref linkend="tag-description"/>.
 			</para>
@@ -405,6 +421,7 @@
     <size type="download">12345678</size>
     <size type="installed">42424242</size>
   </release>
+  <release version="1.1" type="development" date="2013-10-20" />
   <release version="1.0" date="2012-08-26" />
 </releases>]]></programlisting>
 		</listitem>

--- a/docs/sources/metainfo/component.xml
+++ b/docs/sources/metainfo/component.xml
@@ -393,14 +393,12 @@
 			<itemizedlist>
 				<listitem><para><literal>stable</literal></para></listitem>
 				<listitem><para><literal>development</literal></para></listitem>
-				<listitem><para><literal>RC</literal></para></listitem>
 			</itemizedlist>
 			<para>
 				By default, if no release type is defined, <code>stable</code> is assumed.
 				A software displaying a listing of releases should only show stable releases and
-				discard any development or release candidate releases if the current version is
-				itself stable. It can show all versions when development or release candidates are
-				also distributed.
+				discard any development release if the current version is itself stable. It can
+				show all versions when development versions of the software are also distributed.
 			</para>
 			<para>
 				Each <literal>release</literal> tag may have a <literal>description</literal> tag as child, containing a brief description of what is new in the release.


### PR DESCRIPTION
The logics behind this proposition is that in GIMP, we have development release. Someone is proposing us to add <releases> tag in our appdata. So far so good.

But he also wants <release> items for the development releases. And that's where I am wondering if that is really relevant information. Well this is definitely relevant for anyone installing such development versions. But for most people, these are releases they will never see (and barely know they exist), and that's normal (distributions are certainly not expected to distribute them). Therefore if such a release listing (is there any software making usage of this tag by the way? GNOME Software 3.26 at least doesn't seem to do anything from it) were to include development versions, this would confuse people.

This is why I am proposing this change so that the <release> tags can be properly categorized.

As a result, any software which is expected to make usage of the release listing should only show stable versions, unless development versions are distributed/installed.