### PR TITLE
Allow building against Qt6

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -209,6 +209,6 @@ subdir('data/')
 subdir('contrib/')
 subdir('docs/')
 subdir('tests/')
-if get_option('qt')
+if get_option('qt') or get_option('qt6')
     subdir('qt/')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,6 +18,11 @@ option('qt',
        value : false,
        description : 'Build libappstream-qt'
 )
+option('qt6',
+       type : 'boolean',
+       value : false,
+       description: 'Build libappstream-qt6'
+)
 option('compose',
        type : 'boolean',
        value : false,

--- a/qt/cmake/AppStreamQtConfig.cmake.in
+++ b/qt/cmake/AppStreamQtConfig.cmake.in
@@ -31,11 +31,11 @@ endmacro()
 add_library(AppStreamQt SHARED IMPORTED)
 set_target_properties(AppStreamQt PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include/"
-  INTERFACE_LINK_LIBRARIES "Qt5::Core"
+  INTERFACE_LINK_LIBRARIES "Qt::Core"
   IMPORTED_LOCATION "@LIBDIR_FULL@/libAppStreamQt.so.${AppStreamQt_VERSION}"
   IMPORTED_SONAME "libAppStreamQt.${AppStreamQt_VERSION_MAJOR}"
 )
 
 ####################################################################################
 
-check_required_components(Qt5Core)
+check_required_components(Qt6Core)

--- a/qt/meson.build
+++ b/qt/meson.build
@@ -2,11 +2,17 @@
 
 asqt_api_level = '2'
 
+if get_option('qt6')
+    qt_major_version = '6'
+else
+    qt_major_version = '5'
+endif
+
 add_languages('cpp', native: true)
 add_languages('cpp', native: false)
 
-qt = import('qt5')
-qt5_dep = dependency('qt5', modules: ['Core'])
+qt = import(f'qt@qt_major_version@')
+qt_dep = dependency(f'qt@qt_major_version@', modules: ['Core'])
 
 asqt_src = [
     'bundle.cpp',
@@ -61,9 +67,9 @@ asqt_moc = qt.preprocess (
     #moc_sources: asqt_src
 )
 
-asqt_cpp_args = []
+asqt_cpp_args = ['-DQT_NO_KEYWORDS']
 if get_option('maintainer')
-    asqt_cpp_args = ['-Wno-inline']
+    asqt_cpp_args += ['-Wno-inline']
 endif
 
 appstreamqt_lib = library ('AppStreamQt',
@@ -73,10 +79,11 @@ appstreamqt_lib = library ('AppStreamQt',
      asqt_moc],
     soversion: asqt_api_level,
     version: as_version,
-    dependencies: [qt5_dep,
+    dependencies: [qt_dep,
                    appstream_dep,
                    gio_dep],
     cpp_args: asqt_cpp_args,
+    override_options : ['cpp_std=gnu++17'],
     install: true
 )
 

--- a/qt/tests/meson.build
+++ b/qt/tests/meson.build
@@ -1,6 +1,6 @@
 # Meson definition for AppStream Qt Tests
 
-qt5_test_dep = dependency('qt5', modules: ['Core', 'Test'])
+qt_test_dep = dependency(f'qt@qt_major_version@', modules: ['Core', 'Test'])
 
 testpaths_h = configuration_data()
 testpaths_h.set_quoted('AS_SAMPLE_DATA_PATH', join_paths(source_root, 'tests', 'samples', 'catalog'))
@@ -15,10 +15,11 @@ asqt_test_moc = qt.preprocess (moc_sources: asqt_test_src)
 as_test_qt_exe = executable ('as-test_qt',
     [asqt_test_src,
      asqt_test_moc],
-    dependencies: [qt5_test_dep],
+    dependencies: [qt_test_dep],
     include_directories: [include_directories('..')],
     link_with: [appstreamqt_lib],
-    cpp_args: asqt_cpp_args
+    cpp_args: asqt_cpp_args,
+    override_options : ['cpp_std=gnu++17']
 )
 test ('as-test_qt',
     as_test_qt_exe,


### PR DESCRIPTION
This adds a new option qt6 to build against Qt6 instead of Qt5

It is incompatible with qt, i.e. it is only possible to build against either Qt5 or Qt6 at a time