### PR TITLE
component: Don't strip ";" from keywords before translating them

### DIFF
--- a/src/as-component.c
+++ b/src/as-component.c
@@ -1301,14 +1301,25 @@ void
 as_component_set_keywords (AsComponent *cpt, gchar **value, const gchar *locale)
 {
 	AsComponentPrivate *priv = GET_PRIVATE (cpt);
+	g_autoptr(GPtrArray) keywords = NULL;
 
 	/* if no locale was specified, we assume the default locale */
 	if (locale == NULL)
 		locale = as_component_get_active_locale (cpt);
 
+	keywords = g_ptr_array_new ();
+
+	if (value != NULL) {
+		for (guint i = 0; value[i] != NULL; ++i) {
+			if (g_strcmp0 (value[i], "") != 0)
+				g_ptr_array_add (keywords, g_strdup (value[i]));
+		}
+	}
+	g_ptr_array_add (keywords, NULL);
+
 	g_hash_table_insert (priv->keywords,
 				g_ref_string_new_intern (locale),
-				g_strdupv (value));
+				(gchar **) (g_ptr_array_steal (keywords, NULL)));
 
 	g_object_notify ((GObject *) cpt, "keywords");
 }

--- a/src/as-desktop-entry.c
+++ b/src/as-desktop-entry.c
@@ -468,10 +468,6 @@ as_desktop_entry_parse_data (AsComponent *cpt,
 			g_auto(GStrv) kws = NULL;
 			g_autoptr(GPtrArray) l10n_data = NULL;
 
-			/* drop last ";" to not get an empty entry later */
-			if (g_str_has_suffix (val, ";"))
-				val[strlen (val) -1] = '\0';
-
 			kws = g_strsplit (val, ";", -1);
 			as_component_set_keywords (cpt, kws, locale);
 
@@ -482,10 +478,6 @@ as_desktop_entry_parse_data (AsComponent *cpt,
 					g_auto(GStrv) e_kws = NULL;
 					const gchar *e_locale = g_ptr_array_index (l10n_data, j);
 					gchar *e_value = g_ptr_array_index (l10n_data, j + 1);
-
-					/* drop last ";" to not get an empty entry later */
-					if (g_str_has_suffix (e_value, ";"))
-						e_value[strlen (e_value) -1] = '\0';
 
 					e_kws = g_strsplit (e_value, ";", -1);
 					as_component_set_keywords (cpt, e_kws, e_locale);


### PR DESCRIPTION
We're failing to translate strings now, when the keywords ends with a
";" as they almost always do, e.g.:

  Keywords=Drivers;Repositories;Repository;PPA;

because we strip the trailing semicolon off before translating, in order
to avoid having empty elements in the output.

Instead what we can do is process the list passed to
`as_component_set_keywords` and remove empties at that point. This
allows us to not modify the string retrieved from the desktop file, and
fixes finding translations.