### PR TITLE
docs: document media_baseurl property of components

### DIFF
--- a/docs/xml/collection-xmldata.xml
+++ b/docs/xml/collection-xmldata.xml
@@ -74,6 +74,16 @@
 			</varlistentry>
 
 			<varlistentry>
+			<term>media_baseurl</term>
+			<listitem>
+				<para>
+					The base URL for media (screenshots, icons, ...) referenced in the metadata file.
+					If this is set, all urls in the document referencing media will be treated relative to the base url.
+				</para>
+			</listitem>
+			</varlistentry>
+
+			<varlistentry>
 			<term>architecture</term>
 			<listitem>
 				<para>


### PR DESCRIPTION
This property is inserted[1] into XML collection metadata by
appstream-generator, but is undocumented.

[1]https://github.com/ximion/appstream-generator/blob/master/src/asgen/engine.d#L318