### PR TITLE
Release url

### DIFF
--- a/docs/sources/metainfo/component.xml
+++ b/docs/sources/metainfo/component.xml
@@ -424,10 +424,18 @@
 				The size itself is set as the value and must be given in bytes.
 			</para>
 			<para>
+				Finally a <literal>release</literal> tag may have one or multiple <literal>url</literal>
+				tags as children. These <literal>url</literal> tags must be links specific to a release.
+				For instance a release news on the project web page for this specific version or a release
+				note should be listed as a <literal>url</literal> with type "homepage".
+				The <literal>url</literal> tag is structured as described in <xref linkend="tag-url"/>.
+			</para>
+			<para>
 			Examples for a valid releases tag:
 			</para>
 			<programlisting language="XML"><![CDATA[<releases>
   <release version="1.2" date="2014-04-12" urgency="high">
+    <url type="homepage">https://example.org/news/version-1.2-release</url>
     <size type="download">12345678</size>
     <size type="installed">42424242</size>
   </release>


### PR DESCRIPTION
This is a proposition for allowing `<url>` inside the `<release>` tag as discussed in the pull request #158.
We do very nice news post on gimp.org now, with a lot of screenshots, explanations and much more, and a link to these would be very good in a release listing for people who want to know more.
And for release notes too. :-)