### PR TITLE
Addresses some problems found while trying to use Pool::componentsByCategories

### DIFF
--- a/qt/chelpers.h
+++ b/qt/chelpers.h
@@ -77,12 +77,13 @@ inline QStringList valueWrap(GList *list)
 
 inline char ** stringListToCharArray(const QStringList& list)
 {
-    char **array = (char**) g_malloc(sizeof(char*) * list.size());
+    char **array = (char**) g_malloc(sizeof(char*) * list.size() + 1);
     for (int i = 0; i < list.size(); ++i) {
         const QByteArray string = list[i].toLocal8Bit();
         array[i] = (char*) g_malloc(sizeof(char) * (string.size() + 1));
         strcpy(array[i], string.constData());
     }
+    array[list.size()] = nullptr;
     return array;
 }
 

--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -24,6 +24,7 @@
 #include <QStringList>
 #include <QUrl>
 #include <QLoggingCategory>
+#include "chelpers.h"
 
 Q_LOGGING_CATEGORY(APPSTREAMQT_POOL, "appstreamqt.pool")
 
@@ -147,9 +148,15 @@ QList<AppStream::Component> Pool::componentsByCategories(const QStringList& cate
     QList<AppStream::Component> res;
     g_autofree gchar **cats_strv = NULL;
 
-    cats_strv = g_new0(gchar *, categories.size() + 1);
-    for (int i = 0; i < categories.size(); ++i)
-        cats_strv[i] = (gchar*) qPrintable(categories.at(i));
+    QVector<QByteArray> utf8Categories;
+    utf8Categories.reserve(categories.size());
+    for (const QString &category : categories) {
+        utf8Categories += category.toUtf8();
+    }
+
+    cats_strv = g_new0(gchar *, utf8Categories.size() + 1);
+    for (int i = 0; i < utf8Categories.size(); ++i)
+        cats_strv[i] = (gchar*) utf8Categories[i].constData();
 
     return cptArrayToQList(as_pool_get_components_by_categories (d->pool, cats_strv));
 }

--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -230,6 +230,7 @@ bool Pool::addComponent(const AppStream::Component& cpt)
 
 uint Pool::cacheFlags() const
 {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return as_pool_get_cache_flags(d->pool);
 #pragma GCC diagnostic pop
@@ -237,6 +238,7 @@ uint Pool::cacheFlags() const
 
 void Pool::setCacheFlags(uint flags)
 {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     as_pool_set_cache_flags(d->pool,
                             (AsCacheFlags) flags);
@@ -245,6 +247,7 @@ void Pool::setCacheFlags(uint flags)
 
 void Pool::clearMetadataLocations()
 {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     as_pool_clear_metadata_locations(d->pool);
 #pragma GCC diagnostic pop
@@ -252,6 +255,7 @@ void Pool::clearMetadataLocations()
 
 void Pool::addMetadataLocation(const QString& directory)
 {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     as_pool_add_metadata_location (d->pool, qPrintable(directory));
 #pragma GCC diagnostic pop
@@ -259,6 +263,7 @@ void Pool::addMetadataLocation(const QString& directory)
 
 QString AppStream::Pool::cacheLocation() const
 {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return QString::fromUtf8(as_pool_get_cache_location(d->pool));
 #pragma GCC diagnostic pop
@@ -266,6 +271,7 @@ QString AppStream::Pool::cacheLocation() const
 
 void Pool::setCacheLocation(const QString &location)
 {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     as_pool_set_cache_location(d->pool, qPrintable(location));
 #pragma GCC diagnostic pop


### PR DESCRIPTION
It was crashing because the list was not getting populated properly. This changes does so and addresses a couple of extra problems found while doing this as seen in their respective commits2.