### PR TITLE
Improve Screenshot validation

### DIFF
--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -206,7 +206,7 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 
 	{ "screenshot-invalid-width",
 	  AS_ISSUE_SEVERITY_ERROR,
-	  N_("The width property must be a integer")
+	  N_("The width property must be a positive integer")
 	},
 
 	{ "screenshot-invalid-height",
@@ -216,27 +216,27 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 
 	{ "screenshot-image-invalid-type",
 	  AS_ISSUE_SEVERITY_ERROR,
-	  N_("The type of the image is neither source or thumbnail")
+	  N_("The type of the image is neither `source` or `thumbnail`")
 	},
 
 	{ "screenshot-image-missing-width",
-	  AS_ISSUE_SEVERITY_ERROR,
-	  N_("The width property must be present if the type is thumbnail")
+	  AS_ISSUE_SEVERITY_WARNING,
+	  N_("The `width` property must be present if the type is `thumbnail`")
 	},
 
 	{ "screenshot-image-missing-height",
-	  AS_ISSUE_SEVERITY_ERROR,
-	  N_("The height property must be present if the type is thumbnail")
+	  AS_ISSUE_SEVERITY_WARNING,
+	  N_("The `height` property must be present if the type is thumbnail")
 	},
 
 	{ "screenshot-image-source-duplicated",
 	  AS_ISSUE_SEVERITY_ERROR,
-	  N_("The source type can only be used once for a image and a language")
+	  N_("The 'source' type can only be used once for a image and a language")
 	},
 
 	{ "screenshot-image-source-missing",
 	  AS_ISSUE_SEVERITY_ERROR,
-	  N_("A screenshot must have at leat one image with the source type")
+	  N_("A screenshot must have at least one image of type `source`")
 	},
 
 	{ "screenshot-image-not-found",
@@ -310,7 +310,7 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 
 	{ "screenshot-default-missing",
 	  AS_ISSUE_SEVERITY_ERROR,
-	  N_("There is no defualt screenshot")
+	  N_("A default screenshot is missing.")
 	},
 
 	{ "relation-invalid-tag",

--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -204,6 +204,41 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	  N_("The update-contact does not appear to be a valid email address (escaping of `@` is only allowed as `_at_` or `_AT_`).")
 	},
 
+	{ "screenshot-invalid-width",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("The width property must be a integer")
+	},
+
+	{ "screenshot-invalid-height",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("The width property must be a integer")
+	},
+
+	{ "screenshot-image-invalid-type",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("The type of the image is neither source or thumbnail")
+	},
+
+	{ "screenshot-image-missing-width",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("The width property must be present if the type is thumbnail")
+	},
+
+	{ "screenshot-image-missing-height",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("The height property must be present if the type is thumbnail")
+	},
+
+	{ "screenshot-image-source-duplicated",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("The source type can only be used once for a image and a language")
+	},
+
+	{ "screenshot-image-source-missing",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("A screenshot must have at leat one image with the source type")
+	},
+
 	{ "screenshot-image-not-found",
 	  AS_ISSUE_SEVERITY_WARNING,
 	  N_("Unable to reach the screenshot image on its remote location - does the image exist?")
@@ -271,6 +306,11 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	{ "screenshot-default-contains-video",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  N_("The default screenshot of a software component must not be a video. Use a static image as default screenshot and set the video as a secondary screenshot.")
+	},
+
+	{ "screenshot-default-missing",
+	  AS_ISSUE_SEVERITY_ERROR,
+	  N_("There is no defualt screenshot")
 	},
 
 	{ "relation-invalid-tag",

--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -1245,7 +1245,7 @@ as_validator_check_screenshots (AsValidator *validator, xmlNode *node, AsCompone
 			continue;
 
 		scr_kind_str = as_xml_get_prop_value (iter, "type");
-		if (g_strcmp0 (scr_kind_str, "default") == 0) {
+		if (as_screenshot_kind_from_string (scr_kind_str) == AS_SCREENSHOT_KIND_DEFAULT) {
 			default_screenshot_found = TRUE;
 			default_screenshot = TRUE;
 		}
@@ -1260,12 +1260,13 @@ as_validator_check_screenshots (AsValidator *validator, xmlNode *node, AsCompone
 		}
 
 		for (iter2 = iter->children; iter2 != NULL; iter2 = iter2->next) {
+			g_autofree gchar *screenshot_width = NULL;
+			g_autofree gchar *screenshot_height = NULL;
+			
 			const gchar *node_name = (const gchar*) iter2->name;
 			if (iter2->type != XML_ELEMENT_NODE)
 				continue;
 
-			g_autofree gchar *screenshot_width = NULL;
-			g_autofree gchar *screenshot_height = NULL;
 
 			screenshot_width = as_xml_get_prop_value (iter2, "width");
 			if (screenshot_width != NULL && !as_str_verify_integer (screenshot_width, 1, G_MAXINT64))


### PR DESCRIPTION
I added the following checks:

- At least one Screenshot must be a default
- Width and Height must be Integers
- `source` and `thumbnail` are the only allowed values for a Image type
- If a Image type is  `thumbnail`, it must have 'width' and 'height'
- Only one Image with type `source` per language is allowed for each Screenshot
- If a Screenshot is a Image, it must contain a source Image