### PR TITLE
Don't use origin subfolder for flatpak icons

### DIFF
--- a/src/as-component.c
+++ b/src/as-component.c
@@ -2139,21 +2139,39 @@ as_component_refine_icons (AsComponent *cpt, GPtrArray *icon_paths)
 				g_autofree gchar *tmp_icon_path_wh = NULL;
 				const gchar *icon_path = (const gchar*) g_ptr_array_index (icon_paths, l);
 
-				if (as_icon_get_scale (icon) <= 1) {
-					tmp_icon_path_wh = g_strdup_printf ("%s/%s/%ix%i/%s",
-										icon_path,
-										origin,
-										as_icon_get_width (icon),
-										as_icon_get_height (icon),
-										icon_fname);
+				// Flatpak repos don't place their icons on an "origin" subdirectory
+				if (g_strcmp0 (origin, "flatpak") == 0) {
+					if (as_icon_get_scale (icon) <= 1) {
+						tmp_icon_path_wh = g_strdup_printf ("%s/%ix%i/%s",
+											icon_path,
+											as_icon_get_width (icon),
+											as_icon_get_height (icon),
+											icon_fname);
+					} else {
+						tmp_icon_path_wh = g_strdup_printf ("%s/%ix%i@%i/%s",
+											icon_path,
+											as_icon_get_width (icon),
+											as_icon_get_height (icon),
+											as_icon_get_scale (icon),
+											icon_fname);
+					}
 				} else {
-					tmp_icon_path_wh = g_strdup_printf ("%s/%s/%ix%i@%i/%s",
-										icon_path,
-										origin,
-										as_icon_get_width (icon),
-										as_icon_get_height (icon),
-										as_icon_get_scale (icon),
-										icon_fname);
+					if (as_icon_get_scale (icon) <= 1) {
+						tmp_icon_path_wh = g_strdup_printf ("%s/%s/%ix%i/%s",
+											icon_path,
+											origin,
+											as_icon_get_width (icon),
+											as_icon_get_height (icon),
+											icon_fname);
+					} else {
+						tmp_icon_path_wh = g_strdup_printf ("%s/%s/%ix%i@%i/%s",
+											icon_path,
+											origin,
+											as_icon_get_width (icon),
+											as_icon_get_height (icon),
+											as_icon_get_scale (icon),
+											icon_fname);
+					}
 				}
 
 				if (g_file_test (tmp_icon_path_wh, G_FILE_TEST_EXISTS)) {
@@ -2176,11 +2194,18 @@ as_component_refine_icons (AsComponent *cpt, GPtrArray *icon_paths)
 			for (j = 0; sizes[j] != NULL; j++) {
 				g_autofree gchar *tmp_icon_path = NULL;
 				/* sometimes, the file already has an extension */
-				tmp_icon_path = g_strdup_printf ("%s/%s/%s/%s",
-								icon_path,
-								origin,
-								sizes[j],
-								icon_fname);
+				if (g_strcmp0 (origin, "flatpak") == 0) {
+					tmp_icon_path = g_strdup_printf ("%s/%s/%s",
+									icon_path,
+									sizes[j],
+									icon_fname);
+				} else {
+					tmp_icon_path = g_strdup_printf ("%s/%s/%s/%s",
+									icon_path,
+									origin,
+									sizes[j],
+									icon_fname);
+				}
 
 				if (g_file_test (tmp_icon_path, G_FILE_TEST_EXISTS)) {
 					/* we have an icon! */
@@ -2202,12 +2227,20 @@ as_component_refine_icons (AsComponent *cpt, GPtrArray *icon_paths)
 				/* file not found, try extensions (we will not do this forever, better fix AppStream data!) */
 				for (k = 0; extensions[k] != NULL; k++) {
 					g_autofree gchar *tmp_icon_path_ext = NULL;
-					tmp_icon_path_ext = g_strdup_printf ("%s/%s/%s/%s.%s",
-								icon_path,
-								origin,
-								sizes[j],
-								icon_fname,
-								extensions[k]);
+					if (g_strcmp0 (origin, "flatpak") == 0) {
+						tmp_icon_path_ext = g_strdup_printf ("%s/%s/%s/%s.%s",
+									icon_path,
+									origin,
+									sizes[j],
+									icon_fname,
+									extensions[k]);
+					} else {
+						tmp_icon_path_ext = g_strdup_printf ("%s/%s/%s.%s",
+									icon_path,
+									sizes[j],
+									icon_fname,
+									extensions[k]);
+					}
 
 					if (g_file_test (tmp_icon_path_ext, G_FILE_TEST_EXISTS)) {
 						/* we have an icon! */


### PR DESCRIPTION
While implementing AppStream support in elementary AppCenter, I've noticed the following behaviour:

When creating an AppStream pool and loading the metadata from a Flatpak appstream folder (e.g. flathub's metadata is stored in `/var/lib/flatpak/appstream/flathub/x86_64/active/` on my computer), no icons are available on any of the components.

The components in flatpak appdata xmls all have icons all in the following format:
`<icon type="cached" height="64" width="64">br.gov.cti.invesalius.png</icon>`

i.e. always cached, and always with a width and a height

However, for cached icons, the `as_component_refine_icons` method checks to see if files exist in a subdirectory structure, where one of the subdirectories is the origin name. As far as I can tell, the origin name will always be `flatpak` due to these hardcoded lines in flatpak:
https://github.com/flatpak/flatpak/blob/2bb84cc52216559b8a8dad2a43ef1b4d309dae2d/common/flatpak-utils.c#L3724-L3725

However, all of the various flatpak repositories I have enabled on my machine don't include an origin subfolder and instead put the icon size directories directly in `icons`:

```
/var/lib/flatpak/appstream/flathub/x86_64/active/
├── appstream.xml
├── appstream.xml.gz
└── icons
    ├── 128x128 [472 entries exceeds filelimit, not opening dir]
    └── 64x64 [508 entries exceeds filelimit, not opening dir]
```

I appreciate this is an issue of whatever generates that directory structure not following the spec properly, but it seems that there are already a bunch of applications and scripts that depend on this directory structure (e.g. GNOME Software and scripts that extract appdata/icons from flatpak repos), plus getting every repo to change would be difficult.

So I propose handling this case in the appstream library. The proposed patch includes an exception to the origin folder when the origin name is `flatpak`, but I'd be open to suggestions of other ways to solve this by people with a better overview of the whole picture than I.
