### PR TITLE
spec: Add support for source locales

### DIFF
--- a/compose/asc-utils-l10n.c
+++ b/compose/asc-utils-l10n.c
@@ -488,6 +488,19 @@ asc_read_translation_status (AscResult *cres,
 		if (!have_results)
 			asc_result_add_hint_simple (cres, cpt, "translations-not-found");
 
+		/* Add a fake entry for the source locale. Do so after checking
+		 * !have_results since the source locale is always guaranteed
+		 * to exist, so would break that check.
+		 * as_component_add_language() will deduplicate in case that’s
+		 * needed. */
+		for (guint i = 0; i < ctx->translations->len; i++) {
+			AsTranslation *t = g_ptr_array_index (ctx->translations, i);
+
+			as_component_add_language (cpt,
+						   as_translation_get_source_locale (t),
+						   100);
+		}
+
 		/* remove translation elements, they should no longer be in the resulting component */
 		g_ptr_array_set_size (ctx->translations, 0);
 	}

--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -1260,6 +1260,11 @@
 			than once.
 		</para>
 		<para>
+			The source strings in the component are assumed to be in the <code>en_US</code> locale. If that is not the case, specify the source locale using
+			the <code>source_locale</code> attribute on the <code>&lt;translation/&gt;</code> tag. The metadata generator will use the source locale
+			to synthesize a <code>&lt;lang/&gt;</code> tag for the source locale, with 100% translation.
+		</para>
+		<para>
 			For Gettext translations, localization data will be looked for in <filename>${prefix}/share/locale/${locale}/LC_MESSAGES/${id}.mo</filename>, where
 			<code>${id}</code> is replaced with the translation domain specified in the <code>&lt;translation/&gt;</code> tag.
 			For Qt translations, if the ID string contains slashes, we will look for translations following either the <filename>${prefix}/share/${id}_${locale}.qm</filename>
@@ -1270,6 +1275,7 @@
 			Example:
 		</para>
 		<programlisting language="XML"><![CDATA[<translation type="gettext">foobar</translation>
+<translation type="gettext" source_locale="de_DE">foobar</translation>
 <translation type="qt">FooBar/translations/foobar</translation>]]></programlisting>
 		</listitem>
 		</varlistentry>

--- a/src/as-translation.h
+++ b/src/as-translation.h
@@ -73,6 +73,10 @@ const gchar		*as_translation_get_id (AsTranslation *tr);
 void			as_translation_set_id (AsTranslation *tr,
 					       const gchar *id);
 
+const gchar		*as_translation_get_source_locale (AsTranslation *tr);
+void			as_translation_set_source_locale (AsTranslation *tr,
+							  const gchar   *locale);
+
 G_END_DECLS
 
 #endif /* __AS_TRANSLATION_H */

--- a/tests/samples/appdata.xml
+++ b/tests/samples/appdata.xml
@@ -30,5 +30,5 @@
     <category>web</category>
   </categories>
   <url type="homepage">http://www.mozilla.com</url>
-  <translation type="gettext">firefox</translation>
+  <translation type="gettext" source_locale="de">firefox</translation>
 </component>

--- a/tests/test-xmldata.c
+++ b/tests/test-xmldata.c
@@ -192,6 +192,7 @@ test_appstream_parser_locale ()
 	g_assert_cmpint (trs->len, ==, 1);
 	tr = AS_TRANSLATION (g_ptr_array_index (trs, 0));
 	g_assert_cmpstr (as_translation_get_id (tr), ==, "firefox");
+	g_assert_cmpstr (as_translation_get_source_locale (tr), ==, "de");
 
 	/* check if we loaded the right amount of icons */
 	g_assert_cmpint (as_component_get_icons (cpt)->len, ==, 2);
@@ -236,7 +237,7 @@ test_appstream_write_locale ()
 				    "    <mediatype>x-scheme-handler/http</mediatype>\n"
 				    "    <mediatype>x-scheme-handler/https</mediatype>\n"
 				    "  </provides>\n"
-				    "  <translation type=\"gettext\">firefox</translation>\n"
+				    "  <translation type=\"gettext\" source_locale=\"de\">firefox</translation>\n"
 				    "  <keywords>\n"
 				    "    <keyword>internet</keyword>\n"
 				    "    <keyword>web</keyword>\n"


### PR DESCRIPTION
This allows specifying the locale of the source translatable strings
in a component. The vast majority of the time, this is `en_US`, but
that’s not guaranteed. Add a `source-locale` attribute to allow changing
this default.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Helps: #345