### PR TITLE
[qt] Rename Component::requires to avoid clash with C++20

### DIFF
--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -361,7 +361,14 @@ void Component::addReplaces(const QString &cid)
     as_component_add_replaces(m_cpt, qPrintable(cid));
 }
 
+#if __cplusplus < 202002L
 QList<Relation> Component::requires() const
+{
+    return requirements();
+}
+#endif
+
+QList<Relation> Component::requirements() const
 {
     QList<AppStream::Relation> res;
 

--- a/qt/component.h
+++ b/qt/component.h
@@ -199,7 +199,10 @@ class APPSTREAMQT_EXPORT Component {
         QStringList replaces() const;
         void addReplaces(const QString& cid);
 
-        QList<AppStream::Relation> requires() const;
+#if __cplusplus < 202002L
+        Q_DECL_DEPRECATED QList<AppStream::Relation> requires() const;
+#endif
+        QList<AppStream::Relation> requirements() const;
         QList<AppStream::Relation> recommends() const;
         QList<AppStream::Relation> supports() const;
         void addRelation(const AppStream::Relation &relation);


### PR DESCRIPTION
In C++20 requires is a reserved keyword

This results in a build failure when a C++20 project includes component.h

To avoid the issue the method gets a new name (requiresComponents). The old method is marked as deprecated and hidden when building in C++20 mode

Fixes #342