### PR TITLE
as-content-rating: Fix a typo in the type macro for AsContentRating

### DIFF
--- a/src/as-content-rating.c
+++ b/src/as-content-rating.c
@@ -1578,6 +1578,6 @@ AsContentRating*
 as_content_rating_new (void)
 {
 	AsContentRating *content_rating;
-	content_rating = g_object_new (AS_TYPE_CONTENT, NULL);
+	content_rating = g_object_new (AS_TYPE_CONTENT_RATING, NULL);
 	return AS_CONTENT_RATING (content_rating);
 }

--- a/src/as-content-rating.h
+++ b/src/as-content-rating.h
@@ -31,7 +31,7 @@
 
 G_BEGIN_DECLS
 
-#define AS_TYPE_CONTENT (as_content_rating_get_type ())
+#define AS_TYPE_CONTENT_RATING (as_content_rating_get_type ())
 G_DECLARE_DERIVABLE_TYPE (AsContentRating, as_content_rating, AS, CONTENT_RATING, GObject)
 
 struct _AsContentRatingClass


### PR DESCRIPTION
This is technically an API break, but since it was a violation of the
GObject naming conventions, it seems likely that nobody had encountered
it before (or relied on it), otherwise it would have been reported.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>