### PR TITLE
Add vcs-browser and contribute URL type

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -392,6 +392,25 @@
 
 				</listitem>
 			</varlistentry>
+
+			<varlistentry>
+				<term>vcs-browser</term>
+				<listitem>
+				<para>
+					URLs of this type should point to a webpage on which the user can browse the sourcecode.
+				</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term>contribute</term>
+				<listitem>
+				<para>
+					URLs of this type should point to a webpage showing information on how to contribute to
+					the described software project.
+				</para>
+				</listitem>
+			</varlistentry>
 			</variablelist>
 		</listitem>
 		</varlistentry>

--- a/src/as-enums.c
+++ b/src/as-enums.c
@@ -91,6 +91,10 @@ as_url_kind_to_string (AsUrlKind url_kind)
 		return "translate";
 	if (url_kind == AS_URL_KIND_CONTACT)
 		return "contact";
+	if (url_kind == AS_URL_KIND_VCS)
+		return "vcs-browser";
+	if (url_kind == AS_URL_KIND_CONTRIBUTE)
+		return "contribute";
 	return "unknown";
 }
 
@@ -119,6 +123,10 @@ as_url_kind_from_string (const gchar *url_kind)
 		return AS_URL_KIND_TRANSLATE;
 	if (g_strcmp0 (url_kind, "contact") == 0)
 		return AS_URL_KIND_CONTACT;
+	if (g_strcmp0 (url_kind, "vcs-browser") == 0)
+		return AS_URL_KIND_VCS;
+	if (g_strcmp0 (url_kind, "contribute") == 0)
+		return AS_URL_KIND_CONTRIBUTE;
 	return AS_URL_KIND_UNKNOWN;
 }
 

--- a/src/as-enums.c
+++ b/src/as-enums.c
@@ -91,7 +91,7 @@ as_url_kind_to_string (AsUrlKind url_kind)
 		return "translate";
 	if (url_kind == AS_URL_KIND_CONTACT)
 		return "contact";
-	if (url_kind == AS_URL_KIND_VCS)
+	if (url_kind == AS_URL_KIND_VCS_BROWSER)
 		return "vcs-browser";
 	if (url_kind == AS_URL_KIND_CONTRIBUTE)
 		return "contribute";
@@ -124,7 +124,7 @@ as_url_kind_from_string (const gchar *url_kind)
 	if (g_strcmp0 (url_kind, "contact") == 0)
 		return AS_URL_KIND_CONTACT;
 	if (g_strcmp0 (url_kind, "vcs-browser") == 0)
-		return AS_URL_KIND_VCS;
+		return AS_URL_KIND_VCS_BROWSER;
 	if (g_strcmp0 (url_kind, "contribute") == 0)
 		return AS_URL_KIND_CONTRIBUTE;
 	return AS_URL_KIND_UNKNOWN;

--- a/src/as-enums.h
+++ b/src/as-enums.h
@@ -81,6 +81,8 @@ typedef enum {
  * @AS_URL_KIND_DONATION:	Page with information about how to donate to the project
  * @AS_URL_KIND_TRANSLATE:	Page with instructions on how to translate the project / submit translations.
  * @AS_URL_KIND_CONTACT:	Contact the developers
+ * @AS_URL_KIND_VCS:	Browse the source code
+ * @AS_URL_KIND_CONTRIBUTE:	Help developing
  *
  * The URL type.
  **/
@@ -93,6 +95,8 @@ typedef enum {
 	AS_URL_KIND_DONATION,
 	AS_URL_KIND_TRANSLATE,
 	AS_URL_KIND_CONTACT,
+	AS_URL_KIND_VCS,
+	AS_URL_KIND_CONTRIBUTE,
 	/*< private >*/
 	AS_URL_KIND_LAST
 } AsUrlKind;

--- a/src/as-enums.h
+++ b/src/as-enums.h
@@ -81,7 +81,7 @@ typedef enum {
  * @AS_URL_KIND_DONATION:	Page with information about how to donate to the project
  * @AS_URL_KIND_TRANSLATE:	Page with instructions on how to translate the project / submit translations.
  * @AS_URL_KIND_CONTACT:	Contact the developers
- * @AS_URL_KIND_VCS:	Browse the source code
+ * @AS_URL_KIND_VCS_BROWSER:	Browse the source code
  * @AS_URL_KIND_CONTRIBUTE:	Help developing
  *
  * The URL type.
@@ -95,7 +95,7 @@ typedef enum {
 	AS_URL_KIND_DONATION,
 	AS_URL_KIND_TRANSLATE,
 	AS_URL_KIND_CONTACT,
-	AS_URL_KIND_VCS,
+	AS_URL_KIND_VCS_BROWSER,
 	AS_URL_KIND_CONTRIBUTE,
 	/*< private >*/
 	AS_URL_KIND_LAST

--- a/tests/test-xmldata.c
+++ b/tests/test-xmldata.c
@@ -674,7 +674,7 @@ test_xml_read_url (void)
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_FAQ), ==, "https://example.org/faq");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_DONATION), ==, "https://example.org/donate");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTACT), ==, "https://example.org/contact");
-	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_VCS), ==, "https://example.org/source");
+	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_VCS_BROWSER), ==, "https://example.org/source");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTRIBUTE), ==, "https://example.org/contribute");
 }
 

--- a/tests/test-xmldata.c
+++ b/tests/test-xmldata.c
@@ -663,6 +663,8 @@ test_xml_read_url (void)
 					 "  <url type=\"faq\">https://example.org/faq</url>\n"
 					 "  <url type=\"donation\">https://example.org/donate</url>\n"
 					 "  <url type=\"contact\">https://example.org/contact</url>\n"
+					 "  <url type=\"vcs-browser\">https://example.org/source</url>\n"
+					 "  <url type=\"contribute\">https://example.org/contribute</url>\n"
 					 "</component>\n";
 
 	cpt = as_xml_test_read_data (xmldata_languages, AS_FORMAT_STYLE_METAINFO);
@@ -672,6 +674,8 @@ test_xml_read_url (void)
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_FAQ), ==, "https://example.org/faq");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_DONATION), ==, "https://example.org/donate");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTACT), ==, "https://example.org/contact");
+	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_VCS), ==, "https://example.org/source");
+	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTRIBUTE), ==, "https://example.org/contribute");
 }
 
 /**

--- a/tests/test-yamldata.c
+++ b/tests/test-yamldata.c
@@ -539,7 +539,7 @@ test_yaml_read_url (void)
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_FAQ), ==, "https://example.org/faq");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_DONATION), ==, "https://example.org/donate");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTACT), ==, "https://example.org/contact");
-	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_VCS), ==, "https://example.org/source");
+	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_VCS_BROWSER), ==, "https://example.org/source");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTRIBUTE), ==, "https://example.org/contribute");
 }
 

--- a/tests/test-yamldata.c
+++ b/tests/test-yamldata.c
@@ -528,8 +528,8 @@ test_yaml_read_url (void)
 				"  homepage: https://example.org\n"
 				"  faq: https://example.org/faq\n"
 				"  donation: https://example.org/donate\n"
-				"  contact: https://example.org/contact\n";
-				"  vcs-browser: https://example.org/source\n";
+				"  contact: https://example.org/contact\n"
+				"  vcs-browser: https://example.org/source\n"
 				"  contribute: https://example.org/contribute\n";
 
 	cpt = as_yaml_test_read_data (yamldata_urls, NULL);

--- a/tests/test-yamldata.c
+++ b/tests/test-yamldata.c
@@ -529,6 +529,8 @@ test_yaml_read_url (void)
 				"  faq: https://example.org/faq\n"
 				"  donation: https://example.org/donate\n"
 				"  contact: https://example.org/contact\n";
+				"  vcs-browser: https://example.org/source\n";
+				"  contribute: https://example.org/contribute\n";
 
 	cpt = as_yaml_test_read_data (yamldata_urls, NULL);
 	g_assert_cmpstr (as_component_get_id (cpt), ==, "org.example.Test");
@@ -537,6 +539,8 @@ test_yaml_read_url (void)
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_FAQ), ==, "https://example.org/faq");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_DONATION), ==, "https://example.org/donate");
 	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTACT), ==, "https://example.org/contact");
+	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_VCS), ==, "https://example.org/source");
+	g_assert_cmpstr (as_component_get_url (cpt, AS_URL_KIND_CONTRIBUTE), ==, "https://example.org/contribute");
 }
 
 /**


### PR DESCRIPTION
This PR adds vcs-browser and contribute as URL types as in #374. It was easier and cleaner to make a new PR than to update the old one.