### PR TITLE
compose: Check optipng is there before we use it

### DIFF
--- a/compose/asc-globals.c
+++ b/compose/asc-globals.c
@@ -190,6 +190,11 @@ void
 asc_globals_set_use_optipng (gboolean enabled)
 {
 	AscGlobalsPrivate *priv = asc_globals_get_priv ();
+	if (enabled && priv->optipng_bin == NULL) {
+		g_critical ("Refusing to enable optipng: not found in $PATH");
+		priv->use_optipng = FALSE;
+		return;
+	}
 	priv->use_optipng = enabled;
 }
 
@@ -216,6 +221,8 @@ asc_globals_set_optipng_binary (const gchar *path)
 	AscGlobalsPrivate *priv = asc_globals_get_priv ();
 	g_free (priv->optipng_bin);
 	priv->optipng_bin = g_strdup (path);
+	if (priv->optipng_bin == NULL)
+		priv->use_optipng = FALSE;
 }
 
 /**

--- a/compose/asc-image.c
+++ b/compose/asc-image.c
@@ -204,6 +204,7 @@ asc_optimize_png (const gchar *fname, GError **error)
 {
 	gint exit_status;
 	gboolean r;
+	const gchar *optipng_path;
 	g_autofree gchar *opng_stdout = NULL;
 	g_autofree gchar *opng_stderr = NULL;
 	g_autofree const gchar **argv = NULL;
@@ -212,8 +213,17 @@ asc_optimize_png (const gchar *fname, GError **error)
 	if (!asc_globals_get_use_optipng ())
 		return TRUE;
 
+	optipng_path = asc_globals_get_optipng_binary ();
+	if (optipng_path == NULL) {
+		g_set_error (error,
+			     ASC_IMAGE_ERROR,
+			     ASC_IMAGE_ERROR_FAILED,
+			     "optipng not found in $PATH");
+		return FALSE;
+	}
+
 	argv = g_new0 (const gchar*, 2 + 1);
-	argv[0] = asc_globals_get_optipng_binary ();
+	argv[0] = optipng_path;
 	argv[1] = fname;
 
 	/* NOTE: Maybe add an option to run optipng with stronger optimization? (>= -o4) */


### PR DESCRIPTION
There are two places we can beef up the checks for optipng

  - When enabling its usage, make sure we found it first, and refuse to
    enable if we didn't.
  - In case `asc_compose_set_optipng_binary (NULL)` was called, check
    before spawning that we have *a* path. It's a programmer error to
    call `g_spawn_sync ()` with `NULL` in `argv[0]`, and the program
    will crash in that case. Also treat `NULL` as disabling optipng when
    passed to `asc_compose_set_optipng_binary`.

In case the binary is removed mid-run or an invalid binary is passed to
`asc_compose_set_optipng_binary`, the `g_spawn_sync` call itself will
fail and we'll report a proper GError. This is the best way to handle
it, as we avoid TOCTTOU races that way.