### PR TITLE
WIP: Specify display_length requires/recommends item

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -834,6 +834,89 @@
 				</listitem>
 			</varlistentry>
 
+			<varlistentry id="tag-requires-recommends-display-width-height">
+				<term>&lt;display_length/&gt;</term>
+				<listitem>
+				<para>
+					Set a relation to the display length defined as an integer value in either <emphasis>millimeters</emphasis> or <emphasis>logical pixels</emphasis>
+					(device pixels divided by scaling factor, roughly equivalent to 0.26mm (1/96in), also known as device-independent pixels).
+					To use millimeters, the <literal>unit</literal> property of this tag needs to be set to value <code>mm</code>, to use logical pixels
+					its value must be <code>px</code>. If no unit is explicitly defined, <code>px</code> is implicitly assumed.
+					Setting the <literal>side</literal> property to either <code>shortest</code> or <code>longest</code> will apply the selected size constraint to
+					either the shortest or longest side of the display rectangle, with <code>shortest</code> being implicitly assumed if no value is set.
+				</para>
+				<note>
+					<title>About Pixel Dimensions</title>
+					<para>
+						One logical pixel (= device independent pixel) roughly corresponds to the visual angle of one pixel on a device with a pixel density of
+						96dpi and a distance from the observer of about 52cm, making the physical pixel about 0.26mm in size.
+						If using logical pixels as unit, they might not always map to exact physical lengths as their exact size is defined by the device providing
+						the display.
+						They do however accurately depict the maximum amount of things that can be drawn in a direction on screen.
+					</para>
+				</note>
+				<para>
+					Relations for the display length can be defined using a <literal>compare</literal> property as described in <xref linkend="tag-requires-recommends"/>.
+					If this property is not present, a value of <code>ge</code> (greater-or-equal) is implicitly assumed.
+				</para>
+				<para>
+					The <literal>display_length</literal> tag also accepts one of the following text values. While their exact meaning in terms of pixel-based or physical size
+					is implementation-defined, the text term must roughly match the screen size of the device class listed next to it in the listing below:
+				</para>
+				<itemizedlist>
+					<listitem><para><code>xsmall</code> - Very small screens, as used in watches, wearables and other small-display devices (about &lt;= 300px).</para></listitem>
+					<listitem><para><code>small</code> - Small screens often used in handheld devices, such as phone screens, small phablets (about &lt; 600px).</para></listitem>
+					<listitem><para><code>medium</code> - Screens in laptops, tablets (about &gt;= 600px)</para></listitem>
+					<listitem><para><code>large</code> - Bigger computer monitors (about &gt;= 1024px)</para></listitem>
+					<listitem><para><code>xlarge</code> - Television screens, large projected images</para></listitem>
+				</itemizedlist>
+				<para>
+					If a text value is used, the <literal>unit</literal> and <literal>side</literal> properties must not be present. For <literal>side</literal>, <code>shortest</code>
+					is assumed in this case.
+					A <literal>compare</literal> property is permitted and will compare the text placeholder values from smallest (<code>xsmall</code>) to largest (<code>xlarge</code>).
+					The text values are intended for adaptive applications which only need or want to give a very rough hint as to which display lengths they support, and do
+					not need fine control over their visibility (as these types of applications will adjust well to most screen sizes at runtime).
+					If finer control is needed, absolute sizes should be used instead.
+				</para>
+				<para>
+					This tag may appear up to four times to set a minimum and maximum dimension required. It is recommended to not mix different units
+					(so e.g. a required minimal width is not requested in both <code>px</code> and <code>mm</code>).
+					If multiple displays are connected to a device, it is acceptable to test against either the largest screen attached to the device, or the combined
+					amount of display space (depending on what makes sense for the respective device).
+				</para>
+				<para>
+					If used in a <literal>requires</literal> block, this relation can be used to restrict an application to only be installable on systems which have a minimum
+					usable display length available for it. If used in a <literal>recommends</literal> block, the application will still be
+					installable, but the user may be shown a warning.
+				</para>
+				<para>
+					If no <literal>display_length</literal> relation is present, a minimum required display (<code>ge</code>) relation
+					of <code>medium</code> is implicitly assumed to preserve backwards compatibility (so applications capable of running on smaller screens
+					need to make their support for that configuration explicit).
+				</para>
+				<para>
+					Examples:
+				</para>
+				<programlisting language="XML"><![CDATA[<!-- recommend at least 600 logical pixels of space -->
+<recommends>
+  <display_length compare="ge">600</display_length>
+</recommends>
+
+<!-- require a device with at least 8x5cm physical screen space for this app -->
+<requires>
+  <display_length side="longest" unit="mm" compare="ge">80</display_length>
+  <display_length side="shortest" unit="mm">50</display_length>
+</requires>
+
+<!-- ensure this application is not run on a very large screen, or
+     very small screen (no tiny handhelds or television screens) -->
+<requires>
+  <display_length compare="lt">xlarge</display_length>
+  <display_length compare="gt">xsmall</display_length>
+</requires>]]></programlisting>
+				</listitem>
+			</varlistentry>
+
 			</variablelist>
 		</listitem>
 

--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -807,6 +807,7 @@
 					<listitem><para><code>console</code> - Control via a console / command-line interface</para></listitem>
 					<listitem><para><code>touch</code> - Input by touching a surface with fingers is possible</para></listitem>
 					<listitem><para><code>gamepad</code> - The component supports gamepads (any game controller with wheels/buttons/joysticks)</para></listitem>
+					<listitem><para><code>tv-remote</code> - Input via a TV remote (with arrow keys, number pad, other basic inputs) is supported.</para></listitem>
 					<listitem><para><code>voice</code> - The software can be controlled via voice recognition/activation</para></listitem>
 					<listitem><para><code>vision</code> - The software can be controlled by computer vision / visual object and sign detection</para></listitem>
 				</itemizedlist>

--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -835,14 +835,12 @@
 				</listitem>
 			</varlistentry>
 
-			<varlistentry id="tag-requires-recommends-display-width-height">
+			<varlistentry id="tag-requires-recommends-display_length">
 				<term>&lt;display_length/&gt;</term>
 				<listitem>
 				<para>
-					Set a relation to the display length defined as an integer value in either <emphasis>millimeters</emphasis> or <emphasis>logical pixels</emphasis>
-					(device pixels divided by scaling factor, roughly equivalent to 0.26mm (1/96in), also known as device-independent pixels).
-					To use millimeters, the <literal>unit</literal> property of this tag needs to be set to value <code>mm</code>, to use logical pixels
-					its value must be <code>px</code>. If no unit is explicitly defined, <code>px</code> is implicitly assumed.
+					Set a relation to the display length defined as an integer value in <emphasis>logical pixels</emphasis> (device pixels divided by scaling factor,
+					roughly equivalent to 0.26mm (1/96in), also known as device-independent pixels).
 					Setting the <literal>side</literal> property to either <code>shortest</code> or <code>longest</code> will apply the selected size constraint to
 					either the shortest or longest side of the display rectangle, with <code>shortest</code> being implicitly assumed if no value is set.
 				</para>
@@ -851,9 +849,9 @@
 					<para>
 						One logical pixel (= device independent pixel) roughly corresponds to the visual angle of one pixel on a device with a pixel density of
 						96dpi and a distance from the observer of about 52cm, making the physical pixel about 0.26mm in size.
-						If using logical pixels as unit, they might not always map to exact physical lengths as their exact size is defined by the device providing
+						When using logical pixels as unit, they might not always map to exact physical lengths as their exact size is defined by the device providing
 						the display.
-						They do however accurately depict the maximum amount of things that can be drawn in a direction on screen.
+						They do however accurately depict the maximum amount of pixels that can be drawn in the depicted direction on the device's display space.
 					</para>
 				</note>
 				<para>
@@ -861,29 +859,39 @@
 					If this property is not present, a value of <code>ge</code> (greater-or-equal) is implicitly assumed.
 				</para>
 				<para>
-					The <literal>display_length</literal> tag also accepts one of the following text values. While their exact meaning in terms of pixel-based or physical size
-					is implementation-defined, the text term must roughly match the screen size of the device class listed next to it in the listing below:
+					The <literal>display_length</literal> tag also accepts one of the following text values. While their exact meaning in terms of pixel-based size
+					is implementation-defined, the text term will roughly match the screen size of the device class listed next to it in the listing below:
 				</para>
 				<itemizedlist>
-					<listitem><para><code>xsmall</code> - Very small screens, as used in watches, wearables and other small-display devices (about &lt;= 300px).</para></listitem>
-					<listitem><para><code>small</code> - Small screens often used in handheld devices, such as phone screens, small phablets (about &lt; 600px).</para></listitem>
-					<listitem><para><code>medium</code> - Screens in laptops, tablets (about &gt;= 600px)</para></listitem>
+					<listitem><para><code>xsmall</code> - Very small screens, as used in watches, wearables and other small-display devices (about &lt;= 360px).</para></listitem>
+					<listitem><para><code>small</code> - Small screens often used in handheld devices, such as phone screens, small phablets (about &lt; 768px).</para></listitem>
+					<listitem><para><code>medium</code> - Screens in laptops, tablets (about &gt;= 768px)</para></listitem>
 					<listitem><para><code>large</code> - Bigger computer monitors (about &gt;= 1024px)</para></listitem>
-					<listitem><para><code>xlarge</code> - Television screens, large projected images</para></listitem>
+					<listitem><para><code>xlarge</code> - Television screens, large projected images (about &gt;= 3840px)</para></listitem>
 				</itemizedlist>
 				<para>
-					If a text value is used, the <literal>unit</literal> and <literal>side</literal> properties must not be present. For <literal>side</literal>, <code>shortest</code>
+					If a text value is used, the <literal>side</literal> property must not be present. For <literal>side</literal>, <code>shortest</code>
 					is assumed in this case.
 					A <literal>compare</literal> property is permitted and will compare the text placeholder values from smallest (<code>xsmall</code>) to largest (<code>xlarge</code>).
 					The text values are intended for adaptive applications which only need or want to give a very rough hint as to which display lengths they support, and do
 					not need fine control over their visibility (as these types of applications will adjust well to most screen sizes at runtime).
 					If finer control is needed, absolute sizes should be used instead.
 				</para>
+				<note>
+					<title>Determining Device Types</title>
+					<para>
+						Please note that a display with a lot of vertical space may not be a television screen, but could also be a large gaming monitor.
+						Similar logic applies to the smaller screen sizes. Therefore, to indicate that an application runs well on a certain <emphasis>device</emphasis>
+						and not just on a certain <emphasis>display</emphasis>, additional metadata is needed, like the application's supported
+						input controls as defined via <xref linkend="tag-requires-recommends-control"/>.
+					</para>
+				</note>
 				<para>
-					This tag may appear up to four times to set a minimum and maximum dimension required. It is recommended to not mix different units
-					(so e.g. a required minimal width is not requested in both <code>px</code> and <code>mm</code>).
+					This tag may appear up to four times to set a minimum and maximum dimension required.
 					If multiple displays are connected to a device, it is acceptable to test against either the largest screen attached to the device, or the combined
-					amount of display space (depending on what makes sense for the respective device).
+					amount of display space (depending on what makes the most sense for the respective device / setup).
+					A software center application may test for the maximum possible resolution of an attached display, and not the currently set display resolution in case
+					it wants to check against hardware capability and not be influenced by user configuration.
 				</para>
 				<para>
 					If used in a <literal>requires</literal> block, this relation can be used to restrict an application to only be installable on systems which have a minimum
@@ -902,12 +910,6 @@
 <recommends>
   <display_length compare="ge">600</display_length>
 </recommends>
-
-<!-- require a device with at least 8x5cm physical screen space for this app -->
-<requires>
-  <display_length side="longest" unit="mm" compare="ge">80</display_length>
-  <display_length side="shortest" unit="mm">50</display_length>
-</requires>
 
 <!-- ensure this application is not run on a very large screen, or
      very small screen (no tiny handhelds or television screens) -->

--- a/src/as-relation-private.h
+++ b/src/as-relation-private.h
@@ -47,6 +47,9 @@ void		as_relation_emit_yaml (AsRelation *relation,
 					 AsContext *ctx,
 					 yaml_emitter_t *emitter);
 
+gint			as_display_length_kind_to_px (AsDisplayLengthKind kind);
+AsDisplayLengthKind	as_display_length_kind_from_px (gint px);
+
 #pragma GCC visibility pop
 G_END_DECLS
 

--- a/src/as-relation.h
+++ b/src/as-relation.h
@@ -62,13 +62,14 @@ typedef enum  {
 
 /**
  * AsRelationItemKind:
- * @AS_RELATION_ITEM_KIND_UNKNOWN:	Unknown kind
- * @AS_RELATION_ITEM_KIND_ID:		A component ID
- * @AS_RELATION_ITEM_KIND_MODALIAS:	A hardware modalias
- * @AS_RELATION_ITEM_KIND_KERNEL:	An operating system kernel (like Linux)
- * @AS_RELATION_ITEM_KIND_MEMORY:	A system RAM requirement
- * @AS_RELATION_ITEM_KIND_FIRMWARE:	A device firmware requirement (used by fwupd)
- * @AS_RELATION_ITEM_KIND_CONTROL:	An input method for users to control software
+ * @AS_RELATION_ITEM_KIND_UNKNOWN:		Unknown kind
+ * @AS_RELATION_ITEM_KIND_ID:			A component ID
+ * @AS_RELATION_ITEM_KIND_MODALIAS:		A hardware modalias
+ * @AS_RELATION_ITEM_KIND_KERNEL:		An operating system kernel (like Linux)
+ * @AS_RELATION_ITEM_KIND_MEMORY:		A system RAM requirement
+ * @AS_RELATION_ITEM_KIND_FIRMWARE:		A device firmware requirement (used by fwupd)
+ * @AS_RELATION_ITEM_KIND_CONTROL:		An input method for users to control software
+ * @AS_RELATION_ITEM_KIND_DISPLAY_LENGTH:	Display edge length
  *
  * Type of the item an #AsRelation is for.
  **/
@@ -80,6 +81,7 @@ typedef enum  {
 	AS_RELATION_ITEM_KIND_MEMORY,
 	AS_RELATION_ITEM_KIND_FIRMWARE,
 	AS_RELATION_ITEM_KIND_CONTROL,
+	AS_RELATION_ITEM_KIND_DISPLAY_LENGTH,
 	/*< private >*/
 	AS_RELATION_ITEM_KIND_LAST
 } AsRelationItemKind;
@@ -134,6 +136,44 @@ typedef enum {
 	AS_CONTROL_KIND_LAST
 } AsControlKind;
 
+/**
+ * AsDisplaySideKind:
+ * @AS_DISPLAY_SIDE_KIND_UNKNOWN:	Unknown
+ * @AS_DISPLAY_SIDE_KIND_SHORTEST:	Shortest side of the display rectangle.
+ * @AS_DISPLAY_SIDE_KIND_LONGEST:	Longest side of the display rectangle.
+ *
+ * Side a display_length requirement is for.
+ **/
+typedef enum  {
+	AS_DISPLAY_SIDE_KIND_UNKNOWN,
+	AS_DISPLAY_SIDE_KIND_SHORTEST,
+	AS_DISPLAY_SIDE_KIND_LONGEST,
+	/*< private >*/
+	AS_DISPLAY_SIDE_KIND_LAST
+} AsDisplaySideKind;
+
+/**
+ * AsDisplayLengthKind:
+ * @AS_DISPLAY_LENGTH_KIND_UNKNOWN:	Unknown
+ * @AS_DISPLAY_LENGTH_KIND_XSMALL:	Very small display
+ * @AS_DISPLAY_LENGTH_KIND_SMALL:	Small display
+ * @AS_DISPLAY_LENGTH_KIND_MEDIUM:	Medium display
+ * @AS_DISPLAY_LENGTH_KIND_LARGE:	Large display
+ * @AS_DISPLAY_LENGTH_KIND_XLARGE:	Very large display
+ *
+ * A rought estimate of how large a given display length is.
+ **/
+typedef enum  {
+	AS_DISPLAY_LENGTH_KIND_UNKNOWN,
+	AS_DISPLAY_LENGTH_KIND_XSMALL,
+	AS_DISPLAY_LENGTH_KIND_SMALL,
+	AS_DISPLAY_LENGTH_KIND_MEDIUM,
+	AS_DISPLAY_LENGTH_KIND_LARGE,
+	AS_DISPLAY_LENGTH_KIND_XLARGE,
+	/*< private >*/
+	AS_DISPLAY_LENGTH_KIND_LAST
+} AsDisplayLengthKind;
+
 const gchar		*as_relation_kind_to_string (AsRelationKind kind);
 AsRelationKind		as_relation_kind_from_string (const gchar *kind_str);
 
@@ -146,6 +186,11 @@ const gchar		*as_relation_compare_to_symbols_string (AsRelationCompare compare);
 
 const gchar		*as_control_kind_to_string (AsControlKind kind);
 AsControlKind		as_control_kind_from_string (const gchar *kind_str);
+
+const gchar		*as_display_side_kind_to_string (AsDisplaySideKind kind);
+AsDisplaySideKind	as_display_side_kind_from_string (const gchar *kind_str);
+
+AsDisplayLengthKind	as_display_length_kind_from_string (const gchar *kind_str);
 
 AsRelation		*as_relation_new (void);
 
@@ -166,10 +211,19 @@ void			as_relation_set_version (AsRelation *relation,
 						  const gchar *version);
 
 const gchar		*as_relation_get_value (AsRelation *relation);
-gint			as_relation_get_value_int (AsRelation *relation);
-AsControlKind		as_relation_get_value_control_kind (AsRelation *relation);
 void			as_relation_set_value (AsRelation *relation,
 					        const gchar *value);
+gint			as_relation_get_value_int (AsRelation *relation);
+
+AsControlKind		as_relation_get_value_control_kind (AsRelation *relation);
+void			as_relation_set_value_control_kind (AsRelation *relation,
+							    AsControlKind kind);
+
+AsDisplaySideKind	as_relation_get_display_side_kind (AsRelation *relation);
+void			as_relation_set_display_side_kind (AsRelation *relation,
+							   AsDisplaySideKind kind);
+gint			as_relation_get_value_px (AsRelation *relation);
+AsDisplayLengthKind	as_relation_get_value_display_length_kind (AsRelation *relation);
 
 gboolean		as_relation_version_compare (AsRelation *relation,
 						     const gchar *version,


### PR DESCRIPTION
This change adds specification text to allow applications to require a minimum display width and/or height in order to be installed or run with recommended settings.
This change would address https://github.com/ximion/appstream/issues/285 

CC: @hughsie @apol @hadess @Exalm