### PR TITLE
docs: Update to remove icon tag from Metadata

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -157,30 +157,6 @@
 		</listitem>
 		</varlistentry>
 
-		<varlistentry id="tag-icon">
-		<term>&lt;icon/&gt;</term>
-		<listitem>
-			<para>
-				The <code>&lt;icon/&gt;</code> tag describes the component icon. It is mostly used for GUI applications (component-type <literal>desktop-application</literal>).
-				It can be of type <literal>stock</literal>, <literal>local</literal> or <literal>remote</literal>.
-			</para>
-			<para>
-				<literal>stock</literal> icons are loaded from the icon stock (the current or hicolor/locolor fallback themes).
-				The icon name must not include any file-extension or path.
-			</para>
-			<para>
-				<literal>local</literal> icons are loaded from a file in the filesystem.
-				They should specify a full file path.
-				This icon type may have <literal>width</literal> and <literal>height</literal>
-                                properties.
-			</para>
-			<para>
-				<literal>remote</literal> icons loaded from a remote URL. Currently, only HTTP/HTTPS urls are supported.
-				This icon type should have <literal>width</literal> and <literal>height</literal> properties.
-			</para>
-		</listitem>
-		</varlistentry>
-
 		<varlistentry id="tag-description">
 		<term>&lt;description/&gt;</term>
 		<listitem>


### PR DESCRIPTION
This is no longer accepted by appstream-util validate-relax:

$ appstream-util validate-relax org.kde.okteta.appdata.xml
org.kde.okteta.appdata.xml: FAILED:
• tag-invalid           : <icon> not allowed in desktop appdata
• tag-invalid           : stock icon is not valid [okteta]
Validation of files failed

See also discussion in https://github.com/keepassxreboot/keepassxc/issues/1131