### PR TITLE
Add an <internet/> kind to requires/recommends/supports

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -1106,6 +1106,58 @@
 				</listitem>
 			</varlistentry>
 
+			<varlistentry id="tag-relations-internet">
+				<term>&lt;internet/&gt;</term>
+				<listitem>
+				<para>
+					Require, recommend or support connectivity to the internet. The value of this item one of the following:
+				</para>
+				<itemizedlist>
+					<listitem><para><code>always</code> - Needs internet connectivity to work. If used in a <literal>recommends</literal> element, then this indicates that the app can work without internet, but the experience will be significantly degraded.</para></listitem>
+					<listitem><para><code>offline-only</code> - Never uses the internet, even if it’s available.</para></listitem>
+					<listitem><para><code>first-run</code> - Uses the internet the first time the application is run, but not normally afterwards.</para></listitem>
+				</itemizedlist>
+				<para>
+					If the value of <literal>&lt;internet/&gt;</literal> is not <literal>offline-only</literal>, the <literal>bandwidth_mbitps</literal> attribute can be
+					set to a bandwidth (in Mbit/s) which is the minimum internet bandwidth needed for the application to be usable. If this attribute is not set, it’s
+					assumed that the application is usable with all internet connections.
+				</para>
+				<para>
+					Examples:
+				</para>
+				<programlisting language="XML"><![CDATA[<!-- always needs the internet -->
+<requires>
+  <internet>always</internet>
+</requires>
+
+<!-- always needs the internet and has a degraded experience if it’s not at least 2Mbit/s -->
+<requires>
+  <internet bandwidth_mbitps="2">always</internet>
+</requires>
+
+<!-- never uses the internet, even if available -->
+<requires>
+  <internet>never</internet>
+</requires>
+
+<!-- requires the internet on first run -->
+<requires>
+  <internet>first-run</internet>
+</requires>
+
+<!-- can work without the internet, but with a degraded experience -->
+<recommends>
+  <internet>always</internet>
+</recommends>
+
+<!-- recommends the internet for when it’s first run, but can work without -->
+<recommends>
+  <internet>first-run</internet>
+</recommends>]]></programlisting>
+				<para>Valid for: <literal>requires</literal>, <literal>recommends</literal>, <literal>supports</literal></para>
+				</listitem>
+			</varlistentry>
+
 			</variablelist>
 		</listitem>
 

--- a/src/as-relation.h
+++ b/src/as-relation.h
@@ -73,6 +73,7 @@ typedef enum  {
  * @AS_RELATION_ITEM_KIND_CONTROL:		An input method for users to control software
  * @AS_RELATION_ITEM_KIND_DISPLAY_LENGTH:	Display edge length
  * @AS_RELATION_ITEM_KIND_HARDWARE:		A Computer Hardware ID (CHID) to depend on system hardware
+ * @AS_RELATION_ITEM_KIND_INTERNET:		Internet connectivity (Since: 0.15.5)
  *
  * Type of the item an #AsRelation is for.
  **/
@@ -86,6 +87,7 @@ typedef enum  {
 	AS_RELATION_ITEM_KIND_CONTROL,
 	AS_RELATION_ITEM_KIND_DISPLAY_LENGTH,
 	AS_RELATION_ITEM_KIND_HARDWARE,
+	AS_RELATION_ITEM_KIND_INTERNET,
 	/*< private >*/
 	AS_RELATION_ITEM_KIND_LAST
 } AsRelationItemKind;
@@ -182,6 +184,27 @@ typedef enum  {
 	AS_DISPLAY_LENGTH_KIND_LAST
 } AsDisplayLengthKind;
 
+/**
+ * AsInternetKind:
+ * @AS_INTERNET_KIND_UNKNOWN:		Unknown
+ * @AS_INTERNET_KIND_ALWAYS:		Always requires/recommends internet
+ * @AS_INTERNET_KIND_OFFLINE_ONLY:	Application is offline-only
+ * @AS_INTERNET_KIND_FIRST_RUN:	Requires/Recommends internet on first run only
+ *
+ * Different internet connectivity requirements or recommendations for an
+ * application.
+ *
+ * Since: 0.15.5
+ **/
+typedef enum  {
+	AS_INTERNET_KIND_UNKNOWN,
+	AS_INTERNET_KIND_ALWAYS,
+	AS_INTERNET_KIND_OFFLINE_ONLY,
+	AS_INTERNET_KIND_FIRST_RUN,
+	/*< private >*/
+	AS_INTERNET_KIND_LAST
+} AsInternetKind;
+
 const gchar		*as_relation_kind_to_string (AsRelationKind kind);
 AsRelationKind		as_relation_kind_from_string (const gchar *kind_str);
 
@@ -200,6 +223,9 @@ AsDisplaySideKind	as_display_side_kind_from_string (const gchar *kind_str);
 
 const gchar		*as_display_length_kind_to_string (AsDisplayLengthKind kind);
 AsDisplayLengthKind	as_display_length_kind_from_string (const gchar *kind_str);
+
+const gchar		*as_internet_kind_to_string (AsInternetKind kind);
+AsInternetKind		as_internet_kind_from_string (const gchar *kind_str);
 
 AsRelation		*as_relation_new (void);
 
@@ -241,6 +267,13 @@ void			as_relation_set_value_px (AsRelation *relation,
 AsDisplayLengthKind	as_relation_get_value_display_length_kind (AsRelation *relation);
 void			as_relation_set_value_display_length_kind (AsRelation *relation,
 								   AsDisplayLengthKind kind);
+
+AsInternetKind		as_relation_get_value_internet_kind (AsRelation *relation);
+void			as_relation_set_value_internet_kind (AsRelation *relation,
+							     AsInternetKind kind);
+guint			as_relation_get_value_internet_bandwidth (AsRelation *relation);
+void			as_relation_set_value_internet_bandwidth (AsRelation *relation,
+								  guint bandwidth_mbitps);
 
 gboolean		as_relation_version_compare (AsRelation *relation,
 						     const gchar *version,

--- a/tests/test-yamldata.c
+++ b/tests/test-yamldata.c
@@ -1023,14 +1023,18 @@ static const gchar *yamldata_relations_field =
 				"- id: org.example.TestDependency\n"
 				"  version: == 1.2\n"
 				"- display_length: 4200\n"
+				"- internet: always\n"
+				"  bandwidth_mbitps: 2\n"
 				"Recommends:\n"
 				"- memory: 2500\n"
 				"- modalias: usb:v1130p0202d*\n"
 				"- display_length: <= xlarge\n"
 				"  side: longest\n"
+				"- internet: first-run\n"
 				"Supports:\n"
 				"- control: gamepad\n"
-				"- control: keyboard\n";
+				"- control: keyboard\n"
+				"- internet: offline-only\n";
 
 /**
  * test_yaml_write_relations:
@@ -1050,6 +1054,9 @@ test_yaml_write_relations (void)
 	g_autoptr(AsRelation) dl_relation2 = NULL;
 	g_autoptr(AsRelation) ctl_relation1 = NULL;
 	g_autoptr(AsRelation) ctl_relation2 = NULL;
+	g_autoptr(AsRelation) internet_relation1 = NULL;
+	g_autoptr(AsRelation) internet_relation2 = NULL;
+	g_autoptr(AsRelation) internet_relation3 = NULL;
 
 	cpt = as_component_new ();
 	as_component_set_kind (cpt, AS_COMPONENT_KIND_GENERIC);
@@ -1063,6 +1070,9 @@ test_yaml_write_relations (void)
 	dl_relation2 = as_relation_new ();
 	ctl_relation1 = as_relation_new ();
 	ctl_relation2 = as_relation_new ();
+	internet_relation1 = as_relation_new ();
+	internet_relation2 = as_relation_new ();
+	internet_relation3 = as_relation_new ();
 
 	as_relation_set_kind (mem_relation, AS_RELATION_KIND_RECOMMENDS);
 	as_relation_set_kind (moda_relation, AS_RELATION_KIND_RECOMMENDS);
@@ -1072,6 +1082,9 @@ test_yaml_write_relations (void)
 	as_relation_set_kind (dl_relation2, AS_RELATION_KIND_REQUIRES);
 	as_relation_set_kind (ctl_relation1, AS_RELATION_KIND_SUPPORTS);
 	as_relation_set_kind (ctl_relation2, AS_RELATION_KIND_SUPPORTS);
+	as_relation_set_kind (internet_relation1, AS_RELATION_KIND_REQUIRES);
+	as_relation_set_kind (internet_relation2, AS_RELATION_KIND_RECOMMENDS);
+	as_relation_set_kind (internet_relation3, AS_RELATION_KIND_SUPPORTS);
 
 	as_relation_set_item_kind (mem_relation, AS_RELATION_ITEM_KIND_MEMORY);
 	as_relation_set_value_int (mem_relation, 2500);
@@ -1097,6 +1110,16 @@ test_yaml_write_relations (void)
 	as_relation_set_value_int (dl_relation2, 4200);
 	as_relation_set_compare (dl_relation2, AS_RELATION_COMPARE_GE);
 
+	as_relation_set_item_kind (internet_relation1, AS_RELATION_ITEM_KIND_INTERNET);
+	as_relation_set_value_internet_kind (internet_relation1, AS_INTERNET_KIND_ALWAYS);
+	as_relation_set_value_internet_bandwidth (internet_relation1, 2);
+
+	as_relation_set_item_kind (internet_relation2, AS_RELATION_ITEM_KIND_INTERNET);
+	as_relation_set_value_internet_kind (internet_relation2, AS_INTERNET_KIND_FIRST_RUN);
+
+	as_relation_set_item_kind (internet_relation3, AS_RELATION_ITEM_KIND_INTERNET);
+	as_relation_set_value_internet_kind (internet_relation3, AS_INTERNET_KIND_OFFLINE_ONLY);
+
 	as_relation_set_item_kind (ctl_relation1, AS_RELATION_ITEM_KIND_CONTROL);
 	as_relation_set_item_kind (ctl_relation2, AS_RELATION_ITEM_KIND_CONTROL);
 	as_relation_set_value_control_kind (ctl_relation1, AS_CONTROL_KIND_GAMEPAD);
@@ -1110,6 +1133,9 @@ test_yaml_write_relations (void)
 	as_component_add_relation (cpt, dl_relation2);
 	as_component_add_relation (cpt, ctl_relation1);
 	as_component_add_relation (cpt, ctl_relation2);
+	as_component_add_relation (cpt, internet_relation1);
+	as_component_add_relation (cpt, internet_relation2);
+	as_component_add_relation (cpt, internet_relation3);
 
 	/* test collection serialization */
 	res = as_yaml_test_serialize (cpt);
@@ -1137,9 +1163,9 @@ test_yaml_read_relations (void)
 	recommends = as_component_get_recommends (cpt);
 	supports = as_component_get_supports (cpt);
 
-	g_assert_cmpint (requires->len, ==, 3);
-	g_assert_cmpint (recommends->len, ==, 3);
-	g_assert_cmpint (supports->len, ==, 2);
+	g_assert_cmpint (requires->len, ==, 4);
+	g_assert_cmpint (recommends->len, ==, 4);
+	g_assert_cmpint (supports->len, ==, 3);
 
 	/* memory relation */
 	relation = AS_RELATION (g_ptr_array_index (recommends, 0));
@@ -1159,6 +1185,13 @@ test_yaml_read_relations (void)
 	g_assert_cmpint (as_relation_get_item_kind (relation), ==, AS_RELATION_ITEM_KIND_DISPLAY_LENGTH);
 	g_assert_cmpint (as_relation_get_value_display_length_kind (relation), ==, AS_DISPLAY_LENGTH_KIND_XLARGE);
 	g_assert_cmpint (as_relation_get_compare (relation), ==, AS_RELATION_COMPARE_LE);
+
+	/* internet relation (REC) */
+	relation = AS_RELATION (g_ptr_array_index (recommends, 3));
+	g_assert_cmpint (as_relation_get_kind (relation), ==, AS_RELATION_KIND_RECOMMENDS);
+	g_assert_cmpint (as_relation_get_item_kind (relation), ==, AS_RELATION_ITEM_KIND_INTERNET);
+	g_assert_cmpint (as_relation_get_value_internet_kind (relation), ==, AS_INTERNET_KIND_FIRST_RUN);
+	g_assert_cmpint (as_relation_get_value_internet_bandwidth (relation), ==, 0);
 
 	/* kernel relation */
 	relation = AS_RELATION (g_ptr_array_index (requires, 0));
@@ -1183,6 +1216,13 @@ test_yaml_read_relations (void)
 	g_assert_cmpint (as_relation_get_value_px (relation), ==, 4200);
 	g_assert_cmpint (as_relation_get_compare (relation), ==, AS_RELATION_COMPARE_GE);
 
+	/* internet relation (REQ) */
+	relation = AS_RELATION (g_ptr_array_index (requires, 3));
+	g_assert_cmpint (as_relation_get_kind (relation), ==, AS_RELATION_KIND_REQUIRES);
+	g_assert_cmpint (as_relation_get_item_kind (relation), ==, AS_RELATION_ITEM_KIND_INTERNET);
+	g_assert_cmpint (as_relation_get_value_internet_kind (relation), ==, AS_INTERNET_KIND_ALWAYS);
+	g_assert_cmpint (as_relation_get_value_internet_bandwidth (relation), ==, 2);
+
 	/* control relation */
 	relation = AS_RELATION (g_ptr_array_index (supports, 0));
 	g_assert_cmpint (as_relation_get_kind (relation), ==, AS_RELATION_KIND_SUPPORTS);
@@ -1192,6 +1232,13 @@ test_yaml_read_relations (void)
 	g_assert_cmpint (as_relation_get_kind (relation), ==, AS_RELATION_KIND_SUPPORTS);
 	g_assert_cmpint (as_relation_get_item_kind (relation), ==, AS_RELATION_ITEM_KIND_CONTROL);
 	g_assert_cmpint (as_relation_get_value_control_kind (relation), ==, AS_CONTROL_KIND_KEYBOARD);
+
+	/* internet relation (supports) */
+	relation = AS_RELATION (g_ptr_array_index (supports, 2));
+	g_assert_cmpint (as_relation_get_kind (relation), ==, AS_RELATION_KIND_SUPPORTS);
+	g_assert_cmpint (as_relation_get_item_kind (relation), ==, AS_RELATION_ITEM_KIND_INTERNET);
+	g_assert_cmpint (as_relation_get_value_internet_kind (relation), ==, AS_INTERNET_KIND_OFFLINE_ONLY);
+	g_assert_cmpint (as_relation_get_value_internet_bandwidth (relation), ==, 0);
 }
 
 


### PR DESCRIPTION
See the commit messages. This adds a new `<internet/>` kind to requires/recommends/supports, both in the spec and in libappstream. It includes unit tests.

Fixes: #343