### PR TITLE
Set error variable if there were some errors during refinement

### DIFF
--- a/src/as-pool.c
+++ b/src/as-pool.c
@@ -1014,6 +1014,12 @@ as_pool_load (AsPool *pool, GCancellable *cancellable, GError **error)
 
 	/* automatically refine the metadata we have in the pool */
 	ret = as_pool_refine_data (pool) && ret;
+	
+	/* report errors if there were errors from as_pool_refine_data */
+	if (!ret && error && !*error)
+		*error = g_new_error_literal(AS_POOL_ERROR,
+					     AS_POOL_ERROR_INCOMPLETE,
+					     "Some components are invalid. See debug output for details");
 
 	return ret;
 }


### PR DESCRIPTION
When as_pool_refine_data encounters bad components, this is reflected
in the return code, but there is no further information given what went
wrong. Give a short hint to the user, and refer to the debug output which
allows determining the cause.