### PR TITLE
doc: help distinguish the 2 'languages' tags

### DIFF
--- a/docs/sources/metainfo/localization.xml
+++ b/docs/sources/metainfo/localization.xml
@@ -19,6 +19,9 @@
 		<para>
 			Language packs can ship one or more metainfo files as <filename>/usr/share/metainfo/%{id}.metainfo.xml</filename>.
 		</para>
+		<para>
+			Do not confuse language packs with the software collection <xref linkend="tag-ct-languages"/> tag, used to identify bundled translations.
+		</para>
 	</section>
 
 	<section id="spec-l10n-example">


### PR DESCRIPTION
Reference Collection's 'languages' tag from the localization page, so upstream don't get confused into generating language packs metadata to reference bundled gettext .mo files. Both pages define a 'languages' tag.