### PR TITLE
ascli: Allow searching by categories

### DIFF
--- a/tools/appstreamcli.c
+++ b/tools/appstreamcli.c
@@ -417,6 +417,36 @@ as_client_run_what_provides (const gchar *command, char **argv, int argc)
 }
 
 /**
+ * as_client_run_by_categories:
+ *
+ * Lists components by their categories.
+ */
+
+static int
+as_client_run_by_categories (const gchar *command, char **argv, int argc)
+{
+
+    g_autoptr(GOptionContext) opt_context = NULL;
+    gint ret;
+    const gchar *value = NULL;
+
+    opt_context = as_client_new_subcommand_option_context (command, find_options);
+    g_option_context_add_main_entries (opt_context, data_collection_options, NULL);
+
+    ret = as_client_option_context_parse (opt_context, command, &argc, &argv);
+    if (ret != 0)
+        return ret;
+
+    if (argc > 2)
+        value = argv[2];
+
+    return ascli_by_categories (optn_cachepath,
+                    value,
+                    optn_details,
+                    optn_no_cache);
+}
+
+/**
  * as_client_run_validate:
  *
  * Validate single metadata files.
@@ -1252,6 +1282,12 @@ as_client_run (char **argv, int argc)
 			/* TRANSLATORS: `appstreamcli what-provides` command description. */
 			_("Get components which provide the given item. Needs an item type (e.g. lib, bin, python3, …) and item value as parameter."),
 			as_client_run_what_provides);
+	ascli_add_cmd (commands,
+			0, "by-categories", NULL, "NAMES",
+			/* TRANSLATORS: `appstreamcli what-provides` command description. */
+			_("Get components that are part of the specified categories in a list with comas (,)."),
+			as_client_run_by_categories);
+
 
 	ascli_add_cmd (commands,
 			1, "dump", NULL, "COMPONENT-ID",

--- a/tools/ascli-actions-mdata.c
+++ b/tools/ascli-actions-mdata.c
@@ -253,6 +253,50 @@ ascli_what_provides (const gchar *cachepath, const gchar *kind_str, const gchar 
 }
 
 /**
+ * ascli_by_categories:
+ *
+ * Get components that match the given @p categories
+ */
+int
+ascli_by_categories (const gchar *cachepath, const gchar *categories, gboolean detailed, gboolean no_cache)
+{
+    g_autoptr(AsPool) dpool = NULL;
+    g_autoptr(GPtrArray) result = NULL;
+    g_autoptr(GError) error = NULL;
+
+    if (categories == NULL) {
+        fprintf (stderr, "%s\n", _("You need to specify a categories to look up."));
+        return 2;
+    }
+
+    dpool = ascli_data_pool_new_and_open (cachepath, no_cache, &error);
+    if (error != NULL) {
+        g_printerr ("%s\n", error->message);
+        return 1;
+    }
+
+    g_auto(GStrv) cats = g_strsplit(categories, ",", 0);
+
+    result = as_pool_get_components_by_categories (dpool, cats);
+    if (result->len == 0) {
+        /* TRANSLATORS: We failed to find any component in the database, likely due to an error */
+        ascli_print_stderr (_("Unable to find components matching %s!"), categories);
+        return 4;
+    }
+
+    if (result->len == 0) {
+        /* TRANSLATORS: We got no full-text search results */
+        ascli_print_stdout (_("No component matching '%s' categories found."), categories);
+        return 0;
+    }
+
+    /* show the result */
+    ascli_print_components (result, detailed);
+
+    return 0;
+}
+
+/**
  * ascli_dump_component:
  *
  * Dump the raw upstream XML for a component.

--- a/tools/ascli-actions-mdata.h
+++ b/tools/ascli-actions-mdata.h
@@ -66,6 +66,10 @@ int		ascli_create_metainfo_template (const gchar *out_fname,
 						const gchar *cpt_kind_str,
 						const gchar *desktop_file);
 
+int		ascli_by_categories (const gchar *cachepath,
+				     const gchar *categories,
+				     gboolean detailed,
+				     gboolean no_cache);
 
 G_END_DECLS
 


### PR DESCRIPTION
Allows the command line interface to be used to list available components for certain categories.