### PR TITLE
AsComponent: Centralize GOnce guard to fix an assertion failure

### DIFF
--- a/src/as-component-private.h
+++ b/src/as-component-private.h
@@ -67,7 +67,6 @@ const gchar		*as_component_get_architecture (AsComponent *cpt);
 void			 as_component_set_architecture (AsComponent *cpt,
 							const gchar *arch);
 
-void			as_component_create_token_cache (AsComponent *cpt);
 GPtrArray		*as_component_generate_tokens_for (AsComponent *cpt,
 							   AsSearchTokenMatch token_kind);
 

--- a/src/as-component.c
+++ b/src/as-component.c
@@ -2867,7 +2867,7 @@ as_component_create_token_cache (AsComponent *cpt)
 	AsComponentPrivate *priv = GET_PRIVATE (cpt);
 	guint flags;
 
-	if (priv->token_cache_valid)
+	if (!g_once_init_enter (&priv->token_cache_valid))
 		return;
 
 	flags = AS_SEARCH_TOKEN_MATCH_MEDIATYPE |
@@ -2886,7 +2886,7 @@ as_component_create_token_cache (AsComponent *cpt)
 		as_component_create_token_cache_target (cpt, donor, flags, NULL);
 	}
 
-	priv->token_cache_valid = TRUE;
+	g_once_init_leave (&priv->token_cache_valid, TRUE);
 }
 
 /**
@@ -2937,10 +2937,7 @@ as_component_search_matches (AsComponent *cpt, const gchar *term)
 		return 0;
 
 	/* ensure the token cache is created */
-	if (g_once_init_enter (&priv->token_cache_valid)) {
-		as_component_create_token_cache (cpt);
-		g_once_init_leave (&priv->token_cache_valid, TRUE);
-	}
+	as_component_create_token_cache (cpt);
 
 	/* find the exact match (which is more awesome than a partial match) */
 	match_pval = g_hash_table_lookup (priv->token_cache, term);
@@ -3022,10 +3019,7 @@ as_component_get_search_tokens (AsComponent *cpt)
 	g_autoptr(GList) keys = NULL;
 
 	/* ensure the token cache is created */
-	if (g_once_init_enter (&priv->token_cache_valid)) {
-		as_component_create_token_cache (cpt);
-		g_once_init_leave (&priv->token_cache_valid, TRUE);
-	}
+	as_component_create_token_cache (cpt);
 
 	/* return all the token cache */
 	keys = g_hash_table_get_keys (priv->token_cache);

--- a/src/as-component.c
+++ b/src/as-component.c
@@ -2861,7 +2861,7 @@ as_component_create_token_cache_target (AsComponent *cpt, AsComponent *donor, gu
  *
  * Internal API.
  */
-void
+static void
 as_component_create_token_cache (AsComponent *cpt)
 {
 	AsComponentPrivate *priv = GET_PRIVATE (cpt);


### PR DESCRIPTION
* trivial: Make as_component_create_token_cache static
    
    It's no longer called from outside AsComponent, so it doesn't need to be
    extern any more.

* AsComponent: Centralize GOnce guard to fix an assertion failure
    
    The token cache only needs to be created once per AsComponent.
    Previously, each of the two callers of as_component_create_token_cache()
    guarded it with an atomic (GOnce) access to priv->token_cache_valid,
    but the implementation had a redundant non-atomic guard. This resulted
    in a GLib assertion failure on leaving the function, because the atomic
    boolean flag indicating whether initialization has completed is not
    meant to be set non-null until g_once_init_leave().
    
    In particular, this resolves test failures in Flatpak 1.13.x
    (which has been ported from libappstream-glib to libappstream) when it
    runs `flatpak search` from its test suite.
    
    Resolves: https://github.com/ximion/appstream/issues/384