### PR TITLE
brackets in spdx license expression rejected by as_is_spdx_license_expression

### DIFF
--- a/src/as-spdx.c
+++ b/src/as-spdx.c
@@ -264,6 +264,10 @@ as_is_spdx_license_expression (const gchar *license)
 			continue;
 		if (g_strcmp0 (tokens[i], "+") == 0)
 			continue;
+		if (g_strcmp0 (tokens[i], "(") == 0)
+			continue;
+		if (g_strcmp0 (tokens[i], ")") == 0)
+			continue;
 		if (g_strcmp0 (tokens[i], "^") == 0) {
 			expect_exception = TRUE;
 			continue;

--- a/tests/test-basics.c
+++ b/tests/test-basics.c
@@ -471,6 +471,7 @@ test_spdx (void)
 	g_assert_true (as_license_is_free_license ("CC0"));
 	g_assert_true (as_license_is_free_license ("GPL-2.0 AND FSFAP"));
 	g_assert_true (as_license_is_free_license ("OFL-1.1 OR (GPL-3.0-or-later WITH Font-exception-2.0)"));
+	g_assert_true (as_is_spdx_license_expression("OFL-1.1 OR (GPL-3.0-or-later WITH Font-exception-2.0)"));
 	g_assert_true (!as_license_is_free_license ("NOASSERTION"));
 	g_assert_true (!as_license_is_free_license ("LicenseRef-proprietary=https://example.com/mylicense.txt"));
 	g_assert_true (!as_license_is_free_license ("MIT AND LicenseRef-proprietary=https://example.com/lic.txt"));


### PR DESCRIPTION
something like: "CC0-1.0 AND (BSD-3-Clause OR LGPL-2.1-only)" is reported by appstreamcli check-license as "invalid" and not "Free and Open Source"

$ appstreamcli check-license "CC0-1.0 AND (BSD-3-Clause OR LGPL-2.1-only)" License Type: invalid
Suitable for AppStream metadata: no
Free and Open Source: no

Trying to debug I find that "as_license_is_free_license" accepts this string as valid, but that "as_is_spdx_license_expression" considers it invalid due to the presence of "(" and ")" so it is rejected there and so ascli_check_license goes on to use as_license_to_spdx_id which turns it into "CC0-1.0-1.0 AND (BSD-3-Clause-3-Clause OR LGPL-2.1-only)" ascli_check_license is ok with brackets, but at this point its mangled and understandably fails.

In fedora in practice I see gnome-software designate libreoffice langpacks as "Proprietary Code" when a similar license tag is extracted from the rpm and propogated into appstream.

https://bugs.documentfoundation.org/show_bug.cgi?id=154056