### PR TITLE
Add install-docs meson build option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ meson <flags> ..
 ninja
 ninja test
 ```
-Possible AppStream-specific flags are:
- -Dqt=true           -- Build the Qt interface library (default: false)
- -Dvapi=true         -- Build Vala API to use the library with the Vala programming language (default: false)
- -Ddocs=true         -- Build specification and other documentation, requires Publican (default: false)
- -Dinstall-docs=true -- Install documentation (default: true)
- -Dmaintainer=true   -- Enable strict compiler options - use this if you write a patch for AppStream (default: false)
- -Dstemming=true     -- Enable support for stemming in fulltext searches (default: true)
- -Dapt-support=true  -- Enable integration with the APT package manager on Debian (default: false)
+Possible AppStream-specific flags are:  
+ -Dqt=true          -- Build the Qt interface library (default: false)  
+ -Dvapi=true        -- Build Vala API to use the library with the Vala programming language (default: false)  
+ -Ddocs=true        -- Build specification and other documentation, requires Publican (default: false)  
+ -Dinstall-docs=true -- Install documentation (default: true)  
+ -Dmaintainer=true  -- Enable strict compiler options - use this if you write a patch for AppStream (default: false)  
+ -Dstemming=true    -- Enable support for stemming in fulltext searches (default: true)  
+ -Dapt-support=true -- Enable integration with the APT package manager on Debian (default: false)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ meson <flags> ..
 ninja
 ninja test
 ```
-Possible AppStream-specific flags are:  
- -Dqt=true          -- Build the Qt interface library (default: false)  
- -Dvapi=true        -- Build Vala API to use the library with the Vala programming language (default: false)  
- -Ddocs=true        -- Build specification and other documentation, requires Publican (default: false)  
- -Dmaintainer=true  -- Enable strict compiler options - use this if you write a patch for AppStream (default: false)  
- -Dstemming=true    -- Enable support for stemming in fulltext searches (default: true)  
- -Dapt-support=true -- Enable integration with the APT package manager on Debian (default: false)
+Possible AppStream-specific flags are:
+ -Dqt=true           -- Build the Qt interface library (default: false)
+ -Dvapi=true         -- Build Vala API to use the library with the Vala programming language (default: false)
+ -Ddocs=true         -- Build specification and other documentation, requires Publican (default: false)
+ -Dinstall-docs=true -- Install documentation (default: true)
+ -Dmaintainer=true   -- Enable strict compiler options - use this if you write a patch for AppStream (default: false)
+ -Dstemming=true     -- Enable support for stemming in fulltext searches (default: true)
+ -Dapt-support=true  -- Enable integration with the APT package manager on Debian (default: false)
 
 ### Installation
 

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -99,8 +99,10 @@ if get_option('docs')
     # helper if you only and always want to rebuild the docs
     run_target('documentation', command: build_docs_cmd)
 
-    install_subdir('html', install_dir: as_doc_target_dir)
-else
+    if get_option('install-docs')
+        install_subdir('html', install_dir: as_doc_target_dir)
+    endif
+elif get_option('install-docs')
     if run_command('[', '-d', join_paths(meson.current_source_dir(), 'html'), ']').returncode() == 0
         # install documentation, if it exists
         install_subdir('html', install_dir: as_doc_target_dir)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -23,6 +23,11 @@ option('apidocs',
        value : true,
        description : 'Build API documentation (automatically enabled when "-Ddocs=true" is passed)'
 )
+option('install-docs',
+       type : 'boolean',
+       value : true,
+       description : 'Install documentation for API and specification'
+)
 option('apt-support',
        type : 'boolean',
        value : false,


### PR DESCRIPTION
--install-docs=false can be used to disable installation of documentation,
which right now can't be disabled as it was possible with cmake.