### PR TITLE
Fix translate URL

### DIFF
--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -139,6 +139,9 @@ Component::UrlKind Component::stringToUrlKind(const QString& urlKindString) {
     if (urlKindString == QLatin1String("contact")) {
         return UrlKindContact;
     }
+    if (urlKindString == QLatin1String("translate")) {
+        return UrlTranslate;
+    }
     return UrlKindUnknown;
 }
 
@@ -150,6 +153,7 @@ Q_GLOBAL_STATIC_WITH_ARGS(UrlKindMap, urlKindMap, ({
         { Component::UrlKindFaq, QLatin1String("faq") },
         { Component::UrlKindHelp, QLatin1String("help") },
         { Component::UrlKindHomepage, QLatin1String("homepage") },
+        { Component::UrlTranslate, QLatin1String("translate") },
         { Component::UrlKindUnknown, QLatin1String("unknown") },
     }));
 


### PR DESCRIPTION
While looking at the source, I saw that UrlTranslate is defined in Header as part of UrlKind but not set.

btw:
Is there any reason why it is named UrlTranslate and not UrlKindTranslate like the other?