### PR TITLE
as-cache: Use correct FTS value per result

### DIFF
--- a/src/as-cache.c
+++ b/src/as-cache.c
@@ -2079,7 +2079,7 @@ as_cache_update_results_with_fts_value (AsCache *cache, MDB_txn *txn, MDB_val dv
 		AsTokenType match_pval;
 
 		cpt_hash = data + i;
-		match_pval = (AsTokenType) *(data + AS_CACHE_CHECKSUM_LEN);
+		match_pval = (AsTokenType) *(data + i + AS_CACHE_CHECKSUM_LEN);
 
 		/* retrieve component with this hash */
 		cpt = g_hash_table_lookup (results_ht, cpt_hash);


### PR DESCRIPTION
I've been looking into some of the searching/sorting logic and I'm not 100% sure on this change due to not being overly familiar with the code and not having worked the logic all the way back yet, but given that

```
ENTRY_LEN = sizeof(AsTokenType) + AS_CACHE_CHECKSUM_LEN * sizeof(guint8);
```

It looks like there is one `AsTokenType` per result, yet it seems the pointer arithmetic for updating `sort_score` doesn't take the array index into account.