### PR TITLE
Implement missing constructors

### DIFF
--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -154,6 +154,21 @@ Component::~Component()
     g_object_unref(m_cpt);
 }
 
+Component& Component::operator=(const Component& other)
+{
+    if (&other != this) {
+        g_object_unref(m_cpt);
+        m_cpt = other.m_cpt;
+        g_object_ref(m_cpt);
+    }
+    return *this;
+}
+
+Component::Component(Component&& other)
+    : m_cpt(other.m_cpt)
+{
+}
+
 _AsComponent * AppStream::Component::asComponent() const
 {
     return m_cpt;

--- a/qt/component.h
+++ b/qt/component.h
@@ -100,7 +100,10 @@ Q_GADGET
         Component(_AsComponent *cpt);
         Component();
         Component(const Component& other);
+        Component(Component&& other);
         ~Component();
+
+        Component& operator=(const Component& c);
 
         _AsComponent *asComponent() const;
 


### PR DESCRIPTION
Fixes a crash when no deref/ref on = operator.
Makes it possible to leverage move semantics on components.