### PR TITLE
Fix as_display_length_kind_from_px()

### DIFF
--- a/src/as-relation.c
+++ b/src/as-relation.c
@@ -423,17 +423,16 @@ as_display_length_kind_to_px (AsDisplayLengthKind kind)
 AsDisplayLengthKind
 as_display_length_kind_from_px (gint px)
 {
-	if (px <= 360 )
-		return AS_DISPLAY_LENGTH_KIND_XSMALL;
-	if (px >= 360 )
-		return AS_DISPLAY_LENGTH_KIND_SMALL;
-	if (px >= 760 )
-		return AS_DISPLAY_LENGTH_KIND_MEDIUM;
-	if (px >= 900 )
-		return AS_DISPLAY_LENGTH_KIND_LARGE;
 	if (px >= 1200 )
 		return AS_DISPLAY_LENGTH_KIND_XLARGE;
-	return AS_DISPLAY_LENGTH_KIND_UNKNOWN;
+	if (px >= 900 )
+		return AS_DISPLAY_LENGTH_KIND_LARGE;
+	if (px >= 760 )
+		return AS_DISPLAY_LENGTH_KIND_MEDIUM;
+	if (px >= 360 )
+		return AS_DISPLAY_LENGTH_KIND_SMALL;
+	if (px < 360 )
+		return AS_DISPLAY_LENGTH_KIND_XSMALL;
 }
 
 /**

--- a/src/as-relation.c
+++ b/src/as-relation.c
@@ -433,6 +433,7 @@ as_display_length_kind_from_px (gint px)
 		return AS_DISPLAY_LENGTH_KIND_SMALL;
 	if (px < 360 )
 		return AS_DISPLAY_LENGTH_KIND_XSMALL;
+	return AS_DISPLAY_LENGTH_KIND_UNKNOWN;
 }
 
 /**


### PR DESCRIPTION
The current implementation returns AS_DISPLAY_LENGTH_KIND_SMALL when px is higher than 360 and AS_DISPLAY_LENGTH_KIND_XSMALL when px is 360 or lower. All other are not returned. This bug was found by LGTM.