### PR TITLE
build: Use c11 rather than gnu11 and define vendor extensions separately

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('AppStream', 'c',
   meson_version: '>=0.48',
-  default_options: ['c_std=gnu11', 'cpp_std=gnu++14'],
+  default_options: ['c_std=c11', 'cpp_std=gnu++14'],
 
   license: 'LGPL-2.1+ and GPL-2.0+',
   version: '0.14.1',
@@ -79,6 +79,9 @@ endif
 add_project_arguments('-Werror=implicit-function-declaration', '-Wno-unused-parameter', language: 'c')
 add_project_arguments('-Wno-unused-parameter', language: 'cpp')
 add_project_arguments('-DAS_COMPILATION', language: 'c')
+
+# Vendor extensions in system headers
+add_project_arguments('-D_POSIX_C_SOURCE=200112L', language: 'c')
 
 #
 # Dependencies

--- a/tools/ascli-actions-mdata.c
+++ b/tools/ascli-actions-mdata.c
@@ -209,7 +209,7 @@ ascli_what_provides (const gchar *cachepath, const gchar *kind_str, const gchar 
 
 	kind = as_provided_kind_from_string (kind_str);
 	if (kind == AS_PROVIDED_KIND_UNKNOWN) {
-		uint i;
+		unsigned int i;
 		g_printerr ("%s\n", _("Invalid type for provided item selected. Valid values are:"));
 		for (i = 1; i < AS_PROVIDED_KIND_LAST; i++)
 			g_printerr (" • %s\n", as_provided_kind_to_string (i));


### PR DESCRIPTION
This makes the code a little more amenable to being built as a
subproject for projects like gnome-software, which use standard C.

See `man 7 feature_test_macros` for details of the vendor extension
macros.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>