### PR TITLE
Sort addons less prominently than applications

### DIFF
--- a/src/as-cache.c
+++ b/src/as-cache.c
@@ -2049,6 +2049,10 @@ as_cache_update_results_with_fts_value (AsCache *cache, MDB_txn *txn, MDB_val dv
 					sort_score |= match_pval << 2;
 				else
 					sort_score |= match_pval;
+
+				if (as_component_get_kind(cpt) == AS_COMPONENT_KIND_ADDON)
+					sort_score--;
+
 				as_component_set_sort_score (cpt, sort_score);
 
 				g_hash_table_insert (results_ht,
@@ -2061,6 +2065,10 @@ as_cache_update_results_with_fts_value (AsCache *cache, MDB_txn *txn, MDB_val dv
 				sort_score |= match_pval << 2;
 			else
 				sort_score |= match_pval;
+
+			if (as_component_get_kind(cpt) == AS_COMPONENT_KIND_ADDON)
+				sort_score--;
+
 			as_component_set_sort_score (cpt, sort_score);
 		}
 	}


### PR DESCRIPTION
Otherwise we get a bunch of addons whenever we search for the
application in question.

See https://bugs.kde.org/show_bug.cgi?id=407588

After:
```
Identifier: org.kde.kdevelop.desktop [desktop-application]
Name: KDevelop
Summary: Featureful, plugin-extensible IDE for C/C++ and other programming languages
Package: kdevelop
Homepage: https://kdevelop.org
Icon: kdevelop_kdevelop.png
---
Identifier: org.kde.kdev-python [addon]
Name: KDevelop Python Support
Summary: Python language support for KDevelop
Package: kdevelop-python
Homepage: https://kdevelop.org
Icon: kdevelop-python_kdevelop.png
---
Identifier: org.kde.kdev-php [addon]
Name: KDevelop PHP Support
Summary: PHP language support for KDevelop
Package: kdevelop-php
Homepage: https://kdevelop.org
Icon: kdevelop-php_kdevelop.png
```

Before:
```
Identifier: org.kde.kdev-python [addon]
Name: KDevelop Python Support
Summary: Python language support for KDevelop
Package: kdevelop-python
Homepage: https://kdevelop.org
Icon: kdevelop-python_kdevelop.png
---
Identifier: org.kde.kdevelop.desktop [desktop-application]
Name: KDevelop
Summary: Featureful, plugin-extensible IDE for C/C++ and other programming languages
Package: kdevelop
Homepage: https://kdevelop.org
Icon: kdevelop_kdevelop.png
---
Identifier: org.kde.kdev-php [addon]
Name: KDevelop PHP Support
Summary: PHP language support for KDevelop
Package: kdevelop-php
Homepage: https://kdevelop.org
Icon: kdevelop-php_kdevelop.png
```