### PR TITLE
Do not propagate a null GError

### DIFF
--- a/src/as-metadata.c
+++ b/src/as-metadata.c
@@ -568,8 +568,9 @@ as_metadata_parse_desktop_data (AsMetadata *metad, const gchar *data, const gcha
 				g_debug ("No component found in desktop-entry data.");
 			else
 				g_debug ("No component found in desktop-entry file: %s", cid);
+		} else {
+			g_propagate_error (error, tmp_error);
 		}
-		g_propagate_error (error, tmp_error);
 		return;
 	}
 


### PR DESCRIPTION
I used to get:
```
** (process:12057): DEBUG: 05:26:52.319: No component found in desktop-entry file: SparkleShare.Autostart.desktop

(process:12057): GLib-CRITICAL **: 05:26:52.319: g_propagate_error: assertion 'src != NULL' failed
```

Possibly because the desktop file is broken, but it's good not to throw critical errors like that.