### PR TITLE
Update duplicate checking

### DIFF
--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -91,6 +91,11 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	  N_("The description contains a web URL in plain text. This is not allowed, please use the <url/> tag instead to share links.")
 	},
 
+	{ "unsupported-translation",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("As per AppStream specification, the mention tag doesn't support translations.")
+	},
+
 	{ "tag-duplicated",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  N_("As per AppStream specification, the mentioned tag must only appear once in this context. Having multiple tags of this kind is not valid.")


### PR DESCRIPTION
This PR adds 2 things:

1. as_validator_check_appear_once() currently allow all tags to have translations. This doesn't make sense for tags like project_license. You can't have one License for English users and one for Spanish users. I added a argument to tell, if translations are allowed or not. If not, the new Issuetag unsupported-translation will be raised.

2. I added the duplicate check to a few more tags e.g. <id>.

Please tell me, if a made a mistake at some point.