### PR TITLE
qt: Fix crash when moving a Component

### DIFF
--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -201,6 +201,7 @@ Component& Component::operator=(const Component& other)
 Component::Component(Component&& other)
     : m_cpt(other.m_cpt)
 {
+    other.m_cpt = nullptr;
 }
 
 _AsComponent * AppStream::Component::asComponent() const


### PR DESCRIPTION
We need to invalidate the one we are moving, otherwise we get a 2x
unref.