### PR TITLE
qt: Make Pool's parent class public

### DIFF
--- a/qt/pool.h
+++ b/qt/pool.h
@@ -35,7 +35,7 @@ namespace AppStream {
  * See http://www.freedesktop.org/wiki/Distributions/AppStream/ for details
  */
 class PoolPrivate;
-class APPSTREAMQT_EXPORT Pool : QObject{
+class APPSTREAMQT_EXPORT Pool : public QObject {
 Q_OBJECT
     public:
         Pool(QObject *parent = nullptr);


### PR DESCRIPTION
It's not the default but what we generally do. It allows us to call
parent class methods normally.