### PR TITLE
ci: Add Fedora to the CI environment

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -3,6 +3,42 @@ name: Build Test
 on: [push, pull_request]
 
 jobs:
+  build-fedora-latest:
+    name: Fedora Latest Stable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: cd tests/ci/ && podman build -t appstream -f ./Dockerfile-fedora-latest .
+
+    - name: Build
+      run: podman run -a stdout -a stderr -e COMPILER_VENDOR=$CVENDOR -e CC=gcc -e CXX=g++ -v `pwd`:/build appstream
+           ./tests/ci/run-build.sh
+
+    - name: Test
+      run: podman run -a stdout -a stderr -e COMPILER_VENDOR=$CVENDOR -e CC=gcc -e CXX=g++ -v `pwd`:/build appstream
+           ./tests/ci/run-tests.sh
+
+
+  build-fedora-rawhide:
+    name: Fedora Rawhide
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: cd tests/ci/ && podman build -t appstream -f ./Dockerfile-fedora-rawhide .
+
+    - name: Build
+      run: podman run -a stdout -a stderr -e COMPILER_VENDOR=$CVENDOR -e CC=gcc -e CXX=g++ -v `pwd`:/build appstream
+           ./tests/ci/run-build.sh
+
+    - name: Test
+      run: podman run -a stdout -a stderr -e COMPILER_VENDOR=$CVENDOR -e CC=gcc -e CXX=g++ -v `pwd`:/build appstream
+           ./tests/ci/run-tests.sh
+
+
   build-debian-stable:
     name: Debian Stable
     runs-on: ubuntu-latest
@@ -55,8 +91,26 @@ jobs:
       run: CC=gcc CXX=g++ ./tests/ci/run-tests.sh
 
 
-  build-sanitized:
-    name: Sanitizers
+  build-sanitized-fedora:
+    name: Sanitizers on Fedora
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: cd tests/ci/ && podman build -t appstream -f ./Dockerfile-fedora-rawhide .
+
+    - name: Build with asan, ubsan
+      run: podman run -a stdout -a stderr --privileged -e COMPILER_VENDOR=$CVENDOR -e CC=gcc -e CXX=g++ -v `pwd`:/build appstream
+           ./tests/ci/run-build.sh sanitize
+
+    - name: Test with asan, ubsan
+      run: podman run -a stdout -a stderr --privileged -e COMPILER_VENDOR=$CVENDOR -e CC=gcc -e CXX=g++ -v `pwd`:/build appstream
+           ./tests/ci/run-tests.sh sanitize
+
+
+  build-sanitized-debian:
+    name: Sanitizers on Debian
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/tests/ci/Dockerfile-fedora-latest
+++ b/tests/ci/Dockerfile-fedora-latest
@@ -1,0 +1,14 @@
+#
+# Docker file for AppStream CI tests on Fedora targeting latest stable
+#
+FROM registry.fedoraproject.org/fedora:latest
+
+# prepare
+RUN mkdir -p /build/ci/
+
+# install build dependencies
+COPY install-deps-rpm.sh /build/ci/
+RUN chmod +x /build/ci/install-deps-rpm.sh && /build/ci/install-deps-rpm.sh
+
+# finish
+WORKDIR /build

--- a/tests/ci/Dockerfile-fedora-rawhide
+++ b/tests/ci/Dockerfile-fedora-rawhide
@@ -1,0 +1,14 @@
+#
+# Docker file for AppStream CI tests on Fedora Rawhide
+#
+FROM registry.fedoraproject.org/fedora:rawhide
+
+# prepare
+RUN mkdir -p /build/ci/
+
+# install build dependencies
+COPY install-deps-rpm.sh /build/ci/
+RUN chmod +x /build/ci/install-deps-rpm.sh && /build/ci/install-deps-rpm.sh
+
+# finish
+WORKDIR /build

--- a/tests/ci/install-deps-rpm.sh
+++ b/tests/ci/install-deps-rpm.sh
@@ -10,7 +10,6 @@ dnf makecache
 
 # install build dependencies
 dnf --assumeyes --quiet --setopt=install_weak_deps=False install \
-    daps \
     gcc \
     gcc-c++ \
     gdb \

--- a/tests/ci/install-deps-rpm.sh
+++ b/tests/ci/install-deps-rpm.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Install AppStream build dependencies
+#
+set -e
+set -x
+
+# update caches
+dnf makecache
+
+# install build dependencies
+dnf --assumeyes --quiet --setopt=install_weak_deps=False install \
+    daps \
+    gcc \
+    gcc-c++ \
+    gdb \
+    meson \
+    gettext \
+    gperf \
+    gtk-doc \
+    intltool \
+    itstool \
+    libasan \
+    libstemmer-devel \
+    libubsan \
+    'pkgconfig(cairo)' \
+    'pkgconfig(freetype2)' \
+    'pkgconfig(fontconfig)' \
+    'pkgconfig(gdk-pixbuf-2.0)' \
+    'pkgconfig(gio-2.0)' \
+    'pkgconfig(gobject-introspection-1.0)' \
+    'pkgconfig(libcurl)' \
+    'pkgconfig(libsoup-2.4)' \
+    'pkgconfig(librsvg-2.0)' \
+    'pkgconfig(libxml-2.0)' \
+    'pkgconfig(lmdb)' \
+    'pkgconfig(packagekit-glib2)' \
+    'pkgconfig(pango)' \
+    'pkgconfig(protobuf-lite)' \
+    'pkgconfig(Qt5Core)' \
+    qt5-linguist \
+    'pkgconfig(yaml-0.1)' \
+    sed \
+    vala \
+    xmlto

--- a/tests/ci/run-build.sh
+++ b/tests/ci/run-build.sh
@@ -9,11 +9,16 @@ set -e
 #
 
 . /etc/os-release
+apt_support=false
 build_compose=true
 maintainer_mode=true
 if [ "$ID" = "ubuntu" ] && [ "$VERSION_CODENAME" = "focal" ]; then
     # we don't make warnings fatal on Ubuntu 20.04
     maintainer_mode=false
+fi;
+if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
+    # apt support is required for debian(-ish) systems
+    apt_support=true
 fi;
 
 build_type=debugoptimized
@@ -48,7 +53,7 @@ meson --buildtype=$build_type \
       -Ddocs=true \
       -Dqt=true \
       -Dcompose=$build_compose \
-      -Dapt-support=true \
+      -Dapt-support=$apt_support \
       -Dvapi=true \
       ..
 

--- a/tests/ci/run-build.sh
+++ b/tests/ci/run-build.sh
@@ -11,6 +11,7 @@ set -e
 . /etc/os-release
 apt_support=false
 build_compose=true
+build_docs=false
 maintainer_mode=true
 if [ "$ID" = "ubuntu" ] && [ "$VERSION_CODENAME" = "focal" ]; then
     # we don't make warnings fatal on Ubuntu 20.04
@@ -19,6 +20,8 @@ fi;
 if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
     # apt support is required for debian(-ish) systems
     apt_support=true
+    # daps is available to build docs
+    build_docs=true
 fi;
 
 build_type=debugoptimized
@@ -50,7 +53,7 @@ mkdir $build_dir && cd $build_dir
 meson --buildtype=$build_type \
       $sanitize_flags \
       -Dmaintainer=$maintainer_mode \
-      -Ddocs=true \
+      -Ddocs=$build_docs \
       -Dqt=true \
       -Dcompose=$build_compose \
       -Dapt-support=$apt_support \
@@ -62,6 +65,8 @@ meson --buildtype=$build_type \
 #
 
 ninja
-ninja documentation
+if [ "$build_docs" = "true" ]; then
+    ninja documentation
+fi
 DESTDIR=/tmp/install_root/ ninja install
 rm -r /tmp/install_root/


### PR DESCRIPTION
As Fedora ships updated GNOME components often earlier than anyone else,
it makes sense to test this to ensure that this continues to work.