### PR TITLE
Check missing release props

### DIFF
--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -691,6 +691,11 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	  N_("The release is missing the `version` property."),
 	},
 
+	{ "release-time-missing",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */
+	  N_("The release is missing either the `date` (preferred) or the `timestamp` property."),
+	},
 	{ "artifact-type-invalid",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */

--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -685,6 +685,12 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	  N_("The value set as release type is invalid."),
 	},
 
+	{ "release-version-missing",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */
+	  N_("The release is missing the `version` property."),
+	},
+
 	{ "artifact-type-invalid",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */

--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -1530,6 +1530,11 @@ as_validator_check_release (AsValidator *validator, xmlNode *node, AsFormatStyle
 	if (prop != NULL) {
 		as_validator_validate_iso8601_complete_date (validator, node, prop);
 		g_free (prop);
+	} else {
+		g_autofree gchar *timestamp = as_xml_get_prop_value (node, "timestamp");
+		/* Neither timestamp, nor date property exists */
+		if (timestamp == NULL)
+			as_validator_add_issue (validator, node, "release-time-missing", "date");
 	}
 	prop = as_xml_get_prop_value (node, "date_eol");
 	if (prop != NULL) {

--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -1519,6 +1519,12 @@ as_validator_check_release (AsValidator *validator, xmlNode *node, AsFormatStyle
 {
 	gchar *prop;
 
+	/* validate presence of version property */
+	prop = as_xml_get_prop_value (node, "version");
+	if (prop == NULL)
+		as_validator_add_issue (validator, node, "release-version-missing", "version");
+	g_free (prop);
+
 	/* validate date strings */
 	prop = as_xml_get_prop_value (node, "date");
 	if (prop != NULL) {


### PR DESCRIPTION
`appstream-util` checks for missing timestamp property, so we can do the same.

What prompted me to check this, was having had a typo `data=...` instead of `date=...` which was caught by `appstream-util`, but not by `appstreamcli`.

An alternative solution could iterate the properties of the release tag and check for unknowns (if that is preferred).

I'm also not sure if the info severity is a good choice or if it should be bumped to warning