### PR TITLE
Allow multiple addons per component

### DIFF
--- a/src/as-pool.c
+++ b/src/as-pool.c
@@ -486,7 +486,7 @@ as_pool_update_addon_info (AsPool *pool, AsComponent *cpt)
 		}
 
 		/* don't act if we already have addons */
-		if (as_component_get_addons (extended_cpt)->len > 0)
+		if (g_ptr_array_find (as_component_get_addons (extended_cpt), cpt, NULL))
 			continue;
 
 		as_component_add_addon (extended_cpt, cpt);

--- a/src/as-pool.c
+++ b/src/as-pool.c
@@ -485,7 +485,7 @@ as_pool_update_addon_info (AsPool *pool, AsComponent *cpt)
 			return;
 		}
 
-		/* don't act if we already have addons */
+		/* don't add the same addon more than once */
 		if (g_ptr_array_find (as_component_get_addons (extended_cpt), cpt, NULL))
 			continue;
 


### PR DESCRIPTION
Currently, only a maximum of one addon is associated with a component.

As far as I understand it, a component should be able to have multiple addons. I.e. multiple components can all have an `extends` field that points to the same component.

In this PR, when looking at the extends field, make sure we add the current component to the addons section of the extended package if the current component isn't in the addons list already, rather than artificially limiting it to 1 addon per component.