### PR TITLE
metadata: Document file not found error code

### DIFF
--- a/src/as-metadata.c
+++ b/src/as-metadata.c
@@ -639,6 +639,9 @@ as_metadata_parse_desktop_data (AsMetadata *metad, const gchar *data, const gcha
  *
  * Parses an AppStream upstream metadata file.
  *
+ * If @file does not exist, %G_IO_ERROR_NOT_FOUND will be returned. Other
+ * #GIOErrors and #AsMetadataErrors may be returned as appropriate.
+ *
  * Returns: %TRUE if the file was parsed without error.
  **/
 gboolean


### PR DESCRIPTION
While working on the port of Flatpak to libappstream[1] I noticed that
we currently don't have proper error checking when loading an appstream
file with appstream-glib that turns out not to exist.[2] appstream-glib
was patched to return G_IO_ERROR_NOT_FOUND in that case[3] and
libappstream already does so in its corresponding API, but this patch
documents that so that if the implementation here is changed it will
hopefully still meet this requirement.

[1] https://github.com/flatpak/flatpak/pull/4426
[2] https://github.com/flatpak/flatpak/blob/284edffe89ecb78a19d01da065030d9f3bf31c76/app/flatpak-builtins-utils.c#L1169
[3] https://github.com/hughsie/appstream-glib/pull/268