### PR TITLE
spdx: Make CC-BY-3.0 and CC-BY-SA-3.0 free

### DIFF
--- a/data/spdx-free-license-ids.txt
+++ b/data/spdx-free-license-ids.txt
@@ -35,7 +35,11 @@ BitTorrent-1.1
 CAL-1.0
 CAL-1.0-Combined-Work-Exception
 CATOSL-1.1
+CC-BY-2.5
+CC-BY-3.0
 CC-BY-4.0
+CC-BY-SA-1.0
+CC-BY-SA-3.0
 CC-BY-SA-4.0
 CC0-1.0
 CDDL-1.0

--- a/tests/test-basics.c
+++ b/tests/test-basics.c
@@ -448,6 +448,9 @@ test_spdx (void)
 	g_free (tmp);
 
 	/* licenses are free-as-in-freedom */
+	g_assert_true (as_license_is_free_license ("GPL-3.0+ and GPL-2.0+ and LGPL-2.0+ and BSD-3-Clause and MIT and CC-BY-SA-1.0 and CC-BY-2.5"));
+	g_assert_true (as_license_is_free_license ("GPL-2.0+ and CC-BY-3.0 and CC-BY-SA-3.0"));
+	g_assert_true (as_license_is_free_license ("GPL-3.0+ and CC-BY-SA-3.0"));
 	g_assert_true (as_license_is_free_license ("CC0"));
 	g_assert_true (as_license_is_free_license ("GPL-2.0 AND FSFAP"));
 	g_assert_true (as_license_is_free_license ("OFL-1.1 OR (GPL-3.0-or-later WITH Font-exception-2.0)"));


### PR DESCRIPTION
Without this, GNOME Weather is considered to be proprietary by GNOME
Software.