### PR TITLE
Fix agreement example

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -1457,7 +1457,7 @@
 			Example:
 		</para>
 		<programlisting language="XML"><![CDATA[<agreement type="privacy" version_id="1.0">
-    <agreement_section type="introduction">
+    <agreement_section id="introduction">
       <name>Introduction</name>
       <description>
         <p>
@@ -1468,7 +1468,7 @@
       </description>
     </agreement_section>
 
-    <agreement_section type="scope">
+    <agreement_section id="scope">
       <name>Scope</name>
       <description>
         <p>


### PR DESCRIPTION
The doc says, that the property must be named `id`, but the example uses `type`.

btw:
Is agreement actually used? anywhere?