### PR TITLE
its: Add translatable option in metainfo.its

### DIFF
--- a/data/its/metainfo.its
+++ b/data/its/metainfo.its
@@ -11,4 +11,8 @@
                                /component/agreement/agreement_section/name |
                                /component/agreement/agreement_section/description"
                      translate="yes"/>
+  <its:translateRule selector="/component/name[@translatable = 'no']"
+                     translate="no"/>
+  <its:translateRule selector="/component/developer_name[@translatable = 'no']"
+                     translate="no"/>
 </its:rules>


### PR DESCRIPTION
Some package does not wish to extract the component name
as translatable since it's the branding name and add the
translatable option.

https://github.com/ximion/appstream/issues/229