### PR TITLE
pool: Offer API to look up by bundles

### DIFF
--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -175,6 +175,14 @@ QList<Component> Pool::componentsByExtends(const QString &extendedId) const
                                                              qPrintable(extendedId)));
 }
 
+QList<Component> Pool::componentsByBundleId(Bundle::Kind kind, const QString &extendedId, bool matchPrefix) const
+{
+    return cptArrayToQList(as_pool_get_components_by_bundle_id(d->pool,
+                                                               static_cast<AsBundleKind>(kind),
+                                                               qPrintable(extendedId),
+                                                               matchPrefix));
+}
+
 QList<AppStream::Component> Pool::search(const QString& term) const
 {
     return cptArrayToQList(as_pool_search(d->pool, qPrintable(term)));

--- a/qt/pool.h
+++ b/qt/pool.h
@@ -134,6 +134,8 @@ public:
 
     QList<AppStream::Component> componentsByExtends(const QString& extendedId) const;
 
+    QList<AppStream::Component> componentsByBundleId(Bundle::Kind kind, const QString& bundleId, bool matchPrefix) const;
+
     QList<AppStream::Component> search(const QString& term) const;
 
 

--- a/src/as-cache.c
+++ b/src/as-cache.c
@@ -1812,6 +1812,36 @@ as_cache_get_components_by_launchable (AsCache *cache, AsLaunchableKind kind, co
 					  error);
 }
 
+/**
+ * as_cache_get_components_by_bundle_id:
+ * @cache: An instance of #AsCache.
+ * @kind: Type of the bundle.
+ * @id: ID of the bundle.
+ * @error: A #GError or %NULL.
+ *
+ * Get components which are provided by a bundle with the given kind and ID.
+ *
+ * Returns: (transfer full): An array of #AsComponent
+ */
+
+GPtrArray*
+as_cache_get_components_by_bundle_id (AsCache *cache, AsBundleKind kind, const gchar *id, gboolean match_prefix, GError **error)
+{
+	g_auto(XbQueryContext) context = XB_QUERY_CONTEXT_INIT ();
+	g_autofree gchar *xpath = NULL;
+	const char *match = match_prefix ? "components/component/bundle[@type='%s'][starts-with(text(), ?)]/.."
+					 : "components/component/bundle[@type='%s'][text()=?]/..";
+	xb_value_bindings_bind_str (xb_query_context_get_bindings (&context),
+				    0, id, NULL);
+	xpath = g_strdup_printf (match, as_bundle_kind_to_string (kind));
+	return as_cache_query_components (cache,
+					  xpath,
+					  &context,
+					  0,
+					  FALSE,
+					  error);
+}
+
 typedef struct {
 	AsSearchTokenMatch	match_value;
 	XbQuery			*query;

--- a/src/as-cache.h
+++ b/src/as-cache.h
@@ -182,6 +182,12 @@ GPtrArray		*as_cache_get_components_by_launchable (AsCache *cache,
 								const gchar *id,
 								GError **error);
 
+GPtrArray		*as_cache_get_components_by_bundle_id (AsCache *cache,
+								AsBundleKind kind,
+								const gchar *id,
+								gboolean match_prefix,
+								GError **error);
+
 GPtrArray		*as_cache_search (AsCache *cache,
 					  const gchar * const *terms,
 					  gboolean sort,

--- a/src/as-pool.c
+++ b/src/as-pool.c
@@ -2213,6 +2213,37 @@ as_pool_get_components_by_extends (AsPool *pool, const gchar *extended_id)
 }
 
 /**
+ * as_pool_get_components_by_bundle_id: (skip)
+ * @pool: An instance of #AsPool.
+ * @kind: The kind of the bundle we are looking for
+ * @bundle_id: The bundle ID to match, as specified in #AsBundle
+ * @match_prefix: If the provided bundle id is the prefix or it needs to match exactly
+ *
+ * Find components that are provided by a bundle with a specific ID by its prefix.
+ * For example, given a AS_BUNDLE_KIND_FLATPAK and a bundle_id "org.kde.dolphin/",
+ * it will list all the components that bundle dolphin. If the bundle_id is
+ * "org.kde.dolphin/x86_64" it will give those with also the architecture.
+ *
+ * Since: 0.16.0
+ */
+GPtrArray*
+as_pool_get_components_by_bundle_id (AsPool *pool, AsBundleKind kind, const gchar *bundle_id, gboolean match_prefix)
+{
+	AsPoolPrivate *priv = GET_PRIVATE (pool);
+	g_autoptr(GError) tmp_error = NULL;
+	GPtrArray *result = NULL;
+	g_autoptr(GRWLockReaderLocker) locker = g_rw_lock_reader_locker_new (&priv->rw_lock);
+
+	result = as_cache_get_components_by_bundle_id (priv->cache, kind, bundle_id, match_prefix, &tmp_error);
+	if (result == NULL) {
+		g_warning ("Unable find components by bundle ID in session cache: %s", tmp_error->message);
+		return g_ptr_array_new_with_free_func (g_object_unref);
+	}
+
+	return result;
+}
+
+/**
  * as_pool_get_components_by_extends_gir: (rename-to as_pool_get_components_by_extends)
  * @pool: An instance of #AsPool.
  * @extended_id: The ID of the component to search extensions for.

--- a/src/as-pool.h
+++ b/src/as-pool.h
@@ -156,6 +156,10 @@ GPtrArray		*as_pool_get_components_by_launchable (AsPool *pool,
 							       const gchar *id);
 GPtrArray		*as_pool_get_components_by_extends (AsPool *pool,
 							       const gchar *extended_id);
+GPtrArray		*as_pool_get_components_by_bundle_id (AsPool *pool,
+							      AsBundleKind kind,
+							      const gchar *bundle_id,
+							      gboolean match_prefix);
 GPtrArray		*as_pool_search (AsPool *pool,
 					 const gchar *search);
 gchar			**as_pool_build_search_tokens (AsPool *pool,


### PR DESCRIPTION
It's often that we will need to look up packages by their name. Include some API that helps us do it.

WIP because it would be necessary to look up by e.g. `org.kde.dolphin` too, not just `org.kde.dolphin/x86_64/master`. Some idea on how to do this would be useful.

Context for this change is here:
https://invent.kde.org/plasma/discover/-/merge_requests/455
