### PR TITLE
Validate timestamp

### DIFF
--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -755,7 +755,6 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 
 	{ "release-timestamp-invalid",
 	  AS_ISSUE_SEVERITY_ERROR,
-	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */
 	  N_("The release timestamp is invalid."),
 	},
 

--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -753,6 +753,12 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	  N_("The release is missing either the `date` (preferred) or the `timestamp` property."),
 	},
 
+	{ "release-timestamp-invalid",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */
+	  N_("The release timestamp is invalid."),
+	},
+
 	{ "artifact-type-invalid",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */

--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -1689,6 +1689,11 @@ as_validator_check_release (AsValidator *validator, xmlNode *node, AsFormatStyle
 		/* Neither timestamp, nor date property exists */
 		if (timestamp == NULL)
 			as_validator_add_issue (validator, node, "release-time-missing", "date");
+		else {
+			if (atoi(timestamp) <= 3000) {
+				as_validator_add_issue (validator, node, "release-timestamp-invalid", "timestamp");
+			}
+		}
 	}
 	prop = as_xml_get_prop_value (node, "date_eol");
 	if (prop != NULL) {

--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -1690,9 +1690,9 @@ as_validator_check_release (AsValidator *validator, xmlNode *node, AsFormatStyle
 		if (timestamp == NULL)
 			as_validator_add_issue (validator, node, "release-time-missing", "date");
 		else {
-			/* check if the timestamp is both a number and higher than 3000. The 3000 is used to check, that it is not a year */
 			if (g_ascii_strtoll (timestamp, NULL, 10) < 3000) {
-				as_validator_add_issue (validator, node, "release-timestamp-invalid", "timestamp");
+				/* check if the timestamp is both a number and higher than 3000. The 3000 is used to check that it is not a year */
+				as_validator_add_issue (validator, node, "release-timestamp-invalid", timestamp);
 			}
 		}
 	}

--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -1690,7 +1690,8 @@ as_validator_check_release (AsValidator *validator, xmlNode *node, AsFormatStyle
 		if (timestamp == NULL)
 			as_validator_add_issue (validator, node, "release-time-missing", "date");
 		else {
-			if (atoi(timestamp) <= 3000) {
+			/* check if the timestamp is both a number and higher than 3000. The 3000 is used to check, that it is not a year */
+			if (g_ascii_strtoll (timestamp, NULL, 10) < 3000) {
 				as_validator_add_issue (validator, node, "release-timestamp-invalid", "timestamp");
 			}
 		}

--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -1686,8 +1686,8 @@ as_validator_check_release (AsValidator *validator, xmlNode *node, AsFormatStyle
 		g_free (prop);
 	} else {
 		g_autofree gchar *timestamp = as_xml_get_prop_value (node, "timestamp");
-		/* Neither timestamp, nor date property exists */
 		if (timestamp == NULL)
+			/* Neither timestamp, nor date property exists */
 			as_validator_add_issue (validator, node, "release-time-missing", "date");
 		else {
 			if (g_ascii_strtoll (timestamp, NULL, 10) < 3000) {


### PR DESCRIPTION
Fixes #402. This fix is a simple if, which doesn't needed much experience in C, so I decried to do the fix myself. I checked for a Timestamp smaller than 3000, if someone has the idea to use the Year as timestamp. I guess no one wants to use 1970/1/1 as release date in the Appstream, so it wouldn't break anything.