### PR TITLE
qt: If the timestamp is 0, return a default QDateTime()

### DIFF
--- a/qt/release.cpp
+++ b/qt/release.cpp
@@ -91,12 +91,14 @@ QString Release::version() const
 
 QDateTime Release::timestamp() const
 {
-    return QDateTime::fromTime_t(as_release_get_timestamp(d->m_release));
+    const guint64 timestamp = as_release_get_timestamp(d->m_release);
+    return timestamp > 0 ? QDateTime::fromTime_t(timestamp) : QDateTime();
 }
 
 QDateTime Release::timestampEol() const
 {
-    return QDateTime::fromTime_t(as_release_get_timestamp_eol(d->m_release));
+    const guint64 timestamp = as_release_get_timestamp_eol(d->m_release);
+    return timestamp > 0 ? QDateTime::fromTime_t(timestamp) : QDateTime();
 }
 
 QString Release::description() const


### PR DESCRIPTION
Otherwise we are creating a date in the seventies that is believed to be
true.

Addresses the discussion here:
https://invent.kde.org/plasma/discover/-/merge_requests/266#note_411067