### PR TITLE
Add a source URL type

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -362,6 +362,15 @@
 
 				</listitem>
 			</varlistentry>
+
+			<varlistentry>
+				<term>source</term>
+				<listitem>
+				<para>
+					Should provide a web link to the source code.
+				</para>
+				</listitem>
+			</varlistentry>
 			</variablelist>
 		</listitem>
 		</varlistentry>

--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -139,6 +139,9 @@ Component::UrlKind Component::stringToUrlKind(const QString& urlKindString) {
     if (urlKindString == QLatin1String("contact")) {
         return UrlKindContact;
     }
+    if (urlKindString == QLatin1String("source")) {
+        return UrlKindSource;
+    }
     return UrlKindUnknown;
 }
 
@@ -150,6 +153,7 @@ Q_GLOBAL_STATIC_WITH_ARGS(UrlKindMap, urlKindMap, ({
         { Component::UrlKindFaq, QLatin1String("faq") },
         { Component::UrlKindHelp, QLatin1String("help") },
         { Component::UrlKindHomepage, QLatin1String("homepage") },
+        { Component::UrlKindSource, QLatin1String("source") },
         { Component::UrlKindUnknown, QLatin1String("unknown") },
     }));
 

--- a/qt/component.h
+++ b/qt/component.h
@@ -88,6 +88,7 @@ class APPSTREAMQT_EXPORT Component {
             UrlKindDonation,
             UrlTranslate,
             UrlKindContact
+            UrlKindSource
         };
         Q_ENUM(UrlKind)
 

--- a/src/as-enums.c
+++ b/src/as-enums.c
@@ -91,6 +91,8 @@ as_url_kind_to_string (AsUrlKind url_kind)
 		return "translate";
 	if (url_kind == AS_URL_KIND_CONTACT)
 		return "contact";
+	if (url_kind == AS_URL_KIND_SOURCE)
+		return "source";
 	return "unknown";
 }
 
@@ -119,6 +121,8 @@ as_url_kind_from_string (const gchar *url_kind)
 		return AS_URL_KIND_TRANSLATE;
 	if (g_strcmp0 (url_kind, "contact") == 0)
 		return AS_URL_KIND_CONTACT;
+	if (g_strcmp0 (url_kind, "source") == 0)
+		return AS_URL_KIND_SOURCE;
 	return AS_URL_KIND_UNKNOWN;
 }
 

--- a/src/as-enums.h
+++ b/src/as-enums.h
@@ -93,6 +93,7 @@ typedef enum {
 	AS_URL_KIND_DONATION,
 	AS_URL_KIND_TRANSLATE,
 	AS_URL_KIND_CONTACT,
+	AS_URL_KIND_SOURCE,
 	/*< private >*/
 	AS_URL_KIND_LAST
 } AsUrlKind;

--- a/tests/test-xmldata.c
+++ b/tests/test-xmldata.c
@@ -660,6 +660,7 @@ test_xml_read_url (void)
 					 "  <url type=\"faq\">https://example.org/faq</url>\n"
 					 "  <url type=\"donation\">https://example.org/donate</url>\n"
 					 "  <url type=\"contact\">https://example.org/contact</url>\n"
+					 "  <url type=\"source\">https://example.org/source</url>\n"
 					 "</component>\n";
 
 	cpt = as_xml_test_read_data (xmldata_languages, AS_FORMAT_STYLE_METAINFO);
@@ -669,6 +670,7 @@ test_xml_read_url (void)
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_FAQ), ==, "https://example.org/faq");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_DONATION), ==, "https://example.org/donate");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTACT), ==, "https://example.org/contact");
+	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_SOURCE), ==, "https://example.org/source");
 }
 
 /**

--- a/tests/test-yamldata.c
+++ b/tests/test-yamldata.c
@@ -526,7 +526,8 @@ test_yaml_read_url (void)
 				"  homepage: https://example.org\n"
 				"  faq: https://example.org/faq\n"
 				"  donation: https://example.org/donate\n"
-				"  contact: https://example.org/contact\n";
+				"  contact: https://example.org/contact\n"
+				"  source:  https://example.org/source\n";
 
 	cpt = as_yaml_test_read_data (yamldata_urls, NULL);
 	g_assert_cmpstr (as_component_get_id (cpt), ==, "org.example.Test");
@@ -535,6 +536,7 @@ test_yaml_read_url (void)
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_FAQ), ==, "https://example.org/faq");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_DONATION), ==, "https://example.org/donate");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTACT), ==, "https://example.org/contact");
+	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_SOURCE), ==, "https://example.org/source");
 }
 
 /**


### PR DESCRIPTION
Most Linux Programs are OpenSource. While smaller Programs use their Repo as Homepage or Link their GitHub issue tracker as Bugtracker, bigger programs does that not. And the Link to the source code is not always prominent on the Homepage, because some Homepages are made for non-programmers. This PR solves this problem. A Link to the source code can be added so users can get there with just one click. 