### PR TITLE
Add vcs-browser URL to metainfo.xml

### DIFF
--- a/data/org.freedesktop.appstream.cli.metainfo.xml
+++ b/data/org.freedesktop.appstream.cli.metainfo.xml
@@ -26,6 +26,7 @@
   <url type="homepage">https://www.freedesktop.org/wiki/Distributions/AppStream/</url>
   <url type="help">https://www.freedesktop.org/software/appstream/docs/chap-AppStream-ManualPages.html</url>
   <url type="bugtracker">https://github.com/ximion/appstream/issues</url>
+  <url type="vcs-browser">https://github.com/ximion/appstream/</url>
 
   <project_group>Freedesktop</project_group>
 

--- a/data/org.freedesktop.appstream.compose.metainfo.xml
+++ b/data/org.freedesktop.appstream.compose.metainfo.xml
@@ -31,6 +31,7 @@
   <url type="homepage">https://www.freedesktop.org/wiki/Distributions/AppStream/</url>
   <url type="help">https://www.freedesktop.org/software/appstream/docs/chap-AppStream-ManualPages.html</url>
   <url type="bugtracker">https://github.com/ximion/appstream/issues</url>
+  <url type="vcs-browser">https://github.com/ximion/appstream/</url>
 
   <project_group>Freedesktop</project_group>
 


### PR DESCRIPTION
This PR adds the new vcs-browser URL type to own metainfo files of appstream.