### PR TITLE
docs: Explicitly rule out nested lists

### DIFF
--- a/docs/sources/metainfo/component.xml
+++ b/docs/sources/metainfo/component.xml
@@ -186,7 +186,7 @@
 			A long description of this component. Some markup can be used.
 		</para>
 		<para>
-			Do not assume the format is HTML. Only paragraph (<literal>p</literal>), ordered list (<literal>ol</literal>) and unordered list (<literal>ul</literal>) with their list items (<literal>li</literal>) are currently supported.
+			Do not assume the format is HTML. Only paragraph (<literal>p</literal>), ordered list (<literal>ol</literal>) and unordered list (<literal>ul</literal>) with their list items (<literal>li</literal>) are currently supported. Nested lists are not supported.
 		</para>
 		<para>
 			In metainfo files, this tag should be translated by-paragraph, meaning that in a translated file, each translated <literal>&lt;p/&gt;</literal> child


### PR DESCRIPTION
Cockpit doesn't support those, but we have a request for it. Let's clarify the spec.

If nested lists are in fact supported, that's just fine as well, of course, but let's clarify that also.
