### PR TITLE
Add API for asking whether the pool is empty

### DIFF
--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -249,6 +249,11 @@ bool Pool::addComponent(const AppStream::Component& cpt)
     return addComponents(cpts);
 }
 
+bool AppStream::Pool::isEmpty() const
+{
+    return as_pool_is_empty(d->pool);
+}
+
 uint Pool::cacheFlags() const
 {
 #pragma GCC diagnostic push

--- a/qt/pool.h
+++ b/qt/pool.h
@@ -159,6 +159,8 @@ public:
     void overrideCacheLocations(const QString &sysDir,
                                 const QString &userDir);
 
+    bool isEmpty() const;
+
     Q_DECL_DEPRECATED bool addComponent(const AppStream::Component& cpt);
 
     Q_DECL_DEPRECATED uint cacheFlags() const;

--- a/src/as-cache.c
+++ b/src/as-cache.c
@@ -1995,3 +1995,16 @@ as_cache_search (AsCache *cache, const gchar * const *terms, gboolean sort, GErr
 
 	return g_steal_pointer (&results);
 }
+
+guint
+as_cache_get_component_count (AsCache* cache)
+{
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GPtrArray) components = as_cache_query_components (cache,
+					  "components/component",
+					  NULL,
+					  0,
+					  FALSE,
+					  &error);
+	return components->len;
+}

--- a/src/as-cache.h
+++ b/src/as-cache.h
@@ -193,6 +193,8 @@ GPtrArray		*as_cache_search (AsCache *cache,
 					  gboolean sort,
 					  GError **error);
 
+guint			as_cache_get_component_count (AsCache *cache);
+
 G_END_DECLS
 
 #endif /* __AS_CACHE_H */

--- a/src/as-pool.c
+++ b/src/as-pool.c
@@ -2888,6 +2888,13 @@ as_pool_set_load_std_data_locations (AsPool *pool, gboolean enabled)
 	}
 }
 
+gboolean
+as_pool_is_empty (AsPool* pool)
+{
+	AsPoolPrivate *priv = GET_PRIVATE (pool);
+	return as_cache_get_component_count (priv->cache) == 0;
+}
+
 /**
  * as_pool_get_os_metadata_cache_age:
  * @pool: An instance of #AsPool.

--- a/src/as-pool.h
+++ b/src/as-pool.h
@@ -181,6 +181,8 @@ void			as_pool_remove_flags (AsPool *pool,
 void			as_pool_set_load_std_data_locations (AsPool *pool,
 							     gboolean enabled);
 
+gboolean		as_pool_is_empty (AsPool *pool);
+
 /* DEPRECATED */
 
 gboolean		as_pool_add_component (AsPool *pool,

--- a/tests/test-pool.c
+++ b/tests/test-pool.c
@@ -486,6 +486,8 @@ test_pool_read (void)
 	cpt_s = AS_COMPONENT (g_ptr_array_index (result, 0));
 	g_assert_cmpstr (as_component_get_id (cpt_s), ==, "org.inkscape.Inkscape");
 	g_clear_pointer (&result, g_ptr_array_unref);
+
+	g_assert_false (as_pool_is_empty (dpool));
 }
 
 /**


### PR DESCRIPTION
On certain systems a refresh is necessary in such cases and, in any case, it's useful to know whether queries are pointless.

---

I wonder if it would make sense to be more specific about what we are looking up, since I guess it could be getting confused by fwupd or flatpak...