### PR TITLE
Allow release description translations

### DIFF
--- a/data/its/metainfo.its
+++ b/data/its/metainfo.its
@@ -6,6 +6,7 @@
                                /component/summary |
                                /component/description |
                                /component/developer_name |
-                               /component/screenshots/screenshot/caption"
+                               /component/screenshots/screenshot/caption |
+                               /component/releases/release/description"
                      translate="yes"/>
 </its:rules>


### PR DESCRIPTION
https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html allows to provide information about releases.
This PR aims at allowing xgettext to list them as translatable strings.