### PR TITLE
qt: add missing Provided::KindId enum

### DIFF
--- a/qt/provided.h
+++ b/qt/provided.h
@@ -59,7 +59,8 @@ class APPSTREAMQT_EXPORT Provided {
             KindDBusSystemService,
             KindDBusUserService,
             KindFirmwareRuntime,
-            KindFirmwareFlashed
+            KindFirmwareFlashed,
+            KindId,
         };
         Q_ENUM(Kind)
 


### PR DESCRIPTION
It was never added to the Qt interface