### PR TITLE
ascli_refresh_cache: fix NULL pointer dereference

### DIFF
--- a/tools/ascli-actions-mdata.c
+++ b/tools/ascli-actions-mdata.c
@@ -81,7 +81,7 @@ ascli_refresh_cache (const gchar *cachepath,
 		ret = as_pool_refresh_system_cache (pool, forced, &cache_updated, &error);
 	} else {
 		as_pool_override_cache_locations (pool, cachepath, NULL);
-		as_pool_load (pool, NULL, &error);
+		ret = as_pool_load (pool, NULL, &error);
 		cache_updated = TRUE;
 	}
 


### PR DESCRIPTION
The command `appstreamcli refresh-cache --cachepath /tmp/cache` segfaults. In this code path, `ret` (initialized to `FALSE`) is not updated when `as_pool_load` returns successfully and sets the `error` pointer to NULL. Then the code tries to print `error->message`.