### PR TITLE
Make as_component_get_sort_score public

### DIFF
--- a/src/as-component-private.h
+++ b/src/as-component-private.h
@@ -82,7 +82,6 @@ GHashTable		*as_component_get_token_cache_table (AsComponent *cpt);
 void			 as_component_set_token_cache_valid (AsComponent *cpt,
 							     gboolean valid);
 
-guint			as_component_get_sort_score (AsComponent *cpt);
 void			as_component_set_sort_score (AsComponent *cpt,
 							guint score);
 

--- a/src/as-component.h
+++ b/src/as-component.h
@@ -372,6 +372,8 @@ gchar			*as_component_to_xml_data (AsComponent *cpt,
 						   AsContext *context,
 						   GError **error);
 
+guint			as_component_get_sort_score (AsComponent *cpt);
+
 /* DEPRECATED */
 
 G_DEPRECATED


### PR DESCRIPTION
Fixes #269 

It turns out that this is a `guint` rather than a custom type, so this works out perfectly in the vapi.

I know you wanted to have a bit more of a think about this in terms of whether this score is suitable for comparing components in disparate pools and whether this is the right approach, but I feel happier that I've done a tiny bit of the leg work :stuck_out_tongue_closed_eyes: 