### PR TITLE
Specify a metadata format for external release descriptions

### DIFF
--- a/compose/asc-compose.c
+++ b/compose/asc-compose.c
@@ -1409,6 +1409,7 @@ asc_compose_process_task_cb (AscComposeTask *ctask, AscCompose *compose)
 	/* process metadata */
 	for (guint i = 0; i < mi_fnames->len; i++) {
 		g_autoptr(GBytes) mi_bytes = NULL;
+		g_autoptr(GBytes) rel_bytes = NULL;
 		g_autoptr(GError) local_error = NULL;
 		g_autoptr(AsComponent) cpt = NULL;
 		g_autofree gchar *mi_basename = NULL;
@@ -1460,15 +1461,18 @@ asc_compose_process_task_cb (AscComposeTask *ctask, AscCompose *compose)
 					       ctask->unit,
 					       cpt,
 					       mi_fname,
-					       as_flags_contains (priv->flags, ASC_COMPOSE_FLAG_ALLOW_NET));
+					       as_flags_contains (priv->flags, ASC_COMPOSE_FLAG_ALLOW_NET),
+					       acurl,
+					       &rel_bytes);
 
 		/* validate the data */
 		if (as_flags_contains (priv->flags, ASC_COMPOSE_FLAG_VALIDATE)) {
 			asc_validate_metainfo_data_for_component (ctask->result,
-									validator,
-									cpt,
-									mi_bytes,
-									mi_basename);
+								  validator,
+								  cpt,
+								  mi_bytes,
+								  mi_basename,
+								  rel_bytes);
 		}
 
 		/* legacy support: Synthesize launchable entry if none was set,

--- a/compose/asc-compose.c
+++ b/compose/asc-compose.c
@@ -1455,6 +1455,13 @@ asc_compose_process_task_cb (AscComposeTask *ctask, AscCompose *compose)
 					  g_strdup (as_component_get_id (cpt)));
 		}
 
+		/* process any release information of this component and download release data if needed */
+		asc_process_metainfo_releases (ctask->result,
+					       ctask->unit,
+					       cpt,
+					       mi_fname,
+					       as_flags_contains (priv->flags, ASC_COMPOSE_FLAG_ALLOW_NET));
+
 		/* validate the data */
 		if (as_flags_contains (priv->flags, ASC_COMPOSE_FLAG_VALIDATE)) {
 			asc_validate_metainfo_data_for_component (ctask->result,

--- a/compose/asc-hint-tags.c
+++ b/compose/asc-hint-tags.c
@@ -103,6 +103,16 @@ AscHintTagStatic asc_hint_tag_list[] =  {
 	  "<code>type=</code> property of the component root-node in the MetaInfo XML file does not contain a spelling mistake."
 	},
 
+	{ "metainfo-releases-download-failed",
+	  AS_ISSUE_SEVERITY_WARNING,
+	  "Unable to download release information from <code>{{url}}</code>. The error message was: {{msg}}."
+	},
+
+	{ "metainfo-releases-read-failed",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  "Unable to read release information from <code>{{path}}</code>. The error message was: {{msg}}."
+	},
+
 	{ "file-read-error",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  "Unable to read data from file <code>{{fname}}</code>: {{msg}}",

--- a/compose/asc-utils-metainfo.h
+++ b/compose/asc-utils-metainfo.h
@@ -37,6 +37,11 @@ AsComponent		*asc_parse_metainfo_data (AscResult *cres,
 AsComponent		*asc_parse_metainfo_data_simple (AscResult *cres,
 							 GBytes *bytes,
 							 const gchar *mi_basename);
+void			asc_process_metainfo_releases (AscResult *cres,
+						       AscUnit *unit,
+						       AsComponent *cpt,
+						       const gchar *mi_filename,
+						       gboolean allow_net);
 
 void			asc_validate_metainfo_data_for_component (AscResult *cres,
 								  AsValidator *validator,

--- a/compose/asc-utils-metainfo.h
+++ b/compose/asc-utils-metainfo.h
@@ -24,6 +24,7 @@
 #include <appstream.h>
 
 #include "as-settings-private.h"
+#include "as-curl.h"
 #include "asc-result.h"
 #include "asc-compose.h"
 
@@ -41,13 +42,16 @@ void			asc_process_metainfo_releases (AscResult *cres,
 						       AscUnit *unit,
 						       AsComponent *cpt,
 						       const gchar *mi_filename,
-						       gboolean allow_net);
+						       gboolean allow_net,
+						       AsCurl *acurl,
+						       GBytes **used_reldata);
 
 void			asc_validate_metainfo_data_for_component (AscResult *cres,
 								  AsValidator *validator,
 								  AsComponent *cpt,
 								  GBytes *bytes,
-								  const gchar *mi_basename);
+								  const gchar *mi_basename,
+								  GBytes *relmd_bytes);
 
 AS_INTERNAL_VISIBLE
 AsComponent		*asc_parse_desktop_entry_data (AscResult *cres,

--- a/data/its/metainfo.its
+++ b/data/its/metainfo.its
@@ -35,6 +35,13 @@
   <its:translateRule selector="/component/releases/release/description[@translate = 'no']"
                      translate="no"/>
 
+  <!-- Release metadata -->
+  <its:translateRule selector="/releases" translate="no"/>
+  <its:translateRule selector="/releases/release/description"
+                     translate="yes"/>
+  <its:translateRule selector="/releases/release/description[@translate = 'no']"
+                     translate="no"/>
+
   <!-- DEPRECATED -->
   <its:translateRule selector="/component/name[@translatable = 'no']"
                      translate="no"/>

--- a/data/its/metainfo.loc
+++ b/data/its/metainfo.loc
@@ -5,10 +5,14 @@
   SPDX-License-Identifier: FSFAP
 -->
 <locatingRules>
+  <locatingRule name="MetaInfo" pattern="*.metainfo.xml">
+    <documentRule localName="component" target="metainfo.its"/>
+  </locatingRule>
   <locatingRule name="MetaInfo" pattern="*.appdata.xml">
     <documentRule localName="component" target="metainfo.its"/>
   </locatingRule>
-  <locatingRule name="MetaInfo" pattern="*.metainfo.xml">
-    <documentRule localName="component" target="metainfo.its"/>
+
+  <locatingRule name="ReleaseData" pattern="*.releases.xml">
+    <documentRule localName="releases" target="metainfo.its"/>
   </locatingRule>
 </locatingRules>

--- a/docs/xml/collection-xmldata.xml
+++ b/docs/xml/collection-xmldata.xml
@@ -505,8 +505,7 @@
 				<term>&lt;releases/&gt;</term>
 				<listitem>
 					<para>
-						The <literal>releases</literal> tag and its <literal>release</literal> children are structured as described in <xref linkend="tag-releases"/>, with the
-						additional requirement that releases must be sorted in a latest-to-oldest order.
+						The <literal>releases</literal> tag and its <literal>release</literal> children are structured as described in <xref linkend="sect-Metadata-Releases"/>.
 					</para>
 					<para>
 						Each <literal>release</literal> tag may have a <literal>description</literal> tag as child, containing a brief description of what is new in the release.
@@ -516,6 +515,11 @@
 						The AppStream collection XML generator may shorten overlong lists of releases to a smaller list, for example of 4 <literal>release</literal> tags.
 						It may also convert ISO 8601 <literal>date</literal> properties of the metainfo file into an UNIX timestamp <literal>timestamp</literal> property.
 						It should avoid generating metadata containing both properties on a <literal>release</literal> tag.
+					</para>
+					<para>
+						If a <xref linkend="tag-releases"/> tag in a metainfo file references an <literal>external</literal> release description, the release description should
+						be read either from the release file provided locally, or, if possible and provided, be downloaded from the URL referenced in the component's <literal>releases</literal>
+						tag.
 					</para>
 					<para>
 						Example for a valid releases tag:

--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -499,11 +499,53 @@
 		<term>&lt;releases/&gt;</term>
 		<listitem>
 			<para>
-				The <code><![CDATA[<releases>]]></code> tag contains multiple <literal>release</literal> children that contain
-				metadata about releases made for this software component.
+				The <code><![CDATA[<releases>]]></code> tag contains multiple <literal>release</literal> children that
+				themselves contain metadata about releases made for this software component.
 				The release information XML is described in-depth in <xref linkend="sect-Metadata-Releases"/>,
 				examples for a valid <literal>releases</literal> tag with artifacts are also provided there.
 			</para>
+			<para>
+				Release information can be embedded in the component's metainfo file, following the XML
+				description outlined in <xref linkend="sect-Metadata-Releases"/>. Alternatively, it can also
+				be split into its own metadata file as described in that section. In case of external metadata,
+				a <literal>releases</literal> tag must still be present in the component's metainfo file, and
+				must have a <literal>type</literal> property set to value <code>external</code> (if the <literal>type</literal>
+				property is missing, a value of <code>embedded</code> is implicitly assumed for it).
+			</para>
+			<para>
+				In case of external metadata, the <literal>releases</literal> tag may also have an <literal>url</literal>
+				property linking to a web location where the release XML can be found and updated separately from the
+				main component metadata. An <literal>url</literal> property must not be present without <literal>type</literal>
+				set to <code>external</code>.
+			</para>
+			<para>
+				Only HTTPS links are allowed for the web URL, and any <literal>artifact</literal> defined in a
+				release description from an external website should not be trusted without further verification, as external
+				release information can currently not be signed.
+			</para>
+			<para>
+				AppStream catalog metadata generators may choose to update the locally provided release information with the data from
+				the web location provided by the URL in <literal>url</literal>.
+				This allow projects to complete release localization after a release was made, or include further information that was
+				not yet available directly at release time.
+				The generated catalog XML data must be complete and must not contain references to external release information.
+			</para>
+			<para>
+				Example for a <literal>releases</literal> block that points to an external metadata file:
+			</para>
+			<programlisting language="XML"><![CDATA[<releases type="external" url="https://example.org/releases/org.example.myapp.releases.xml" />]]></programlisting>
+			<important>
+				<title>Local Release Data</title>
+				<para>
+					Please note that even if release data is external and also provided on a remote location, it also <emphasis>must</emphasis> be
+					available locally, installed as a file into <filename>/usr/share/metainfo/releases/%{cid}.releases.xml</filename>.
+					The local file may not contain all information (for example it may not have a complete release description or all translations),
+					but basic data such as the released versions and their release dates should be present.
+				</para>
+				<para>
+					It is an error to reference an external release data file, but not provide a local copy of it.
+				</para>
+			</important>
 		</listitem>
 		</varlistentry>
 

--- a/docs/xml/releases-data.xml
+++ b/docs/xml/releases-data.xml
@@ -13,6 +13,27 @@
 			This section documents the <xref linkend="tag-releases"/> tag that can be part of a <literal>component</literal> to provide
 			information about releases made for the respective component.
 		</para>
+		<para>
+			Alternatively to being embedded in a component metainfo file, the data may also be split into a dedicated XML file to be updated separately.
+		</para>
+	</section>
+
+	<section id="spec-releases-location">
+		<title>Locations</title>
+
+		<para>
+			Release data may be present directly in a component metainfo file, but also optionally be split out into an external metadata file.
+		</para>
+		<para>
+			If the <literal>releases</literal> XML is part of a metainfo file, it is embedded into it following the semantics described in the document.
+		</para>
+		<para>
+			If the <literal>releases</literal> XML is external, the metainfo file must contain a <xref linkend="tag-releases"/> tag with the <literal>type</literal>
+			property set to <code>external</code> as described for component XML.
+			The data described in this section is placed in a separate XML file with <literal>releases</literal> being its root node.
+			The file must be installed as <filename>/usr/share/metainfo/releases/%{cid}.releases.xml</filename>, where <code>cid</code> is the component ID of the component
+			the release information belongs to.
+		</para>
 	</section>
 
 	<section id="spec-releases-example">

--- a/src/as-component-private.h
+++ b/src/as-component-private.h
@@ -54,6 +54,9 @@ void			as_component_complete (AsComponent *cpt,
 						gchar *scr_base_url,
 						GPtrArray *icon_paths);
 
+gint			as_component_releases_compare (gconstpointer a,
+						       gconstpointer b);
+
 AS_INTERNAL_VISIBLE
 GHashTable		*as_component_get_languages_table (AsComponent *cpt);
 

--- a/src/as-component.c
+++ b/src/as-component.c
@@ -761,7 +761,7 @@ as_component_get_releases (AsComponent *cpt)
 	g_autoptr(GError) error = NULL;
 
 	if (!as_component_load_releases (cpt, FALSE, FALSE, &error))
-		g_warning ("Error loading data for %s: %s",
+		g_debug ("Error loading data for %s: %s",
 			   as_component_get_data_id (cpt), error->message);
 	return priv->releases;
 }

--- a/src/as-component.h
+++ b/src/as-component.h
@@ -198,6 +198,27 @@ typedef enum /*< skip >*/ __attribute__((__packed__)) {
 /* DEPRECATED */
 #define AS_SEARCH_TOKEN_MATCH_MIMETYPE AS_SEARCH_TOKEN_MATCH_MEDIATYPE
 
+/**
+ * AsReleasesKind:
+ * @AS_RELEASES_KIND_UNKNOWN:		Unknown releases type
+ * @AS_RELEASES_KIND_EMBEDDED:		Release info is embedded in metainfo file
+ * @AS_RELEASES_KIND_EXTERNAL:		Release info is split to a separate file
+ *
+ * The kind of a releases block.
+ *
+ * Since: 0.16.0
+ **/
+typedef enum {
+	AS_RELEASES_KIND_UNKNOWN,
+	AS_RELEASES_KIND_EMBEDDED,
+	AS_RELEASES_KIND_EXTERNAL,
+	/*< private >*/
+	AS_RELEASES_KIND_LAST
+} AsReleasesKind;
+
+const gchar	*as_releases_kind_to_string (AsReleasesKind kind);
+AsReleasesKind	as_releases_kind_from_string (const gchar *kind_str);
+
 AsComponent		*as_component_new (void);
 
 AsValueFlags		as_component_get_value_flags (AsComponent *cpt);
@@ -330,9 +351,24 @@ void			as_component_add_url (AsComponent *cpt,
 						AsUrlKind url_kind,
 						const gchar *url);
 
+gboolean		as_component_load_releases_from_bytes (AsComponent *cpt,
+								GBytes *bytes,
+								GError **error);
+gboolean		as_component_load_releases (AsComponent *cpt,
+						    gboolean reload,
+						    gboolean allow_net,
+						    GError **error);
 GPtrArray		*as_component_get_releases (AsComponent *cpt);
 void			as_component_add_release (AsComponent *cpt,
-							AsRelease* release);
+						  AsRelease* release);
+
+AsReleasesKind		as_component_get_releases_kind (AsComponent *cpt);
+void			as_component_set_releases_kind (AsComponent *cpt,
+							AsReleasesKind kind);
+
+const gchar		*as_component_get_releases_url (AsComponent *cpt);
+void			as_component_set_releases_url (AsComponent *cpt,
+						       const gchar *url);
 
 GPtrArray		*as_component_get_extends (AsComponent *cpt);
 void			as_component_add_extends (AsComponent *cpt,

--- a/src/as-context-private.h
+++ b/src/as-context-private.h
@@ -23,6 +23,7 @@
 
 #include "as-context.h"
 #include "as-component.h"
+#include "as-curl.h"
 
 G_BEGIN_DECLS
 #pragma GCC visibility push(hidden)
@@ -43,6 +44,9 @@ void			as_context_localized_ht_set (AsContext *ctx,
 						     GHashTable *lht,
 						     const gchar *value,
 						     const gchar *locale);
+
+AsCurl			*as_context_get_curl (AsContext *ctx,
+					      GError **error);
 
 #pragma GCC visibility pop
 G_END_DECLS

--- a/src/as-metadata.h
+++ b/src/as-metadata.h
@@ -107,6 +107,16 @@ gboolean		as_metadata_parse_desktop_data (AsMetadata *metad,
 							const gchar *cid,
 							GError **error);
 
+GPtrArray		*as_metadata_parse_releases_bytes (AsMetadata *metad,
+							   GBytes *bytes,
+							   GError **error);
+GPtrArray		*as_metadata_parse_releases_file (AsMetadata *metad,
+							  GFile *file,
+							  GError **error);
+gchar			*as_metadata_releases_to_data (AsMetadata *metad,
+						       GPtrArray *releases,
+						       GError **error);
+
 AsComponent		*as_metadata_get_component (AsMetadata *metad);
 GPtrArray		*as_metadata_get_components (AsMetadata *metad);
 

--- a/src/as-news-convert.c
+++ b/src/as-news-convert.c
@@ -111,7 +111,7 @@ as_releases_to_metainfo_xml_chunk (GPtrArray *releases, GError **error)
 					n_releases);
 	}
 
-	xml_raw = as_xml_node_to_str (root, error);
+	xml_raw = as_xml_node_free_to_str (root, error);
 	if ((error != NULL) && (*error != NULL))
 		return NULL;
 

--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -821,6 +821,28 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	     "Sorting releases also increases overall readability of the metainfo file."),
 	},
 
+	{ "releases-type-invalid",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  /* TRANSLATORS: Please do not translate AppStream tag/property names (in backticks). */
+	  N_("The type of the releases block is invalid. It needs to either `embedded` (the default) or `external`."),
+	},
+
+	{ "releases-url-insecure",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("The URL to an external release metadata file is insecure. This is not allowed, please use HTTPS URLs only."),
+	},
+
+	{ "releases-download-failed",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("Failed to download release metadata."),
+	},
+
+	{ "releases-external-not-found",
+	  AS_ISSUE_SEVERITY_WARNING,
+	  N_("A local release metadata file was not found. It is strongly recommended to validate this metadata "
+	     "together with the main MetaInfo file."),
+	},
+
 	{ "release-urgency-invalid",
 	  AS_ISSUE_SEVERITY_WARNING,
 	  N_("The value set as release urgency is not a known urgency value."),

--- a/src/as-validator.h
+++ b/src/as-validator.h
@@ -49,12 +49,14 @@ struct _AsValidatorClass
  * AsValidatorError:
  * @AS_VALIDATOR_ERROR_FAILED:			Generic failure
  * @AS_VALIDATOR_ERROR_OVERRIDE_INVALID:	The issue override was not accepted.
+ * @AS_VALIDATOR_ERROR_INVALID_FILENAME:	The filename was invalid.
  *
  * The error type.
  **/
 typedef enum {
 	AS_VALIDATOR_ERROR_FAILED,
 	AS_VALIDATOR_ERROR_OVERRIDE_INVALID,
+	AS_VALIDATOR_ERROR_INVALID_FILENAME,
 	/*< private >*/
 	AS_VALIDATOR_ERROR_LAST
 } AsValidatorError;
@@ -66,7 +68,7 @@ AsValidator		*as_validator_new (void);
 
 void			as_validator_clear_issues (AsValidator *validator);
 gboolean		as_validator_validate_file (AsValidator *validator,
-							GFile* metadata_file);
+							GFile *metadata_file);
 gboolean		as_validator_validate_bytes (AsValidator *validator,
 							GBytes *metadata);
 gboolean		as_validator_validate_data (AsValidator *validator,
@@ -74,6 +76,16 @@ gboolean		as_validator_validate_data (AsValidator *validator,
 gboolean		as_validator_validate_tree (AsValidator *validator,
 							const gchar *root_dir);
 
+void			as_validator_clear_release_data (AsValidator *validator);
+gboolean		as_validator_add_release_bytes (AsValidator *validator,
+							const gchar *release_fname,
+							GBytes *release_metadata,
+							GError **error);
+gboolean		as_validator_add_release_file (AsValidator *validator,
+						       GFile *release_file,
+						       GError **error);
+
+guint			as_validator_get_issue_files_count (AsValidator *validator);
 GList			*as_validator_get_issues (AsValidator *validator);
 GHashTable		*as_validator_get_issues_per_file (AsValidator *validator);
 gboolean		as_validator_get_report_yaml (AsValidator *validator,

--- a/src/as-xml.c
+++ b/src/as-xml.c
@@ -1089,7 +1089,7 @@ as_xml_parse_document (const gchar *data, gssize len, GError **error)
 }
 
 /**
- * as_xml_node_to_str:
+ * as_xml_node_free_to_str:
  * @root: The document root node.
  *
  * Converts an XML node into its textural representation.
@@ -1099,7 +1099,7 @@ as_xml_parse_document (const gchar *data, gssize len, GError **error)
  * Returns: XML metadata.
  */
 gchar*
-as_xml_node_to_str (xmlNode *root, GError **error)
+as_xml_node_free_to_str (xmlNode *root, GError **error)
 {
 	xmlDoc *doc;
 	gchar *xmlstr = NULL;

--- a/src/as-xml.h
+++ b/src/as-xml.h
@@ -89,6 +89,7 @@ void		as_xml_add_custom_node (xmlNode *root,
 					const gchar *node_name,
 					GHashTable *custom);
 
+#define as_xml_node_new(name)		xmlNewNode (NULL, (xmlChar*) name)
 #define as_xml_add_node(root, name)	xmlNewChild (root, NULL, (xmlChar*) name, NULL)
 xmlNode		*as_xml_add_text_node (xmlNode *root,
 					const gchar *name,
@@ -101,7 +102,8 @@ xmlDoc		*as_xml_parse_document (const gchar *data,
 					gssize len,
 					GError **error);
 
-gchar		*as_xml_node_to_str (xmlNode *root, GError **error);
+gchar		*as_xml_node_free_to_str (xmlNode *root,
+					  GError **error);
 
 #pragma GCC visibility pop
 G_END_DECLS

--- a/tests/samples/org.example.pomidaq.metainfo.xml
+++ b/tests/samples/org.example.pomidaq.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="desktop-application">
+  <id>org.example.pomidaq</id>
+  <name>PoMiDAQ</name>
+  <summary>View and record videos from UCLA Miniscopes</summary>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>LGPL-3.0+</project_license>
+  <description>
+    <p>
+      PoMiDAQ is a recording software for UCLA Miniscopes for neuroscientific research.
+      It provides an easy way to record videos from Miniscopes, create Z-stacks to give an
+      overview of visible cells or tissue features and provides an online background subtraction
+      feature to gain an initial insight into cellular calcium activity while data is recorded.
+      Recorded data is encoded with the FFV1 codec by default, to allow for smaller,
+      lossless video files that are safe to archive.
+    </p>
+  </description>
+  <launchable type="desktop-id">pomidaq.desktop</launchable>
+  <url type="homepage">https://github.com/bothlab/pomidaq</url>
+  <url type="bugtracker">https://github.com/bothlab/pomidaq/issues</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Recording a raw video of calcium activity while displaying the difference to the average background</caption>
+      <image type="source">https://raw.githubusercontent.com/bothlab/pomidaq/master/contrib/screenshots/v0.4.4_diffdisplay.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Displaying the raw image data recorded from a GRIN lens in CA1 of a mouse hippocampus</caption>
+      <image type="source">https://raw.githubusercontent.com/bothlab/pomidaq/master/contrib/screenshots/v0.4.4_rawdisplay.png</image>
+    </screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.1"/>
+
+  <releases type="external" url="https://raw.githubusercontent.com/ximion/appstream/master/tests/samples/releases/org.example.pomidaq.releases.xml" />
+</component>

--- a/tests/samples/releases/org.example.pomidaq.releases.xml
+++ b/tests/samples/releases/org.example.pomidaq.releases.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<releases>
+  <release type="stable" version="0.4.5" date="2022-08-20T00:00:00Z">
+    <description>
+      <p>This release adds the following features:</p>
+      <ul>
+        <li>Display device name for camera ID on Linux</li>
+        <li>Don't store data in temporary location by default</li>
+        <li>Update screenshots</li>
+        <li>Add Flatpak bundle build recipe</li>
+        <li>Validate &amp; augment metainfo file using appstreamcli</li>
+      </ul>
+      <p>This release fixes the following bugs:</p>
+      <ul>
+        <li>Prevent in-tree builds</li>
+        <li>Give a better error when trying to build against GLES instead of OpenGL</li>
+        <li>cmake: Find more recent FFmpeg versions as well</li>
+      </ul>
+    </description>
+  </release>
+  <release type="stable" version="0.4.4" date="2021-12-16T00:00:00Z">
+    <description>
+      <p>This release adds the following features:</p>
+      <ul>
+        <li>Implement z-stack capture feature for Miniscopes with an EWL</li>
+        <li>Run display image rendering as event loop callback</li>
+      </ul>
+      <p>This release fixes the following bug:</p>
+      <ul>
+        <li>Resolve a few compiler warnings</li>
+      </ul>
+    </description>
+  </release>
+  <release type="stable" version="0.4.3" date="2021-09-21T00:00:00Z">
+    <description>
+      <p>This release adds the following feature:</p>
+      <ul>
+        <li>Make build instructions a bit more beginner-friendly</li>
+      </ul>
+      <p>This release fixes the following bugs:</p>
+      <ul>
+        <li>Give video display container a minimum width</li>
+        <li>Don't use deprecated FFmpeg API</li>
+        <li>Save view splitter sizes as byte array, instead of variant</li>
+      </ul>
+    </description>
+  </release>
+  <release type="stable" version="0.4.2" date="2021-05-24T00:00:00Z">
+    <description>
+      <p>This release adds the following features:</p>
+      <ul>
+        <li>Add spin boxes for sliding values, in addition to slider widgets</li>
+        <li>Start Miniscopes on highest framerate by default</li>
+      </ul>
+      <p>This release fixes the following bugs:</p>
+      <ul>
+        <li>Tell DAQ board when we are recording data</li>
+        <li>Consistently sort Miniscope controls</li>
+        <li>Save &amp; restore main window splitter position</li>
+      </ul>
+    </description>
+  </release>
+</releases>


### PR DESCRIPTION
Hi!
This PR contains the specification for a "new" metadata format that contains release descriptions. Having them split out of the main metainfo file allows them to be updated independently and separately, and even allows us to fetch updated release information automatically at catalog build time.

This PR follows the discussion at #354 

Short summary of the changes:
* To use external release metadata, the main metainfo component must contain a `releases` tag with the property `external="yes"` (*note: maybe `type="external"` is better / more consistent?*). This is done so we don't need to `stat()` around too much and to have the metadata author communicate their intent clearly (good for validation!).
* External release metadata files follow the existing specification for AppStream releases, the `releases` tag is the root node of their XML.
* External release metadata files must be installed as `/usr/share/metainfo/releases/%{cid}.releases.xml` (`cid` being the component ID they belong to).
* External releases may be downloaded from a HTTPS web URL set in the metainfo file's `releases` tag.
* The external release data *must* be installed locally, even if it is incomplete. Only having the web URL is not permitted.
* Any `artifact` present in a release file downloaded from a remote source must not be trusted without further verification for now, until release metadata signing is implemented.

As you can see, I cut out the signing & verification issue for now, which, given that we only allow HTTPS links for release metadata, is probably also only a real problem in case of domain hijacking. That way we can make progress on this feature and add signing later (I have ideas as for how that may work too, but taking one step at a time feels like the better approach).

Feedback is very welcome before this gets implemented! (Especially from @pwithnall and @Pointedstick :-))