### PR TITLE
Port Qt API to use QAnyStringView

### DIFF
--- a/qt/bundle.cpp
+++ b/qt/bundle.cpp
@@ -125,6 +125,6 @@ bool Bundle::isEmpty() const
 
 QDebug operator<<(QDebug s, const AppStream::Bundle& bundle)
 {
-    s.nospace() << "AppStream::Bundle(" << stringViewToChar(bundle.id()) << ")";
+    s.nospace() << "AppStream::Bundle(" << bundle.id().toString() << ")";
     return s.space();
 }

--- a/qt/bundle.cpp
+++ b/qt/bundle.cpp
@@ -27,14 +27,14 @@
 
 using namespace AppStream;
 
-QString Bundle::kindToString(Bundle::Kind kind)
+QAnyStringView Bundle::kindToString(Bundle::Kind kind)
 {
     return as_bundle_kind_to_string((AsBundleKind) kind);
 }
 
-Bundle::Kind Bundle::stringToKind(const QString& kindString)
+Bundle::Kind Bundle::stringToKind(const QAnyStringView& kindString)
 {
-    return Bundle::Kind(as_bundle_kind_from_string(qPrintable(kindString)));
+    return Bundle::Kind(as_bundle_kind_from_string(stringViewToChar(kindString)));
 }
 
 class AppStream::BundleData : public QSharedData {
@@ -108,14 +108,14 @@ void Bundle::setKind(Kind kind)
     as_bundle_set_kind(d->m_bundle, (AsBundleKind) kind);
 }
 
-QString Bundle::id() const
+QAnyStringView Bundle::id() const
 {
     return valueWrap(as_bundle_get_id(d->m_bundle));
 }
 
-void Bundle::setId(const QString& id)
+void Bundle::setId(const QAnyStringView& id)
 {
-    as_bundle_set_id(d->m_bundle, qPrintable(id));
+    as_bundle_set_id(d->m_bundle, stringViewToChar(id));
 }
 
 bool Bundle::isEmpty() const
@@ -125,6 +125,6 @@ bool Bundle::isEmpty() const
 
 QDebug operator<<(QDebug s, const AppStream::Bundle& bundle)
 {
-    s.nospace() << "AppStream::Bundle(" << bundle.id() << ")";
+    s.nospace() << "AppStream::Bundle(" << stringViewToChar(bundle.id()) << ")";
     return s.space();
 }

--- a/qt/bundle.h
+++ b/qt/bundle.h
@@ -21,7 +21,7 @@
 #define APPSTREAMQT_BUNDLE_H
 
 #include <QSharedDataPointer>
-#include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include "appstreamqt_export.h"
 
@@ -57,8 +57,8 @@ class APPSTREAMQT_EXPORT Bundle {
         };
         Q_ENUM(Kind)
 
-        static Kind stringToKind(const QString& kindString);
-        static QString kindToString(Kind kind);
+        static Kind stringToKind(const QAnyStringView& kindString);
+        static QAnyStringView kindToString(Kind kind);
 
         /**
          * \return the bundle kind.
@@ -69,8 +69,8 @@ class APPSTREAMQT_EXPORT Bundle {
         /**
          * \return the bundle ID.
          */
-        QString id() const;
-        void setId(const QString& id);
+        QAnyStringView id() const;
+        void setId(const QAnyStringView& id);
 
         bool isEmpty() const;
 

--- a/qt/category.cpp
+++ b/qt/category.cpp
@@ -76,22 +76,22 @@ _AsCategory * AppStream::Category::asCategory() const
     return d->category();
 }
 
-QString Category::id() const
+QAnyStringView Category::id() const
 {
     return valueWrap(as_category_get_id(d->m_category));
 }
 
-QString Category::name() const
+QAnyStringView Category::name() const
 {
     return valueWrap(as_category_get_name(d->m_category));
 }
 
-QString Category::summary() const
+QAnyStringView Category::summary() const
 {
     return valueWrap(as_category_get_summary(d->m_category));
 }
 
-QString Category::icon() const
+QAnyStringView Category::icon() const
 {
     return valueWrap(as_category_get_icon(d->m_category));
 }
@@ -108,10 +108,10 @@ QList<Category> Category::children() const
     return ret;
 }
 
-QStringList Category::desktopGroups() const
+QList<QAnyStringView> Category::desktopGroups() const
 {
     auto dgs = as_category_get_desktop_groups(d->m_category);
-    QStringList ret;
+    QList<QAnyStringView> ret;
     ret.reserve(dgs->len);
     for(uint i = 0; i < dgs->len; i++) {
         auto dg = (const gchar*) g_ptr_array_index (dgs, i);
@@ -122,7 +122,7 @@ QStringList Category::desktopGroups() const
 
 QDebug operator<<(QDebug s, const AppStream::Category& category)
 {
-    s.nospace() << "AppStream::Category(" << category.id() << ")";
+    s.nospace() << "AppStream::Category(" << stringViewToChar(category.id()) << ")";
     return s.space();
 }
 

--- a/qt/category.cpp
+++ b/qt/category.cpp
@@ -122,7 +122,7 @@ QList<QAnyStringView> Category::desktopGroups() const
 
 QDebug operator<<(QDebug s, const AppStream::Category& category)
 {
-    s.nospace() << "AppStream::Category(" << stringViewToChar(category.id()) << ")";
+    s.nospace() << "AppStream::Category(" << category.id().toString() << ")";
     return s.space();
 }
 

--- a/qt/category.h
+++ b/qt/category.h
@@ -22,6 +22,7 @@
 
 #include <QSharedDataPointer>
 #include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include "appstreamqt_export.h"
 
@@ -46,13 +47,13 @@ class APPSTREAMQT_EXPORT Category {
          */
         _AsCategory *asCategory() const;
 
-        QString id() const;
-        QString name() const;
-        QString summary() const;
-        QString icon() const;
+        QAnyStringView id() const;
+        QAnyStringView name() const;
+        QAnyStringView summary() const;
+        QAnyStringView icon() const;
 
         QList<Category> children() const;
-        QStringList desktopGroups() const;
+        QList<QAnyStringView> desktopGroups() const;
 
     private:
         QSharedDataPointer<CategoryData> d;

--- a/qt/chelpers.h
+++ b/qt/chelpers.h
@@ -20,68 +20,78 @@
 #ifndef APPSTREAMQT_CHELPERS_H
 #define APPSTREAMQT_CHELPERS_H
 
+#include "qanystringview.h"
+#include "qglobal.h"
 #include <glib.h>
 #include <QStringList>
+#include <QAnyStringView>
 
 namespace AppStream {
 
-inline QString valueWrap(const gchar *cstr)
+inline QAnyStringView valueWrap(const gchar *cstr)
 {
-    return QString::fromUtf8(cstr);
+    return QAnyStringView(cstr);
 }
 
-inline QStringList valueWrap(gchar **strv)
+inline QList<QAnyStringView> valueWrap(gchar **strv)
 {
-    QStringList res;
+    QList<QAnyStringView> res;
     if (strv == NULL)
         return res;
     for (uint i = 0; strv[i] != NULL; i++) {
-        res.append (QString::fromUtf8(strv[i]));
+        res.append (QAnyStringView(strv[i]));
     }
     return res;
 }
 
-inline QStringList valueWrap(const gchar **strv)
+inline QList<QAnyStringView> valueWrap(const gchar **strv)
 {
-    QStringList res;
+    QList<QAnyStringView> res;
     if (strv == NULL)
         return res;
     for (uint i = 0; strv[i] != NULL; i++) {
-        res.append (QString::fromUtf8(strv[i]));
+        res.append (QAnyStringView(strv[i]));
     }
     return res;
 }
 
-inline QStringList valueWrap(GPtrArray *array)
+inline QList<QAnyStringView> valueWrap(GPtrArray *array)
 {
-    QStringList res;
+    QList<QAnyStringView> res;
     res.reserve(array->len);
     for (uint i = 0; i < array->len; i++) {
         auto strval = (const gchar*) g_ptr_array_index (array, i);
-        res.append (QString::fromUtf8(strval));
+        res.append (QAnyStringView(strval));
     }
     return res;
 }
 
-inline QStringList valueWrap(GList *list)
+inline QList<QAnyStringView> valueWrap(GList *list)
 {
     GList *l;
-    QStringList res;
+    QList<QAnyStringView> res;
     res.reserve(g_list_length(list));
     for (l = list; l != NULL; l = l->next) {
         auto strval = (const gchar*) l->data;
-        res.append (QString::fromUtf8(strval));
+        res.append (QAnyStringView(strval));
     }
     return res;
 }
 
-inline char ** stringListToCharArray(const QStringList& list)
+inline const char* stringViewToChar(QAnyStringView str) {
+    QByteArray bytes = QByteArray();
+    bytes.resize(str.size_bytes() + 1);
+    bytes.append((char*)str.data(), str.size_bytes());
+    bytes.append('\0');
+    return bytes.constData();
+}
+
+inline char ** stringListToCharArray(QList<QAnyStringView> list)
 {
     char **array = (char**) g_malloc(sizeof(char*) * list.size() + 1);
     for (int i = 0; i < list.size(); ++i) {
-        const QByteArray string = list[i].toLocal8Bit();
-        array[i] = (char*) g_malloc(sizeof(char) * (string.size() + 1));
-        strcpy(array[i], string.constData());
+        array[i] = (char*) g_malloc(sizeof(char) * (list[i].size_bytes() + 1));
+        strcpy(array[i], stringViewToChar(list[i]));
     }
     array[list.size()] = nullptr;
     return array;

--- a/qt/chelpers.h
+++ b/qt/chelpers.h
@@ -78,13 +78,22 @@ inline QList<QAnyStringView> valueWrap(GList *list)
     return res;
 }
 
-inline const char* stringViewToChar(QAnyStringView str) {
+inline QByteArray stringViewToBytes(QAnyStringView str) {
+    if(str.isNull()) {
+        return nullptr;
+    }
     QByteArray bytes = QByteArray();
-    bytes.resize(str.size_bytes() + 1);
+    bytes.reserve(str.size_bytes() + 1);
     bytes.append((char*)str.data(), str.size_bytes());
     bytes.append('\0');
-    return bytes.constData();
+    return bytes;
 }
+
+// This needs to be a macro otherwise the QByteArray we used will
+// be freed before we are done with its data
+#ifndef stringViewToChar
+#define stringViewToChar(STR) (stringViewToBytes(STR).constData())
+#endif
 
 inline char ** stringListToCharArray(QList<QAnyStringView> list)
 {

--- a/qt/chelpers.h
+++ b/qt/chelpers.h
@@ -82,10 +82,7 @@ inline QByteArray stringViewToBytes(QAnyStringView str) {
     if(str.isNull()) {
         return QByteArray();
     }
-    QByteArray bytes = QByteArray();
-    bytes.reserve(str.size_bytes() + 1);
-    bytes.append((char*)str.data(), str.size_bytes());
-    bytes.append('\0');
+    QByteArray bytes = QByteArray((char*)str.data(), str.size_bytes());
     return bytes;
 }
 

--- a/qt/chelpers.h
+++ b/qt/chelpers.h
@@ -80,7 +80,7 @@ inline QList<QAnyStringView> valueWrap(GList *list)
 
 inline QByteArray stringViewToBytes(QAnyStringView str) {
     if(str.isNull()) {
-        return nullptr;
+        return QByteArray();
     }
     QByteArray bytes = QByteArray();
     bytes.reserve(str.size_bytes() + 1);

--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -38,37 +38,37 @@
 
 using namespace AppStream;
 
-QString Component::kindToString(Component::Kind kind)
+QAnyStringView Component::kindToString(Component::Kind kind)
 {
-    return QString::fromUtf8(as_component_kind_to_string(static_cast<AsComponentKind>(kind)));
+    return valueWrap(as_component_kind_to_string(static_cast<AsComponentKind>(kind)));
 }
 
-Component::Kind Component::stringToKind(const QString& kindString)
+Component::Kind Component::stringToKind(QAnyStringView kindString)
 {
     if(kindString.isEmpty()) {
         return KindGeneric;
     }
-    return static_cast<Component::Kind>(as_component_kind_from_string(qPrintable(kindString)));
+    return static_cast<Component::Kind>(as_component_kind_from_string(stringViewToChar(kindString)));
 }
 
-QString Component::urlKindToString(Component::UrlKind kind)
+QAnyStringView Component::urlKindToString(Component::UrlKind kind)
 {
-    return QString::fromUtf8(as_url_kind_to_string(static_cast<AsUrlKind>(kind)));
+    return valueWrap(as_url_kind_to_string(static_cast<AsUrlKind>(kind)));
 }
 
-Component::UrlKind Component::stringToUrlKind(const QString& urlKindString)
+Component::UrlKind Component::stringToUrlKind(QAnyStringView urlKindString)
 {
-    return static_cast<Component::UrlKind>(as_url_kind_from_string(qPrintable(urlKindString)));
+    return static_cast<Component::UrlKind>(as_url_kind_from_string(stringViewToChar(urlKindString)));
 }
 
-QString Component::scopeToString(Component::Scope scope)
+QAnyStringView Component::scopeToString(Component::Scope scope)
 {
-    return QString::fromUtf8(as_component_scope_to_string(static_cast<AsComponentScope>(scope)));
+    return valueWrap(as_component_scope_to_string(static_cast<AsComponentScope>(scope)));
 }
 
-Component::Scope Component::stringToScope(const QString& scopeString)
+Component::Scope Component::stringToScope(QAnyStringView scopeString)
 {
-    return static_cast<Component::Scope>(as_component_scope_from_string(qPrintable(scopeString)));
+    return static_cast<Component::Scope>(as_component_scope_from_string(stringViewToChar(scopeString)));
 }
 
 Component::Component(const Component& other)
@@ -123,14 +123,14 @@ void AppStream::Component::setValueFlags(uint flags)
     as_component_set_value_flags(m_cpt, (AsValueFlags) flags);
 }
 
-QString AppStream::Component::activeLocale() const
+QAnyStringView AppStream::Component::activeLocale() const
 {
     return valueWrap(as_component_get_active_locale(m_cpt));
 }
 
-void AppStream::Component::setActiveLocale(const QString& locale)
+void AppStream::Component::setActiveLocale(QAnyStringView locale)
 {
-    as_component_set_active_locale(m_cpt, qPrintable(locale));
+    as_component_set_active_locale(m_cpt, stringViewToChar(locale));
 }
 
 Component::Kind Component::kind() const
@@ -143,34 +143,34 @@ void Component::setKind(Component::Kind kind)
     as_component_set_kind(m_cpt, static_cast<AsComponentKind>(kind));
 }
 
-QString AppStream::Component::origin() const
+QAnyStringView AppStream::Component::origin() const
 {
     return valueWrap(as_component_get_origin(m_cpt));
 }
 
-void AppStream::Component::setOrigin(const QString& origin)
+void AppStream::Component::setOrigin(QAnyStringView origin)
 {
-    as_component_set_origin(m_cpt, qPrintable(origin));
+    as_component_set_origin(m_cpt, stringViewToChar(origin));
 }
 
-QString Component::id() const
+QAnyStringView Component::id() const
 {
     return valueWrap(as_component_get_id(m_cpt));
 }
 
-void Component::setId(const QString& id)
+void Component::setId(QAnyStringView id)
 {
-    as_component_set_id(m_cpt, qPrintable(id));
+    as_component_set_id(m_cpt, stringViewToChar(id));
 }
 
-QString Component::dataId() const
+QAnyStringView Component::dataId() const
 {
     return valueWrap(as_component_get_data_id(m_cpt));
 }
 
-void Component::setDataId(const QString& cdid)
+void Component::setDataId(QAnyStringView cdid)
 {
-    as_component_set_data_id(m_cpt, qPrintable(cdid));
+    as_component_set_data_id(m_cpt, stringViewToChar(cdid));
 }
 
 Component::Scope Component::scope() const
@@ -183,56 +183,56 @@ void Component::setScope(Component::Scope scope)
     as_component_set_scope(m_cpt, static_cast<AsComponentScope>(scope));
 }
 
-QStringList Component::packageNames() const
+QList<QAnyStringView> Component::packageNames() const
 {
     return valueWrap(as_component_get_pkgnames(m_cpt));
 }
 
-void AppStream::Component::setPackageNames(const QStringList& list)
+void AppStream::Component::setPackageNames(QList<QAnyStringView> list)
 {
     char **packageList = stringListToCharArray(list);
     as_component_set_pkgnames(m_cpt, packageList);
     g_strfreev(packageList);
 }
 
-QString AppStream::Component::sourcePackageName() const
+QAnyStringView AppStream::Component::sourcePackageName() const
 {
     return valueWrap(as_component_get_source_pkgname(m_cpt));
 }
 
-void AppStream::Component::setSourcePackageName(const QString& sourcePkg)
+void AppStream::Component::setSourcePackageName(QAnyStringView sourcePkg)
 {
-    as_component_set_source_pkgname(m_cpt, qPrintable(sourcePkg));
+    as_component_set_source_pkgname(m_cpt, stringViewToChar(sourcePkg));
 }
 
-QString Component::name() const
+QAnyStringView Component::name() const
 {
     return valueWrap(as_component_get_name(m_cpt));
 }
 
-void Component::setName(const QString& name, const QString& lang)
+void Component::setName(QAnyStringView name, QAnyStringView lang)
 {
-    as_component_set_name(m_cpt, qPrintable(name), lang.isEmpty()? NULL : qPrintable(lang));
+    as_component_set_name(m_cpt, stringViewToChar(name), lang.isEmpty()? NULL : stringViewToChar(lang));
 }
 
-QString Component::summary() const
+QAnyStringView Component::summary() const
 {
     return valueWrap(as_component_get_summary(m_cpt));
 }
 
-void Component::setSummary(const QString& summary, const QString& lang)
+void Component::setSummary(QAnyStringView summary, QAnyStringView lang)
 {
-    as_component_set_summary(m_cpt, qPrintable(summary), lang.isEmpty()? NULL : qPrintable(lang));
+    as_component_set_summary(m_cpt, stringViewToChar(summary), lang.isEmpty()? NULL : stringViewToChar(lang));
 }
 
-QString Component::description() const
+QAnyStringView Component::description() const
 {
     return valueWrap(as_component_get_description(m_cpt));
 }
 
-void Component::setDescription(const QString& description, const QString& lang)
+void Component::setDescription(QAnyStringView description, QAnyStringView lang)
 {
-    as_component_set_description(m_cpt, qPrintable(description), lang.isEmpty()? NULL : qPrintable(lang));
+    as_component_set_description(m_cpt, stringViewToChar(description), lang.isEmpty()? NULL : stringViewToChar(lang));
 }
 
 AppStream::Launchable AppStream::Component::launchable(AppStream::Launchable::Kind kind) const
@@ -248,74 +248,74 @@ void AppStream::Component::addLaunchable(const AppStream::Launchable& launchable
     as_component_add_launchable(m_cpt, launchable.asLaunchable());
 }
 
-QString AppStream::Component::metadataLicense() const
+QAnyStringView AppStream::Component::metadataLicense() const
 {
     return valueWrap(as_component_get_metadata_license(m_cpt));
 }
 
-void AppStream::Component::setMetadataLicense(const QString& license)
+void AppStream::Component::setMetadataLicense(QAnyStringView license)
 {
-    as_component_set_metadata_license(m_cpt, qPrintable(license));
+    as_component_set_metadata_license(m_cpt, stringViewToChar(license));
 }
 
-QString Component::projectLicense() const
+QAnyStringView Component::projectLicense() const
 {
     return valueWrap(as_component_get_project_license(m_cpt));
 }
 
-void Component::setProjectLicense(const QString& license)
+void Component::setProjectLicense(QAnyStringView license)
 {
-    as_component_set_project_license(m_cpt, qPrintable(license));
+    as_component_set_project_license(m_cpt, stringViewToChar(license));
 }
 
-QString Component::projectGroup() const
+QAnyStringView Component::projectGroup() const
 {
     return valueWrap(as_component_get_project_group(m_cpt));
 }
 
-void Component::setProjectGroup(const QString& group)
+void Component::setProjectGroup(QAnyStringView group)
 {
-    as_component_set_project_group(m_cpt, qPrintable(group));
+    as_component_set_project_group(m_cpt, stringViewToChar(group));
 }
 
-QString Component::developerName() const
+QAnyStringView Component::developerName() const
 {
     return valueWrap(as_component_get_developer_name(m_cpt));
 }
 
-void Component::setDeveloperName(const QString& developerName, const QString& lang)
+void Component::setDeveloperName(QAnyStringView developerName, QAnyStringView lang)
 {
-    as_component_set_developer_name(m_cpt, qPrintable(developerName), lang.isEmpty()? NULL : qPrintable(lang));
+    as_component_set_developer_name(m_cpt, stringViewToChar(developerName), lang.isEmpty()? NULL : stringViewToChar(lang));
 }
 
-QStringList Component::compulsoryForDesktops() const
+QList<QAnyStringView> Component::compulsoryForDesktops() const
 {
     return valueWrap(as_component_get_compulsory_for_desktops(m_cpt));
 }
 
-void AppStream::Component::setCompulsoryForDesktop(const QString& desktop)
+void AppStream::Component::setCompulsoryForDesktop(QAnyStringView desktop)
 {
-    as_component_set_compulsory_for_desktop(m_cpt, qPrintable(desktop));
+    as_component_set_compulsory_for_desktop(m_cpt, stringViewToChar(desktop));
 }
 
-bool Component::isCompulsoryForDesktop(const QString& desktop) const
+bool Component::isCompulsoryForDesktop(QAnyStringView desktop) const
 {
-    return as_component_is_compulsory_for_desktop(m_cpt, qPrintable(desktop));
+    return as_component_is_compulsory_for_desktop(m_cpt, stringViewToChar(desktop));
 }
 
-QStringList Component::categories() const
+QList<QAnyStringView> Component::categories() const
 {
     return valueWrap(as_component_get_categories(m_cpt));
 }
 
-void AppStream::Component::addCategory(const QString& category)
+void AppStream::Component::addCategory(QAnyStringView category)
 {
-    as_component_add_category(m_cpt, qPrintable(category));
+    as_component_add_category(m_cpt, stringViewToChar(category));
 }
 
-bool Component::hasCategory(const QString& category) const
+bool Component::hasCategory(QAnyStringView category) const
 {
-    return as_component_has_category(m_cpt, qPrintable(category));
+    return as_component_has_category(m_cpt, stringViewToChar(category));
 }
 
 bool AppStream::Component::isMemberOfCategory(const AppStream::Category& category) const
@@ -323,14 +323,14 @@ bool AppStream::Component::isMemberOfCategory(const AppStream::Category& categor
     return as_component_is_member_of_category(m_cpt, category.asCategory());
 }
 
-QStringList Component::extends() const
+QList<QAnyStringView> Component::extends() const
 {
     return valueWrap(as_component_get_extends(m_cpt));
 }
 
-void AppStream::Component::addExtends(const QString& extend)
+void AppStream::Component::addExtends(QAnyStringView extend)
 {
-    as_component_add_extends(m_cpt, qPrintable(extend));
+    as_component_add_extends(m_cpt, stringViewToChar(extend));
 }
 
 QList<AppStream::Component> Component::addons() const
@@ -351,14 +351,14 @@ void AppStream::Component::addAddon(const AppStream::Component& addon)
     as_component_add_addon(m_cpt, addon.asComponent());
 }
 
-QStringList Component::replaces() const
+QList<QAnyStringView> Component::replaces() const
 {
     return valueWrap(as_component_get_replaces(m_cpt));
 }
 
-void Component::addReplaces(const QString &cid)
+void Component::addReplaces(QAnyStringView cid)
 {
-    as_component_add_replaces(m_cpt, qPrintable(cid));
+    as_component_add_replaces(m_cpt, stringViewToChar(cid));
 }
 
 QList<Relation> Component::requirements() const
@@ -405,19 +405,19 @@ void Component::addRelation(const Relation &relation)
     as_component_add_relation(m_cpt, relation.asRelation());
 }
 
-QStringList AppStream::Component::languages() const
+QList<QAnyStringView> AppStream::Component::languages() const
 {
     return valueWrap(as_component_get_languages(m_cpt));
 }
 
-int AppStream::Component::language(const QString& locale) const
+int AppStream::Component::language(QAnyStringView locale) const
 {
-    return as_component_get_language(m_cpt, qPrintable(locale));
+    return as_component_get_language(m_cpt, stringViewToChar(locale));
 }
 
-void AppStream::Component::addLanguage(const QString& locale, int percentage)
+void AppStream::Component::addLanguage(QAnyStringView locale, int percentage)
 {
-    as_component_add_language(m_cpt, qPrintable(locale), percentage);
+    as_component_add_language(m_cpt, stringViewToChar(locale), percentage);
 }
 
 QList<AppStream::Translation> AppStream::Component::translations() const
@@ -446,9 +446,9 @@ QUrl Component::url(Component::UrlKind kind) const
     return QUrl(url);
 }
 
-void AppStream::Component::addUrl(AppStream::Component::UrlKind kind, const QString& url)
+void AppStream::Component::addUrl(AppStream::Component::UrlKind kind, QAnyStringView url)
 {
-    as_component_add_url(m_cpt, (AsUrlKind) kind, qPrintable(url));
+    as_component_add_url(m_cpt, (AsUrlKind) kind, stringViewToChar(url));
 }
 
 QList<Icon> Component::icons() const
@@ -588,17 +588,17 @@ void AppStream::Component::addSuggested(const AppStream::Suggested& suggested)
     as_component_add_suggested(m_cpt, suggested.suggested());
 }
 
-QStringList AppStream::Component::searchTokens() const
+QList<QAnyStringView> AppStream::Component::searchTokens() const
 {
     return valueWrap(as_component_get_search_tokens(m_cpt));
 }
 
-uint AppStream::Component::searchMatches(const QString& term) const
+uint AppStream::Component::searchMatches(QAnyStringView term) const
 {
-    return as_component_search_matches(m_cpt, qPrintable(term));
+    return as_component_search_matches(m_cpt, stringViewToChar(term));
 }
 
-uint AppStream::Component::searchMatchesAll(const QStringList& terms) const
+uint AppStream::Component::searchMatchesAll(QList<QAnyStringView> terms) const
 {
     char **termList = stringListToCharArray(terms);
     const uint searchMatches = as_component_search_matches_all(m_cpt, termList);
@@ -635,19 +635,19 @@ QHash<QString, QString> AppStream::Component::custom() const
     auto custom = as_component_get_custom(m_cpt);
     g_hash_table_iter_init(&iter, custom);
     while (g_hash_table_iter_next(&iter, &key, &value)) {
-        result.insert(valueWrap(static_cast<char*>(key)), valueWrap(static_cast<char*>(value)));
+        result.insert(QString::fromUtf8(static_cast<char*>(key)), QString::fromUtf8(static_cast<char*>(value)));
     }
     return result;
 }
 
-QString AppStream::Component::customValue(const QString& key)
+QAnyStringView AppStream::Component::customValue(QAnyStringView key)
 {
-    return valueWrap(as_component_get_custom_value(m_cpt, qPrintable(key)));
+    return valueWrap(as_component_get_custom_value(m_cpt, stringViewToChar(key)));
 }
 
-bool AppStream::Component::insertCustomValue(const QString& key, const QString& value)
+bool AppStream::Component::insertCustomValue(QAnyStringView key, QAnyStringView value)
 {
-    return as_component_insert_custom_value(m_cpt, qPrintable(key), qPrintable(value));
+    return as_component_insert_custom_value(m_cpt, stringViewToChar(key), stringViewToChar(value));
 }
 
 QList<AppStream::ContentRating> AppStream::Component::contentRatings() const
@@ -663,9 +663,9 @@ QList<AppStream::ContentRating> AppStream::Component::contentRatings() const
     return res;
 }
 
-AppStream::ContentRating AppStream::Component::contentRating(const QString& kind) const
+AppStream::ContentRating AppStream::Component::contentRating(QAnyStringView kind) const
 {
-    auto rating = as_component_get_content_rating(m_cpt, qPrintable(kind));
+    auto rating = as_component_get_content_rating(m_cpt, stringViewToChar(kind));
     if (rating == NULL)
         return ContentRating();
     return ContentRating(rating);
@@ -676,29 +676,29 @@ void AppStream::Component::addContentRating(const AppStream::ContentRating& cont
     as_component_add_content_rating(m_cpt, contentRating.asContentRating());
 }
 
-QString Component::nameVariantSuffix() const
+QAnyStringView Component::nameVariantSuffix() const
 {
     return valueWrap(as_component_get_name_variant_suffix(m_cpt));
 }
 
-void Component::setNameVariantSuffix(const QString& variantSuffix, const QString& lang)
+void Component::setNameVariantSuffix(QAnyStringView variantSuffix, QAnyStringView lang)
 {
-    as_component_set_name_variant_suffix(m_cpt, qPrintable(variantSuffix), lang.isEmpty()? NULL : qPrintable(lang));
+    as_component_set_name_variant_suffix(m_cpt, stringViewToChar(variantSuffix), lang.isEmpty()? NULL : stringViewToChar(lang));
 }
 
-bool Component::hasTag(const QString &ns, const QString &tagName)
+bool Component::hasTag(QAnyStringView ns, QAnyStringView tagName)
 {
-    return as_component_has_tag(m_cpt, qPrintable(ns), qPrintable(tagName));
+    return as_component_has_tag(m_cpt, stringViewToChar(ns), stringViewToChar(tagName));
 }
 
-bool Component::addTag(const QString &ns, const QString &tagName)
+bool Component::addTag(QAnyStringView ns, QAnyStringView tagName)
 {
-    return as_component_add_tag(m_cpt, qPrintable(ns), qPrintable(tagName));
+    return as_component_add_tag(m_cpt, stringViewToChar(ns), stringViewToChar(tagName));
 }
 
-void Component::removeTag(const QString &ns, const QString &tagName)
+void Component::removeTag(QAnyStringView ns, QAnyStringView tagName)
 {
-    as_component_remove_tag(m_cpt, qPrintable(ns), qPrintable(tagName));
+    as_component_remove_tag(m_cpt, stringViewToChar(ns), stringViewToChar(tagName));
 }
 
 void Component::clearTags()
@@ -721,7 +721,8 @@ bool Component::isValid() const
     return as_component_is_valid(m_cpt);
 }
 
-QString AppStream::Component::toString() const
+QAnyStringView AppStream::Component::toString() const
 {
     return valueWrap(as_component_to_string(m_cpt));
 }
+

--- a/qt/component.h
+++ b/qt/component.h
@@ -23,7 +23,8 @@
 #include <QSharedDataPointer>
 #include <QObject>
 #include <QUrl>
-#include <QStringList>
+#include <QAnyStringView>
+#include <QList>
 #include <QSize>
 #include "appstreamqt_export.h"
 #include "provided.h"
@@ -107,14 +108,14 @@ class APPSTREAMQT_EXPORT Component {
         };
         Q_ENUM(ValueFlags)
 
-        static Kind stringToKind(const QString& kindString);
-        static QString kindToString(Kind kind);
+        static Kind stringToKind(QAnyStringView kindString);
+        static QAnyStringView kindToString(Kind kind);
 
-        static UrlKind stringToUrlKind(const QString& urlKindString);
-        static QString urlKindToString(AppStream::Component::UrlKind kind);
+        static UrlKind stringToUrlKind(QAnyStringView urlKindString);
+        static QAnyStringView urlKindToString(AppStream::Component::UrlKind kind);
 
-        static Scope stringToScope(const QString& scopeString);
-        static QString scopeToString(AppStream::Component::Scope scope);
+        static Scope stringToScope(QAnyStringView scopeString);
+        static QAnyStringView scopeToString(AppStream::Component::Scope scope);
 
         Component(_AsComponent *cpt);
         Component();
@@ -129,87 +130,87 @@ class APPSTREAMQT_EXPORT Component {
         uint valueFlags() const;
         void setValueFlags(uint flags);
 
-        QString activeLocale() const;
-        void setActiveLocale(const QString& locale);
+        QAnyStringView activeLocale() const;
+        void setActiveLocale(QAnyStringView locale);
 
         Kind kind () const;
         void setKind (Component::Kind kind);
 
-        QString origin() const;
-        void setOrigin(const QString& origin);
+        QAnyStringView origin() const;
+        void setOrigin(QAnyStringView origin);
 
-        QString id() const;
-        void setId(const QString& id);
+        QAnyStringView id() const;
+        void setId(QAnyStringView id);
 
-        QString dataId() const;
-        void setDataId(const QString& cdid);
+        QAnyStringView dataId() const;
+        void setDataId(QAnyStringView cdid);
 
         Scope scope () const;
         void setScope (Component::Scope scope);
 
-        QStringList packageNames() const;
-        void setPackageNames(const QStringList& list);
+        QList<QAnyStringView> packageNames() const;
+        void setPackageNames(QList<QAnyStringView> list);
 
-        QString sourcePackageName() const;
-        void setSourcePackageName(const QString& sourcePkg);
+        QAnyStringView sourcePackageName() const;
+        void setSourcePackageName(QAnyStringView sourcePkg);
 
-        QString name() const;
-        void setName(const QString& name, const QString& lang = {});
+        QAnyStringView name() const;
+        void setName(QAnyStringView name, QAnyStringView lang = {});
 
-        QString summary() const;
-        void setSummary(const QString& summary, const QString& lang = {});
+        QAnyStringView summary() const;
+        void setSummary(QAnyStringView summary, QAnyStringView lang = {});
 
-        QString description() const;
-        void setDescription(const QString& description, const QString& lang = {});
+        QAnyStringView description() const;
+        void setDescription(QAnyStringView description, QAnyStringView lang = {});
 
         AppStream::Launchable launchable(AppStream::Launchable::Kind kind) const;
         void addLaunchable(const AppStream::Launchable& launchable);
 
-        QString metadataLicense() const;
-        void setMetadataLicense(const QString& license);
+        QAnyStringView metadataLicense() const;
+        void setMetadataLicense(QAnyStringView license);
 
-        QString projectLicense() const;
-        void setProjectLicense(const QString& license);
+        QAnyStringView projectLicense() const;
+        void setProjectLicense(QAnyStringView license);
 
-        QString projectGroup() const;
-        void setProjectGroup(const QString& group);
+        QAnyStringView projectGroup() const;
+        void setProjectGroup(QAnyStringView group);
 
-        QString developerName() const;
-        void setDeveloperName(const QString& developerName, const QString& lang = {});
+        QAnyStringView developerName() const;
+        void setDeveloperName(QAnyStringView developerName, QAnyStringView lang = {});
 
-        QStringList compulsoryForDesktops() const;
-        void setCompulsoryForDesktop(const QString& desktop);
-        bool isCompulsoryForDesktop(const QString& desktop) const;
+        QList<QAnyStringView> compulsoryForDesktops() const;
+        void setCompulsoryForDesktop(QAnyStringView desktop);
+        bool isCompulsoryForDesktop(QAnyStringView desktop) const;
 
-        QStringList categories() const;
-        void addCategory(const QString& category);
-        bool hasCategory(const QString& category) const;
+        QList<QAnyStringView> categories() const;
+        void addCategory(QAnyStringView category);
+        bool hasCategory(QAnyStringView category) const;
         bool isMemberOfCategory(const AppStream::Category& category) const;
 
-        QStringList extends() const;
-        void setExtends(const QStringList& extends);
-        void addExtends(const QString& extend);
+        QList<QAnyStringView> extends() const;
+        void setExtends(QList<QAnyStringView> extends);
+        void addExtends(QAnyStringView extend);
 
         QList<AppStream::Component> addons() const;
         void addAddon(const AppStream::Component& addon);
 
-        QStringList replaces() const;
-        void addReplaces(const QString& cid);
+        QList<QAnyStringView> replaces() const;
+        void addReplaces(QAnyStringView cid);
 
         QList<AppStream::Relation> requirements() const;
         QList<AppStream::Relation> recommends() const;
         QList<AppStream::Relation> supports() const;
         void addRelation(const AppStream::Relation &relation);
 
-        QStringList languages() const;
-        int language(const QString& locale) const;
-        void addLanguage(const QString& locale, int percentage);
+        QList<QAnyStringView> languages() const;
+        int language(QAnyStringView locale) const;
+        void addLanguage(QAnyStringView locale, int percentage);
 
         QList<AppStream::Translation> translations() const;
         void addTranslation(const AppStream::Translation& translation);
 
         QUrl url(UrlKind kind) const;
-        void addUrl(UrlKind kind, const QString& url);
+        void addUrl(UrlKind kind, QAnyStringView url);
 
         QList<AppStream::Icon> icons() const;
         AppStream::Icon icon(const QSize& size) const;
@@ -241,9 +242,9 @@ class APPSTREAMQT_EXPORT Component {
         QList<AppStream::Suggested> suggested() const;
         void addSuggested(const AppStream::Suggested& suggested);
 
-        QStringList searchTokens() const;
-        uint searchMatches(const QString& term) const;
-        uint searchMatchesAll(const QStringList& terms) const;
+        QList<QAnyStringView> searchTokens() const;
+        uint searchMatches(QAnyStringView term) const;
+        uint searchMatchesAll(QList<QAnyStringView> terms) const;
 
         uint sortScore() const;
         void setSortScore(uint score);
@@ -252,26 +253,26 @@ class APPSTREAMQT_EXPORT Component {
         void setMergeKind(MergeKind kind);
 
         QHash<QString,QString> custom() const;
-        QString customValue(const QString& key);
-        bool insertCustomValue(const QString& key, const QString& value);
+        QAnyStringView customValue(QAnyStringView key);
+        bool insertCustomValue(QAnyStringView key, QAnyStringView value);
 
         QList<AppStream::ContentRating> contentRatings() const;
-        AppStream::ContentRating contentRating(const QString& kind) const;
+        AppStream::ContentRating contentRating(QAnyStringView kind) const;
         void addContentRating(const AppStream::ContentRating& contentRating);
 
-        QString nameVariantSuffix() const;
-        void setNameVariantSuffix(const QString& variantSuffix, const QString& lang = {});
+        QAnyStringView nameVariantSuffix() const;
+        void setNameVariantSuffix(QAnyStringView variantSuffix, QAnyStringView lang = {});
 
-        bool hasTag(const QString &ns, const QString &tagName);
-        bool addTag(const QString &ns, const QString &tagName);
-        void removeTag(const QString &ns, const QString &tagName);
+        bool hasTag(QAnyStringView ns, QAnyStringView tagName);
+        bool addTag(QAnyStringView ns, QAnyStringView tagName);
+        void removeTag(QAnyStringView ns, QAnyStringView tagName);
         void clearTags();
 
         bool isFree() const;
         bool isIgnored() const;
         bool isValid() const;
 
-        QString toString() const;
+        QAnyStringView toString() const;
 
     private:
         _AsComponent *m_cpt;

--- a/qt/contentrating.cpp
+++ b/qt/contentrating.cpp
@@ -56,14 +56,14 @@ public:
     AsContentRating* m_contentRating;
 };
 
-AppStream::ContentRating::RatingValue AppStream::ContentRating::stringToRatingValue(const QString& ratingValue)
+AppStream::ContentRating::RatingValue AppStream::ContentRating::stringToRatingValue(QAnyStringView ratingValue)
 {
-    return static_cast<ContentRating::RatingValue>(as_content_rating_value_from_string(qPrintable(ratingValue)));
+    return static_cast<ContentRating::RatingValue>(as_content_rating_value_from_string(stringViewToChar(ratingValue)));
 }
 
-QString AppStream::ContentRating::ratingValueToString(AppStream::ContentRating::RatingValue ratingValue)
+QAnyStringView AppStream::ContentRating::ratingValueToString(AppStream::ContentRating::RatingValue ratingValue)
 {
-    return QString::fromUtf8(as_content_rating_value_to_string(static_cast<AsContentRatingValue>(ratingValue)));
+    return valueWrap(as_content_rating_value_to_string(static_cast<AsContentRatingValue>(ratingValue)));
 }
 
 ContentRating::ContentRating()
@@ -96,14 +96,14 @@ _AsContentRating * AppStream::ContentRating::asContentRating() const
     return d->contentRating();
 }
 
-QString AppStream::ContentRating::kind() const
+QAnyStringView AppStream::ContentRating::kind() const
 {
     return valueWrap(as_content_rating_get_kind(d->m_contentRating));
 }
 
-void AppStream::ContentRating::setKind(const QString& kind)
+void AppStream::ContentRating::setKind(QAnyStringView kind)
 {
-    as_content_rating_set_kind(d->m_contentRating, qPrintable(kind));
+    as_content_rating_set_kind(d->m_contentRating, stringViewToChar(kind));
 }
 
 uint AppStream::ContentRating::minimumAge() const
@@ -111,28 +111,28 @@ uint AppStream::ContentRating::minimumAge() const
     return as_content_rating_get_minimum_age(d->m_contentRating);
 }
 
-AppStream::ContentRating::RatingValue AppStream::ContentRating::value(const QString& id) const
+AppStream::ContentRating::RatingValue AppStream::ContentRating::value(QAnyStringView id) const
 {
-    return static_cast<AppStream::ContentRating::RatingValue>(as_content_rating_get_value(d->m_contentRating, qPrintable(id)));
+    return static_cast<AppStream::ContentRating::RatingValue>(as_content_rating_get_value(d->m_contentRating, stringViewToChar(id)));
 }
 
-void AppStream::ContentRating::setValue(const QString& id, AppStream::ContentRating::RatingValue ratingValue)
+void AppStream::ContentRating::setValue(QAnyStringView id, AppStream::ContentRating::RatingValue ratingValue)
 {
-    as_content_rating_set_value(d->m_contentRating, qPrintable(id), (AsContentRatingValue) ratingValue);
+    as_content_rating_set_value(d->m_contentRating, stringViewToChar(id), (AsContentRatingValue) ratingValue);
 }
 
-QString AppStream::ContentRating::description(const QString& id) const
+QAnyStringView AppStream::ContentRating::description(QAnyStringView id) const
 {
-    return QString::fromUtf8(as_content_rating_attribute_get_description(qPrintable(id), as_content_rating_get_value(d->m_contentRating, qPrintable(id))));
+    return valueWrap(as_content_rating_attribute_get_description(stringViewToChar(id), as_content_rating_get_value(d->m_contentRating, stringViewToChar(id))));
 }
 
-QStringList AppStream::ContentRating::ratingIds() const
+QList<QAnyStringView> AppStream::ContentRating::ratingIds() const
 {
     return AppStream::valueWrap(as_content_rating_get_rating_ids(d->m_contentRating));
 }
 
 QDebug operator<<(QDebug s, const AppStream::ContentRating& contentRating)
 {
-    s.nospace() << "AppStream::ContentRating(" << contentRating.kind() << contentRating.minimumAge() << ")";
+    s.nospace() << "AppStream::ContentRating(" << stringViewToChar(contentRating.kind()) << contentRating.minimumAge() << ")";
     return s.space();
 }

--- a/qt/contentrating.cpp
+++ b/qt/contentrating.cpp
@@ -133,6 +133,6 @@ QList<QAnyStringView> AppStream::ContentRating::ratingIds() const
 
 QDebug operator<<(QDebug s, const AppStream::ContentRating& contentRating)
 {
-    s.nospace() << "AppStream::ContentRating(" << stringViewToChar(contentRating.kind()) << contentRating.minimumAge() << ")";
+    s.nospace() << "AppStream::ContentRating(" << contentRating.kind().toString() << contentRating.minimumAge() << ")";
     return s.space();
 }

--- a/qt/contentrating.h
+++ b/qt/contentrating.h
@@ -23,7 +23,7 @@
 #define APPSTREAMQT_CONTENT_RATING_H
 
 #include <QSharedDataPointer>
-#include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include "appstreamqt_export.h"
 
@@ -51,8 +51,8 @@ class APPSTREAMQT_EXPORT ContentRating {
         ContentRating(const ContentRating& category);
         ~ContentRating();
 
-        static RatingValue stringToRatingValue(const QString& ratingValue);
-        static QString ratingValueToString(RatingValue ratingValue);
+        static RatingValue stringToRatingValue(QAnyStringView ratingValue);
+        static QAnyStringView ratingValueToString(RatingValue ratingValue);
 
         ContentRating& operator=(const ContentRating& category);
         bool operator==(const ContentRating& r) const;
@@ -62,16 +62,16 @@ class APPSTREAMQT_EXPORT ContentRating {
          */
         _AsContentRating *asContentRating() const;
 
-        QString kind() const;
-        void setKind(const QString& kind);
+        QAnyStringView kind() const;
+        void setKind(QAnyStringView kind);
 
         uint minimumAge() const;
 
-        RatingValue value(const QString& id) const;
-        void setValue(const QString& id, RatingValue ratingValue);
+        RatingValue value(QAnyStringView id) const;
+        void setValue(QAnyStringView id, RatingValue ratingValue);
 
-        QStringList ratingIds() const;
-        QString description(const QString& id) const;
+        QList<QAnyStringView> ratingIds() const;
+        QAnyStringView description(QAnyStringView id) const;
 
     private:
         QSharedDataPointer<ContentRatingData> d;

--- a/qt/icon.cpp
+++ b/qt/icon.cpp
@@ -128,14 +128,14 @@ const QUrl Icon::url() const {
         return QUrl::fromLocalFile(as_icon_get_filename(d->m_icon));
 }
 
-const QString Icon::name() const
+const QAnyStringView Icon::name() const
 {
     return valueWrap(as_icon_get_name(d->m_icon));
 }
 
-void Icon::setName(const QString& name)
+void Icon::setName(QAnyStringView name)
 {
-    as_icon_set_name(d->m_icon, qPrintable(name));
+    as_icon_set_name(d->m_icon, stringViewToChar(name));
 }
 
 bool Icon::isEmpty() const
@@ -153,7 +153,7 @@ QDebug operator<<(QDebug s, const AppStream::Icon& image) {
     if (!image.url().isEmpty())
         s.nospace() << ',' << image.url();
     if (!image.name().isEmpty())
-        s.nospace() << ',' << image.name();
+        s.nospace() << ',' << image.name().toString();
     s.nospace() << "[" << image.width() << "x" << image.height() << "])";
     return s;
 }

--- a/qt/icon.h
+++ b/qt/icon.h
@@ -74,8 +74,8 @@ class APPSTREAMQT_EXPORT Icon {
         /**
          * \return the icon (stock) name
          */
-        const QString name() const;
-        void setName(const QString& name);
+        const QAnyStringView name() const;
+        void setName(QAnyStringView name);
 
         /**
          * \return the expected width of this image

--- a/qt/launchable.cpp
+++ b/qt/launchable.cpp
@@ -118,9 +118,9 @@ QList<QAnyStringView> AppStream::Launchable::entries() const
     return valueWrap(as_launchable_get_entries(d->m_launchable));
 }
 
-void AppStream::Launchable::addEntry(const QString& entry)
+void AppStream::Launchable::addEntry(QAnyStringView entry)
 {
-    as_launchable_add_entry(d->m_launchable, qPrintable(entry));
+    as_launchable_add_entry(d->m_launchable, stringViewToChar(entry));
 }
 
 QDebug operator<<(QDebug s, const AppStream::Launchable& launchable)

--- a/qt/launchable.cpp
+++ b/qt/launchable.cpp
@@ -57,7 +57,7 @@ public:
 };
 
 
-AppStream::Launchable::Kind AppStream::Launchable::stringToKind(const QString& kindString)
+AppStream::Launchable::Kind AppStream::Launchable::stringToKind(QAnyStringView kindString)
 {
     if (kindString == QLatin1String("desktop-id")) {
         return AppStream::Launchable::KindDesktopId;
@@ -65,7 +65,7 @@ AppStream::Launchable::Kind AppStream::Launchable::stringToKind(const QString& k
     return AppStream::Launchable::KindUnknown;
 }
 
-QString AppStream::Launchable::kindToString(AppStream::Launchable::Kind kind)
+QAnyStringView AppStream::Launchable::kindToString(AppStream::Launchable::Kind kind)
 {
     if (kind == AppStream::Launchable::KindDesktopId) {
         return QLatin1String("desktop-id");
@@ -113,7 +113,7 @@ void AppStream::Launchable::setKind(AppStream::Launchable::Kind kind)
     as_launchable_set_kind(d->m_launchable, (AsLaunchableKind) kind);
 }
 
-QStringList AppStream::Launchable::entries() const
+QList<QAnyStringView> AppStream::Launchable::entries() const
 {
     return valueWrap(as_launchable_get_entries(d->m_launchable));
 }
@@ -125,8 +125,12 @@ void AppStream::Launchable::addEntry(const QString& entry)
 
 QDebug operator<<(QDebug s, const AppStream::Launchable& launchable)
 {
+    QStringList launchEntries = QStringList();
+    for(int i = 0; i < launchable.entries().size(); i++) {
+        launchEntries.append(launchable.entries()[i].toString());
+    }
     s.nospace() << "AppStream::Launchable("
-                << Launchable::kindToString(launchable.kind()) << ":"
-                << launchable.entries() << ")";
+                << Launchable::kindToString(launchable.kind()).toString() << ":"
+                << launchEntries << ")";
     return s.space();
 }

--- a/qt/launchable.h
+++ b/qt/launchable.h
@@ -22,7 +22,7 @@
 #define APPSTREAMQT_LAUNCHABLE_H
 
 #include <QSharedDataPointer>
-#include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include "appstreamqt_export.h"
 
@@ -48,8 +48,8 @@ class APPSTREAMQT_EXPORT Launchable {
         Launchable(const Launchable& launchable);
         ~Launchable();
 
-        static Kind stringToKind(const QString& kindString);
-        static QString kindToString(Kind kind);
+        static Kind stringToKind(QAnyStringView kindString);
+        static QAnyStringView kindToString(Kind kind);
 
         Launchable& operator=(const Launchable& launchable);
         bool operator==(const Launchable& r) const;
@@ -62,7 +62,7 @@ class APPSTREAMQT_EXPORT Launchable {
         Kind kind() const;
         void setKind(Kind kind);
 
-        QStringList entries() const;
+        QList<QAnyStringView> entries() const;
         void addEntry(const QString& entry);
 
     private:

--- a/qt/launchable.h
+++ b/qt/launchable.h
@@ -63,7 +63,7 @@ class APPSTREAMQT_EXPORT Launchable {
         void setKind(Kind kind);
 
         QList<QAnyStringView> entries() const;
-        void addEntry(const QString& entry);
+        void addEntry(QAnyStringView entry);
 
     private:
         QSharedDataPointer<LaunchableData> d;

--- a/qt/meson.build
+++ b/qt/meson.build
@@ -65,6 +65,9 @@ asqt_cpp_args = ['-DQT_NO_KEYWORDS']
 if get_option('maintainer')
     asqt_cpp_args += ['-Wno-inline']
 endif
+if get_option('qt6')
+    asqt_cpp_args += ['-DUSE_QANYSTRINGVIEW']
+endif
 
 appstreamqt_lib = library ('AppStreamQt',
     [asqt_src,

--- a/qt/metadata.cpp
+++ b/qt/metadata.cpp
@@ -241,14 +241,6 @@ AppStream::Metadata::MetadataError AppStream::Metadata::saveCatalog(QAnyStringVi
     return AppStream::Metadata::MetadataErrorNoError;
 }
 
-<<<<<<< HEAD
-=======
-AppStream::Metadata::MetadataError AppStream::Metadata::saveCollection(QAnyStringView collection, AppStream::Metadata::FormatKind format)
-{
-    return saveCatalog(collection, format);
-}
-
->>>>>>> c26dd9b0 (Port Qt6 API to use QAnyStringView instead of QString)
 AppStream::Metadata::FormatVersion AppStream::Metadata::formatVersion() const
 {
     return static_cast<AppStream::Metadata::FormatVersion>(as_metadata_get_format_version(d->m_metadata));

--- a/qt/metadata.h
+++ b/qt/metadata.h
@@ -22,7 +22,7 @@
 #define APPSTREAMQT_METADATA_H
 
 #include <QSharedDataPointer>
-#include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include "appstreamqt_export.h"
 
@@ -76,11 +76,11 @@ class APPSTREAMQT_EXPORT Metadata {
         };
         Q_ENUM(MetadataError)
 
-        static FormatKind stringToFormatKind(const QString& kindString);
-        static QString formatKindToString(FormatKind format);
+        static FormatKind stringToFormatKind(QAnyStringView kindString);
+        static QAnyStringView formatKindToString(FormatKind format);
 
-        static FormatVersion stringToFormatVersion(const QString& formatVersionString);
-        static QString formatVersionToString(FormatVersion version);
+        static FormatVersion stringToFormatVersion(QAnyStringView formatVersionString);
+        static QAnyStringView formatVersionToString(FormatVersion version);
 
         Metadata();
         explicit Metadata(_AsMetadata *metadata);
@@ -95,24 +95,24 @@ class APPSTREAMQT_EXPORT Metadata {
          */
         _AsMetadata *asMetadata() const;
 
-        MetadataError parseFile(const QString& file, FormatKind format);
+        MetadataError parseFile(QAnyStringView file, FormatKind format);
 
-        MetadataError parse(const QString& data, FormatKind format);
+        MetadataError parse(QAnyStringView data, FormatKind format);
 
-        MetadataError parseDesktopData(const QString& data, const QString& cid);
+        MetadataError parseDesktopData(QAnyStringView data, QAnyStringView cid);
 
         AppStream::Component component() const;
         QList<AppStream::Component> components() const;
         void clearComponents();
         void addComponent(const AppStream::Component& component);
 
-        QString componentToMetainfo(FormatKind format) const;
+        QAnyStringView componentToMetainfo(FormatKind format) const;
 
-        MetadataError saveMetainfo(const QString& fname, FormatKind format);
+        MetadataError saveMetainfo(QAnyStringView fname, FormatKind format);
 
-        QString componentsToCatalog(FormatKind format) const;
+        QAnyStringView componentsToCatalog(FormatKind format) const;
 
-        MetadataError saveCatalog(const QString& filename, FormatKind format);
+        MetadataError saveCatalog(QAnyStringView filename, FormatKind format);
 
         FormatVersion formatVersion() const;
         void setFormatVersion(FormatVersion formatVersion);
@@ -120,11 +120,11 @@ class APPSTREAMQT_EXPORT Metadata {
         FormatStyle formatStyle() const;
         void setFormatStyle(FormatStyle format);
 
-        QString locale() const;
-        void setLocale(const QString& locale);
+        QAnyStringView locale() const;
+        void setLocale(QAnyStringView locale);
 
-        QString origin() const;
-        void setOrigin(const QString& origin);
+        QAnyStringView origin() const;
+        void setOrigin(QAnyStringView origin);
 
         bool updateExisting() const;
         void setUpdateExisting(bool updateExisting);
@@ -132,8 +132,8 @@ class APPSTREAMQT_EXPORT Metadata {
         bool writeHeader() const;
         void setWriteHeader(bool writeHeader);
 
-        QString architecture() const;
-        void setArchitecture(const QString& architecture);
+        QAnyStringView architecture() const;
+        void setArchitecture(QAnyStringView architecture);
 
         /**
          * \return The last error message received.

--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -149,7 +149,7 @@ QList<AppStream::Component> Pool::componentsByCategories(QList<QAnyStringView> c
     utf8Categories.reserve(categories.size());
     for (QAnyStringView category : categories) {
         QByteArray bytes = QByteArray();
-        bytes.resize(category.size_bytes() + 1);
+        bytes.reserve(category.size_bytes() + 1);
         bytes.append((char*)category.data(), category.size_bytes());
         bytes.append('\0');
         utf8Categories += bytes;

--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -123,16 +123,16 @@ QList<Component> Pool::components() const
     return cptArrayToQList(as_pool_get_components(d->pool));
 }
 
-QList<Component> Pool::componentsById(const QString& cid) const
+QList<Component> Pool::componentsById(QAnyStringView cid) const
 {
-    return cptArrayToQList(as_pool_get_components_by_id(d->pool, qPrintable(cid)));
+    return cptArrayToQList(as_pool_get_components_by_id(d->pool, stringViewToChar(cid)));
 }
 
-QList<Component> Pool::componentsByProvided(Provided::Kind kind, const QString& item) const
+QList<Component> Pool::componentsByProvided(Provided::Kind kind, QAnyStringView item) const
 {
     return cptArrayToQList(as_pool_get_components_by_provided_item(d->pool,
                                                                    static_cast<AsProvidedKind>(kind),
-                                                                   qPrintable(item)));
+                                                                   stringViewToChar(item)));
 }
 
 QList<AppStream::Component> Pool::componentsByKind(Component::Kind kind) const
@@ -140,15 +140,19 @@ QList<AppStream::Component> Pool::componentsByKind(Component::Kind kind) const
     return cptArrayToQList(as_pool_get_components_by_kind(d->pool, static_cast<AsComponentKind>(kind)));
 }
 
-QList<AppStream::Component> Pool::componentsByCategories(const QStringList& categories) const
+QList<AppStream::Component> Pool::componentsByCategories(QList<QAnyStringView> categories) const
 {
     QList<AppStream::Component> res;
     g_autofree gchar **cats_strv = NULL;
 
     QVector<QByteArray> utf8Categories;
     utf8Categories.reserve(categories.size());
-    for (const QString &category : categories) {
-        utf8Categories += category.toUtf8();
+    for (QAnyStringView category : categories) {
+        QByteArray bytes = QByteArray();
+        bytes.resize(category.size_bytes() + 1);
+        bytes.append((char*)category.data(), category.size_bytes());
+        bytes.append('\0');
+        utf8Categories += bytes;
     }
 
     cats_strv = g_new0(gchar *, utf8Categories.size() + 1);
@@ -158,35 +162,35 @@ QList<AppStream::Component> Pool::componentsByCategories(const QStringList& cate
     return cptArrayToQList(as_pool_get_components_by_categories (d->pool, cats_strv));
 }
 
-QList<Component> Pool::componentsByLaunchable(Launchable::Kind kind, const QString& value) const
+QList<Component> Pool::componentsByLaunchable(Launchable::Kind kind, QAnyStringView value) const
 {
     return cptArrayToQList(as_pool_get_components_by_launchable(d->pool,
                                                                 static_cast<AsLaunchableKind>(kind),
-                                                                qPrintable(value)));
+                                                                stringViewToChar(value)));
 }
 
-QList<Component> Pool::componentsByExtends(const QString &extendedId) const
+QList<Component> Pool::componentsByExtends(QAnyStringView extendedId) const
 {
     return cptArrayToQList(as_pool_get_components_by_extends(d->pool,
-                                                             qPrintable(extendedId)));
+                                                             stringViewToChar(extendedId)));
 }
 
-QList<Component> Pool::componentsByBundleId(Bundle::Kind kind, const QString &extendedId, bool matchPrefix) const
+QList<Component> Pool::componentsByBundleId(Bundle::Kind kind, QAnyStringView extendedId, bool matchPrefix) const
 {
     return cptArrayToQList(as_pool_get_components_by_bundle_id(d->pool,
                                                                static_cast<AsBundleKind>(kind),
-                                                               qPrintable(extendedId),
+                                                               stringViewToChar(extendedId),
                                                                matchPrefix));
 }
 
-QList<AppStream::Component> Pool::search(const QString& term) const
+QList<AppStream::Component> Pool::search(QAnyStringView term) const
 {
-    return cptArrayToQList(as_pool_search(d->pool, qPrintable(term)));
+    return cptArrayToQList(as_pool_search(d->pool, stringViewToChar(term)));
 }
 
-void Pool::setLocale(const QString& locale)
+void Pool::setLocale(QAnyStringView locale)
 {
-    as_pool_set_locale (d->pool, qPrintable(locale));
+    as_pool_set_locale (d->pool, stringViewToChar(locale));
 }
 
 uint Pool::flags() const
@@ -214,10 +218,10 @@ void Pool::resetExtraDataLocations()
     as_pool_reset_extra_data_locations (d->pool);
 }
 
-void Pool::addExtraDataLocation(const QString &directory, Metadata::FormatStyle formatStyle)
+void Pool::addExtraDataLocation(QAnyStringView directory, Metadata::FormatStyle formatStyle)
 {
     as_pool_add_extra_data_location (d->pool,
-                                     qPrintable(directory),
+                                     stringViewToChar(directory),
                                      (AsFormatStyle) formatStyle);
 }
 
@@ -226,11 +230,11 @@ void Pool::setLoadStdDataLocations(bool enabled)
     as_pool_set_load_std_data_locations(d->pool, enabled);
 }
 
-void Pool::overrideCacheLocations(const QString &sysDir, const QString &userDir)
+void Pool::overrideCacheLocations(QAnyStringView sysDir, QAnyStringView userDir)
 {
     as_pool_override_cache_locations (d->pool,
-                                      sysDir.isEmpty()? nullptr : qPrintable(sysDir),
-                                      userDir.isEmpty()? nullptr : qPrintable(userDir));
+                                      sysDir.isEmpty()? nullptr : stringViewToChar(sysDir),
+                                      userDir.isEmpty()? nullptr : stringViewToChar(userDir));
 }
 
 bool AppStream::Pool::isEmpty() const

--- a/qt/pool.h
+++ b/qt/pool.h
@@ -101,24 +101,24 @@ public:
 
     QList<AppStream::Component> components() const;
 
-    QList<AppStream::Component> componentsById(const QString& cid) const;
+    QList<AppStream::Component> componentsById(QAnyStringView cid) const;
 
-    QList<AppStream::Component> componentsByProvided(Provided::Kind kind, const QString& item) const;
+    QList<AppStream::Component> componentsByProvided(Provided::Kind kind, QAnyStringView item) const;
 
     QList<AppStream::Component> componentsByKind(Component::Kind kind) const;
 
-    QList<AppStream::Component> componentsByCategories(const QStringList& categories) const;
+    QList<AppStream::Component> componentsByCategories(QList<QAnyStringView> categories) const;
 
-    QList<AppStream::Component> componentsByLaunchable(Launchable::Kind kind, const QString& value) const;
+    QList<AppStream::Component> componentsByLaunchable(Launchable::Kind kind, QAnyStringView value) const;
 
-    QList<AppStream::Component> componentsByExtends(const QString& extendedId) const;
+    QList<AppStream::Component> componentsByExtends(QAnyStringView extendedId) const;
 
-    QList<AppStream::Component> componentsByBundleId(Bundle::Kind kind, const QString& bundleId, bool matchPrefix) const;
+    QList<AppStream::Component> componentsByBundleId(Bundle::Kind kind, QAnyStringView bundleId, bool matchPrefix) const;
 
-    QList<AppStream::Component> search(const QString& term) const;
+    QList<AppStream::Component> search(QAnyStringView term) const;
 
 
-    void setLocale(const QString& locale);
+    void setLocale(QAnyStringView locale);
 
     uint flags() const;
     void setFlags(uint flags);
@@ -126,11 +126,11 @@ public:
     void removeFlags(uint flags);
 
     void resetExtraDataLocations();
-    void addExtraDataLocation(const QString &directory, Metadata::FormatStyle formatStyle);
+    void addExtraDataLocation(QAnyStringView directory, Metadata::FormatStyle formatStyle);
 
     void setLoadStdDataLocations(bool enabled);
-    void overrideCacheLocations(const QString &sysDir,
-                                const QString &userDir);
+    void overrideCacheLocations(QAnyStringView sysDir,
+                                QAnyStringView userDir);
 
     bool isEmpty() const;
 

--- a/qt/provided.cpp
+++ b/qt/provided.cpp
@@ -61,14 +61,14 @@ public:
     AsProvided *m_prov;
 };
 
-QString Provided::kindToString(Provided::Kind kind)
+QAnyStringView Provided::kindToString(Provided::Kind kind)
 {
     return valueWrap(as_provided_kind_to_string((AsProvidedKind) kind));
 }
 
-Provided::Kind Provided::stringToKind(const QString& kindString)
+Provided::Kind Provided::stringToKind(QAnyStringView kindString)
 {
-    return Provided::Kind(as_provided_kind_from_string(qPrintable(kindString)));
+    return Provided::Kind(as_provided_kind_from_string(stringViewToChar(kindString)));
 }
 
 Provided::Provided(const Provided& other)
@@ -113,14 +113,14 @@ Provided::Kind Provided::kind() const
     return Provided::Kind(as_provided_get_kind(d->m_prov));
 }
 
-QStringList Provided::items() const
+QList<QAnyStringView> Provided::items() const
 {
     return valueWrap(as_provided_get_items(d->m_prov));
 }
 
-bool Provided::hasItem(const QString& item) const
+bool Provided::hasItem(QAnyStringView item) const
 {
-    return as_provided_has_item (d->m_prov, qPrintable(item));
+    return as_provided_has_item (d->m_prov, stringViewToChar(item));
 }
 
 bool Provided::isEmpty() const
@@ -132,6 +132,10 @@ bool Provided::isEmpty() const
 }
 
 QDebug operator<<(QDebug s, const AppStream::Provided& Provided) {
-    s.nospace() << "AppStream::Provided(" << Provided.kind() << ',' << Provided.items() << "])";
+    QStringList items = QStringList();
+    for(int i = 0; i < Provided.items().size(); i++) {
+        items.append(Provided.items()[i].toString());
+    }
+    s.nospace() << "AppStream::Provided(" << Provided.kind() << ',' << items << "])";
     return s.space();
 }

--- a/qt/provided.h
+++ b/qt/provided.h
@@ -64,13 +64,13 @@ class APPSTREAMQT_EXPORT Provided {
         };
         Q_ENUM(Kind)
 
-        static Kind stringToKind(const QString& kind);
-        static QString kindToString(Kind kind);
+        static Kind stringToKind(QAnyStringView kind);
+        static QAnyStringView kindToString(Kind kind);
 
         Kind kind() const;
 
-        QStringList items() const;
-        bool hasItem(const QString &item) const;
+        QList<QAnyStringView> items() const;
+        bool hasItem(QAnyStringView item) const;
 
         bool isEmpty() const;
 

--- a/qt/relation.cpp
+++ b/qt/relation.cpp
@@ -59,69 +59,69 @@ public:
 };
 
 
-QString Relation::kindToString(Relation::Kind kind)
+QAnyStringView Relation::kindToString(Relation::Kind kind)
 {
-    return QString::fromUtf8(as_relation_kind_to_string(static_cast<AsRelationKind>(kind)));
+    return valueWrap(as_relation_kind_to_string(static_cast<AsRelationKind>(kind)));
 }
 
-Relation::Kind Relation::stringToKind(const QString &string)
+Relation::Kind Relation::stringToKind(QAnyStringView string)
 {
-    return static_cast<Kind>(as_relation_kind_from_string(qPrintable(string)));
+    return static_cast<Kind>(as_relation_kind_from_string(stringViewToChar(string)));
 }
 
-QString Relation::itemKindToString(Relation::ItemKind ikind)
+QAnyStringView Relation::itemKindToString(Relation::ItemKind ikind)
 {
-    return QString::fromUtf8(as_relation_item_kind_to_string(static_cast<AsRelationItemKind>(ikind)));
+    return valueWrap(as_relation_item_kind_to_string(static_cast<AsRelationItemKind>(ikind)));
 }
 
-Relation::ItemKind Relation::stringToItemKind(const QString &string)
+Relation::ItemKind Relation::stringToItemKind(QAnyStringView string)
 {
-    return static_cast<ItemKind>(as_relation_item_kind_from_string(qPrintable(string)));
+    return static_cast<ItemKind>(as_relation_item_kind_from_string(stringViewToChar(string)));
 }
 
-Relation::Compare Relation::stringToCompare(const QString &string)
+Relation::Compare Relation::stringToCompare(QAnyStringView string)
 {
-    return static_cast<Compare>(as_relation_compare_from_string(qPrintable(string)));
+    return static_cast<Compare>(as_relation_compare_from_string(stringViewToChar(string)));
 }
 
-QString Relation::compareToString(Relation::Compare cmp)
+QAnyStringView Relation::compareToString(Relation::Compare cmp)
 {
-    return QString::fromUtf8(as_relation_compare_to_string(static_cast<AsRelationCompare>(cmp)));
+    return valueWrap(as_relation_compare_to_string(static_cast<AsRelationCompare>(cmp)));
 }
 
-QString Relation::compareToSymbolsString(Relation::Compare cmp)
+QAnyStringView Relation::compareToSymbolsString(Relation::Compare cmp)
 {
     return QString::fromUtf8(as_relation_compare_to_symbols_string(static_cast<AsRelationCompare>(cmp)));
 }
 
-QString Relation::controlKindToString(Relation::ControlKind ckind)
+QAnyStringView Relation::controlKindToString(Relation::ControlKind ckind)
 {
-    return QString::fromUtf8(as_control_kind_to_string(static_cast<AsControlKind>(ckind)));
+    return valueWrap(as_control_kind_to_string(static_cast<AsControlKind>(ckind)));
 }
 
-Relation::ControlKind Relation::controlKindFromString(const QString &string)
+Relation::ControlKind Relation::controlKindFromString(QAnyStringView string)
 {
-    return static_cast<ControlKind>(as_control_kind_from_string(qPrintable(string)));
+    return static_cast<ControlKind>(as_control_kind_from_string(stringViewToChar(string)));
 }
 
-QString Relation::displaySideKindToString(Relation::DisplaySideKind kind)
+QAnyStringView Relation::displaySideKindToString(Relation::DisplaySideKind kind)
 {
-    return QString::fromUtf8(as_display_side_kind_to_string(static_cast<AsDisplaySideKind>(kind)));
+    return valueWrap(as_display_side_kind_to_string(static_cast<AsDisplaySideKind>(kind)));
 }
 
-Relation::DisplaySideKind Relation::stringToDisplaySideKind(const QString &string)
+Relation::DisplaySideKind Relation::stringToDisplaySideKind(QAnyStringView string)
 {
-    return static_cast<DisplaySideKind>(as_display_side_kind_from_string(qPrintable(string)));
+    return static_cast<DisplaySideKind>(as_display_side_kind_from_string(stringViewToChar(string)));
 }
 
-QString Relation::displayLengthKindToString(Relation::DisplayLengthKind kind)
+QAnyStringView Relation::displayLengthKindToString(Relation::DisplayLengthKind kind)
 {
-    return QString::fromUtf8(as_display_length_kind_to_string(static_cast<AsDisplayLengthKind>(kind)));
+    return valueWrap(as_display_length_kind_to_string(static_cast<AsDisplayLengthKind>(kind)));
 }
 
-Relation::DisplayLengthKind Relation::stringToDisplayLengthKind(const QString &string)
+Relation::DisplayLengthKind Relation::stringToDisplayLengthKind(QAnyStringView string)
 {
-    return static_cast<DisplayLengthKind>(as_display_length_kind_from_string(qPrintable(string)));
+    return static_cast<DisplayLengthKind>(as_display_length_kind_from_string(stringViewToChar(string)));
 }
 
 Relation::Relation()
@@ -157,9 +157,9 @@ _AsRelation* AppStream::Relation::asRelation() const
 QDebug operator<<(QDebug s, const AppStream::Relation& relation)
 {
     s.nospace() << "AppStream::Relation("
-                << Relation::kindToString(relation.kind()) << ":"
-                << Relation::itemKindToString(relation.itemKind()) << ":"
-                << relation.valueStr() << ")";
+                << Relation::kindToString(relation.kind()).toString() << ":"
+                << Relation::itemKindToString(relation.itemKind()).toString() << ":"
+                << relation.valueStr().toString() << ")";
     return s.space();
 }
 
@@ -193,24 +193,24 @@ void Relation::setCompare(Relation::Compare compare)
     as_relation_set_compare(d->relation(), static_cast<AsRelationCompare>(compare));
 }
 
-QString Relation::version() const
+QAnyStringView Relation::version() const
 {
     return valueWrap(as_relation_get_version(d->relation()));
 }
 
-void Relation::setVersion(const QString &version)
+void Relation::setVersion(QAnyStringView version)
 {
-    as_relation_set_version(d->relation(), qPrintable(version));
+    as_relation_set_version(d->relation(), stringViewToChar(version));
 }
 
-QString Relation::valueStr() const
+QAnyStringView Relation::valueStr() const
 {
     return valueWrap(as_relation_get_value_str(d->relation()));
 }
 
-void Relation::setValueStr(const QString &value)
+void Relation::setValueStr(QAnyStringView value)
 {
-    as_relation_set_value_str(d->relation(), qPrintable(value));
+    as_relation_set_value_str(d->relation(), stringViewToChar(value));
 }
 
 int Relation::valueInt() const
@@ -263,10 +263,10 @@ void Relation::setValueDisplayLengthKind(Relation::DisplayLengthKind kind)
     as_relation_set_value_display_length_kind(d->relation(), static_cast<AsDisplayLengthKind>(kind));
 }
 
-bool Relation::versionCompare(const QString &version)
+bool Relation::versionCompare(QAnyStringView version)
 {
     g_autoptr(GError) error = NULL;
-    bool ret = as_relation_version_compare(d->relation(), qPrintable(version), &error);
+    bool ret = as_relation_version_compare(d->relation(), stringViewToChar(version), &error);
     if (!ret && error)
         d->lastError = QString::fromUtf8(error->message);
     return ret;
@@ -290,7 +290,7 @@ CheckResult Relation::isSatisfied(SystemInfo *sysInfo, Pool *pool, QString *mess
     return static_cast<CheckResult>(result);
 }
 
-QString Relation::lastError() const
+QAnyStringView Relation::lastError() const
 {
     return d->lastError;
 }

--- a/qt/relation.h
+++ b/qt/relation.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include <QSharedDataPointer>
-#include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include "appstreamqt_export.h"
 
@@ -105,24 +105,24 @@ class APPSTREAMQT_EXPORT Relation {
         };
         Q_ENUM(DisplayLengthKind)
 
-        static QString kindToString(Kind kind);
-        static Kind stringToKind(const QString &string);
+        static QAnyStringView kindToString(Kind kind);
+        static Kind stringToKind(QAnyStringView string);
 
-        static QString itemKindToString(ItemKind ikind);
-        static ItemKind stringToItemKind(const QString &string);
+        static QAnyStringView itemKindToString(ItemKind ikind);
+        static ItemKind stringToItemKind(QAnyStringView string);
 
-        static Compare stringToCompare(const QString &string);
-        static QString compareToString(Compare cmp);
-        static QString compareToSymbolsString(Compare cmp);
+        static Compare stringToCompare(QAnyStringView string);
+        static QAnyStringView compareToString(Compare cmp);
+        static QAnyStringView compareToSymbolsString(Compare cmp);
 
-        static QString controlKindToString(ControlKind ckind);
-        static ControlKind controlKindFromString(const QString &string);
+        static QAnyStringView controlKindToString(ControlKind ckind);
+        static ControlKind controlKindFromString(QAnyStringView string);
 
-        static QString displaySideKindToString(DisplaySideKind kind);
-        static DisplaySideKind stringToDisplaySideKind(const QString &string);
+        static QAnyStringView displaySideKindToString(DisplaySideKind kind);
+        static DisplaySideKind stringToDisplaySideKind(QAnyStringView string);
 
-        static QString displayLengthKindToString(DisplayLengthKind kind);
-        static DisplayLengthKind stringToDisplayLengthKind(const QString &string);
+        static QAnyStringView displayLengthKindToString(DisplayLengthKind kind);
+        static DisplayLengthKind stringToDisplayLengthKind(QAnyStringView string);
 
         Relation();
         Relation(_AsRelation* relation);
@@ -146,11 +146,11 @@ class APPSTREAMQT_EXPORT Relation {
         Compare compare() const;
         void setCompare(Compare compare);
 
-        QString version() const;
-        void setVersion(const QString &version);
+        QAnyStringView version() const;
+        void setVersion(QAnyStringView version);
 
-        QString valueStr() const;
-        void setValueStr(const QString &value);
+        QAnyStringView valueStr() const;
+        void setValueStr(QAnyStringView value);
 
         int valueInt() const;
         void setValueInt(int value);
@@ -167,13 +167,13 @@ class APPSTREAMQT_EXPORT Relation {
         DisplayLengthKind valueDisplayLengthKind() const;
         void setValueDisplayLengthKind(DisplayLengthKind kind);
 
-        bool versionCompare(const QString &version);
+        bool versionCompare(QAnyStringView version);
 
         CheckResult isSatisfied(SystemInfo *sysInfo,
                                 Pool *pool,
                                 QString *message);
 
-        QString lastError() const;
+        QAnyStringView lastError() const;
 
     private:
         QSharedDataPointer<RelationData> d;

--- a/qt/release.cpp
+++ b/qt/release.cpp
@@ -21,6 +21,7 @@
 #include "appstream.h"
 
 #include "release.h"
+#include "chelpers.h"
 
 #include <QDateTime>
 #include <QDebug>
@@ -84,9 +85,9 @@ Release::Kind Release::kind() const
     return Release::Kind(as_release_get_kind(d->m_release));
 }
 
-QString Release::version() const
+QAnyStringView Release::version() const
 {
-    return QString::fromUtf8(as_release_get_version(d->m_release));
+    return valueWrap(as_release_get_version(d->m_release));
 }
 
 QDateTime Release::timestamp() const
@@ -101,14 +102,14 @@ QDateTime Release::timestampEol() const
     return timestamp > 0 ? QDateTime::fromSecsSinceEpoch(timestamp) : QDateTime();
 }
 
-QString Release::description() const
+QAnyStringView Release::description() const
 {
-    return QString::fromUtf8(as_release_get_description(d->m_release));
+    return valueWrap(as_release_get_description(d->m_release));
 }
 
-QString Release::activeLocale() const
+QAnyStringView Release::activeLocale() const
 {
-    return QString::fromUtf8(as_release_get_active_locale(d->m_release));
+    return valueWrap(as_release_get_active_locale(d->m_release));
 }
 
 Release::UrgencyKind Release::urgency() const
@@ -118,6 +119,6 @@ Release::UrgencyKind Release::urgency() const
 
 QDebug operator<<(QDebug s, const AppStream::Release& release)
 {
-    s.nospace() << "AppStream::Release(" << release.version() << ": " << release.description() << ")";
+    s.nospace() << "AppStream::Release(" << release.version().toString() << ": " << release.description().toString() << ")";
     return s.space();
 }

--- a/qt/release.h
+++ b/qt/release.h
@@ -22,7 +22,7 @@
 #define APPSTREAMQT_RELEASE_H
 
 #include <QSharedDataPointer>
-#include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include <QCryptographicHash>
 #include "appstreamqt_export.h"
@@ -83,14 +83,14 @@ class APPSTREAMQT_EXPORT Release {
 
         Kind kind() const;
 
-        QString version() const;
+        QAnyStringView version() const;
 
         QDateTime timestamp() const;
         QDateTime timestampEol() const;
 
-        QString description() const;
+        QAnyStringView description() const;
 
-        QString activeLocale() const;
+        QAnyStringView activeLocale() const;
 
         UrgencyKind urgency() const;
 

--- a/qt/screenshot.cpp
+++ b/qt/screenshot.cpp
@@ -96,14 +96,14 @@ Screenshot::MediaKind Screenshot::mediaKind() const
     return Screenshot::MediaKind(as_screenshot_get_media_kind(d->screenshot()));
 }
 
-QString Screenshot::caption() const
+QAnyStringView Screenshot::caption() const
 {
     return valueWrap(as_screenshot_get_caption(d->m_scr));
 }
 
-void Screenshot::setCaption(const QString& caption, const QString& lang)
+void Screenshot::setCaption(QAnyStringView caption, QAnyStringView lang)
 {
-    as_screenshot_set_caption(d->m_scr, qPrintable(caption), lang.isEmpty()? NULL : qPrintable(lang));
+    as_screenshot_set_caption(d->m_scr, stringViewToChar(caption), lang.isEmpty()? NULL : stringViewToChar(lang));
 }
 
 QList<Image> Screenshot::images() const
@@ -135,7 +135,7 @@ QList<Video> Screenshot::videos() const
 QDebug operator<<(QDebug s, const AppStream::Screenshot& screenshot) {
     s.nospace() << "AppStream::Screenshot(";
     if (!screenshot.caption().isEmpty())
-        s.nospace() << screenshot.caption() << ":";
+        s.nospace() << screenshot.caption().toString() << ":";
     s.nospace() << screenshot.images() << ')';
     return s.space();
 }

--- a/qt/screenshot.h
+++ b/qt/screenshot.h
@@ -25,7 +25,7 @@
 #include <QSharedDataPointer>
 #include "appstreamqt_export.h"
 
-#include <QString>
+#include <QAnyStringView>
 #include <QList>
 
 
@@ -86,8 +86,8 @@ public:
     /**
      * \return caption for this image or a null QString if no caption
      */
-    QString caption() const;
-    void setCaption(const QString& caption, const QString& lang = {});
+    QAnyStringView caption() const;
+    void setCaption(QAnyStringView caption, QAnyStringView lang = {});
 
 private:
     QSharedDataPointer<ScreenshotData> d;

--- a/qt/spdx.cpp
+++ b/qt/spdx.cpp
@@ -22,55 +22,55 @@
 #include "appstream.h"
 #include "chelpers.h"
 
-bool AppStream::SPDX::isLicenseId(const QString &license_id)
+bool AppStream::SPDX::isLicenseId(QAnyStringView license_id)
 {
-    return as_is_spdx_license_id(qPrintable(license_id));
+    return as_is_spdx_license_id(stringViewToChar(license_id));
 }
 
-bool AppStream::SPDX::isLicenseExceptionId(const QString &exception_id)
+bool AppStream::SPDX::isLicenseExceptionId(QAnyStringView exception_id)
 {
-    return as_is_spdx_license_exception_id(qPrintable(exception_id));
+    return as_is_spdx_license_exception_id(stringViewToChar(exception_id));
 }
 
-bool AppStream::SPDX::isLicenseExpression(const QString &license)
+bool AppStream::SPDX::isLicenseExpression(QAnyStringView license)
 {
-    return as_is_spdx_license_expression(qPrintable(license));
+    return as_is_spdx_license_expression(stringViewToChar(license));
 }
 
-bool AppStream::SPDX::isMetadataLicense(const QString &license)
+bool AppStream::SPDX::isMetadataLicense(QAnyStringView license)
 {
-    return as_license_is_metadata_license(qPrintable(license));
+    return as_license_is_metadata_license(stringViewToChar(license));
 }
 
-bool AppStream::SPDX::isFreeLicense(const QString &license)
+bool AppStream::SPDX::isFreeLicense(QAnyStringView license)
 {
-    return as_license_is_free_license(qPrintable(license));
+    return as_license_is_free_license(stringViewToChar(license));
 }
 
-QStringList AppStream::SPDX::tokenizeLicense(const QString &license)
+QList<QAnyStringView> AppStream::SPDX::tokenizeLicense(QAnyStringView license)
 {
-    g_auto(GStrv) strv = as_spdx_license_tokenize(qPrintable(license));
+    g_auto(GStrv) strv = as_spdx_license_tokenize(stringViewToChar(license));
     return AppStream::valueWrap(strv);
 }
 
-QString AppStream::SPDX::detokenizeLicense(const QStringList &license_tokens)
+QAnyStringView AppStream::SPDX::detokenizeLicense(QList<QAnyStringView> license_tokens)
 {
     g_autofree gchar *res = NULL;
     g_auto(GStrv) tokens = NULL;
 
     tokens = AppStream::stringListToCharArray(license_tokens);
     res = as_spdx_license_detokenize(tokens);
-    return QString::fromUtf8(res);
+    return valueWrap(res);
 }
 
-QString AppStream::SPDX::asSpdxId(const QString &license)
+QAnyStringView AppStream::SPDX::asSpdxId(QAnyStringView license)
 {
-    g_autofree gchar *res = as_license_to_spdx_id(qPrintable(license));
-    return QString::fromUtf8(res);
+    g_autofree gchar *res = as_license_to_spdx_id(stringViewToChar(license));
+    return valueWrap(res);
 }
 
-QString AppStream::SPDX::licenseUrl(const QString &license)
+QAnyStringView AppStream::SPDX::licenseUrl(QAnyStringView license)
 {
-    g_autofree gchar *res = as_get_license_url(qPrintable(license));
-    return QString::fromUtf8(res);
+    g_autofree gchar *res = as_get_license_url(stringViewToChar(license));
+    return valueWrap(res);
 }

--- a/qt/spdx.h
+++ b/qt/spdx.h
@@ -21,24 +21,25 @@
 #define APPSTREAMQT_SPDX_H
 
 #include <QStringList>
+#include <QAnyStringView>
 #include "appstreamqt_export.h"
 
 namespace AppStream {
 
 namespace SPDX {
-APPSTREAMQT_EXPORT bool isLicenseId(const QString &license_id);
-APPSTREAMQT_EXPORT bool isLicenseExceptionId(const QString &exception_id);
-APPSTREAMQT_EXPORT bool isLicenseExpression(const QString &license);
+APPSTREAMQT_EXPORT bool isLicenseId(QAnyStringView license_id);
+APPSTREAMQT_EXPORT bool isLicenseExceptionId(QAnyStringView exception_id);
+APPSTREAMQT_EXPORT bool isLicenseExpression(QAnyStringView license);
 
-APPSTREAMQT_EXPORT bool isMetadataLicense(const QString &license);
-APPSTREAMQT_EXPORT bool isFreeLicense(const QString &license);
+APPSTREAMQT_EXPORT bool isMetadataLicense(QAnyStringView license);
+APPSTREAMQT_EXPORT bool isFreeLicense(QAnyStringView license);
 
-APPSTREAMQT_EXPORT QStringList tokenizeLicense(const QString &license);
-APPSTREAMQT_EXPORT QString detokenizeLicense(const QStringList &license_tokens);
+APPSTREAMQT_EXPORT QList<QAnyStringView> tokenizeLicense(QAnyStringView license);
+APPSTREAMQT_EXPORT QAnyStringView detokenizeLicense(QList<QAnyStringView> license_tokens);
 
-APPSTREAMQT_EXPORT QString asSpdxId(const QString &license);
+APPSTREAMQT_EXPORT QAnyStringView asSpdxId(QAnyStringView license);
 
-APPSTREAMQT_EXPORT QString licenseUrl(const QString &license);
+APPSTREAMQT_EXPORT QAnyStringView licenseUrl(QAnyStringView license);
 
 }
 

--- a/qt/suggested.cpp
+++ b/qt/suggested.cpp
@@ -95,18 +95,22 @@ void Suggested::setKind(Suggested::Kind kind)
     as_suggested_set_kind(d->m_suggested, (AsSuggestedKind) kind);
 }
 
-const QStringList AppStream::Suggested::ids() const
+const QList<QAnyStringView> AppStream::Suggested::ids() const
 {
     return valueWrap(as_suggested_get_ids(d->m_suggested));
 }
 
-void AppStream::Suggested::addSuggested(const QString& id)
+void AppStream::Suggested::addSuggested(QAnyStringView id)
 {
-    as_suggested_add_id(d->m_suggested, qPrintable(id));
+    as_suggested_add_id(d->m_suggested, stringViewToChar(id));
 }
 
 QDebug operator<<(QDebug s, const AppStream::Suggested& suggested)
 {
-    s.nospace() << "AppStream::Suggested(" << suggested.ids() << ")";
+    QStringList ids = QStringList();
+    for(int i = 0; i < suggested.ids().size(); i++) {
+        ids.append(suggested.ids()[i].toString());
+    }
+    s.nospace() << "AppStream::Suggested(" << ids << ")";
     return s.space();
 }

--- a/qt/suggested.h
+++ b/qt/suggested.h
@@ -22,6 +22,7 @@
 
 #include <QSharedDataPointer>
 #include <QObject>
+#include <QAnyStringView>
 #include "appstreamqt_export.h"
 
 class QUrl;
@@ -67,8 +68,8 @@ class APPSTREAMQT_EXPORT Suggested {
         /**
          * \return the local or remote url for this suggested
          */
-        const QStringList ids() const;
-        void addSuggested(const QString &id);
+        const QList<QAnyStringView> ids() const;
+        void addSuggested(QAnyStringView id);
 
     private:
         QSharedDataPointer<SuggestedData> d;

--- a/qt/systeminfo.cpp
+++ b/qt/systeminfo.cpp
@@ -82,37 +82,37 @@ _AsSystemInfo * AppStream::SystemInfo::asSystemInfo() const
     return d->sysInfo;
 }
 
-QString SystemInfo::osId() const
+QAnyStringView SystemInfo::osId() const
 {
     return valueWrap(as_system_info_get_os_id(d->sysInfo));
 }
 
-QString SystemInfo::osCid() const
+QAnyStringView SystemInfo::osCid() const
 {
     return valueWrap(as_system_info_get_os_cid(d->sysInfo));
 }
 
-QString SystemInfo::osName() const
+QAnyStringView SystemInfo::osName() const
 {
     return valueWrap(as_system_info_get_os_name(d->sysInfo));
 }
 
-QString SystemInfo::osVersion() const
+QAnyStringView SystemInfo::osVersion() const
 {
     return valueWrap(as_system_info_get_os_version(d->sysInfo));
 }
 
-QString SystemInfo::osHomepage() const
+QAnyStringView SystemInfo::osHomepage() const
 {
     return valueWrap(as_system_info_get_os_homepage(d->sysInfo));
 }
 
-QString SystemInfo::kernelName() const
+QAnyStringView SystemInfo::kernelName() const
 {
     return valueWrap(as_system_info_get_kernel_name(d->sysInfo));
 }
 
-QString SystemInfo::kernelVersion() const
+QAnyStringView SystemInfo::kernelVersion() const
 {
     return valueWrap(as_system_info_get_kernel_version(d->sysInfo));
 }
@@ -122,28 +122,28 @@ ulong SystemInfo::memoryTotal() const
     return as_system_info_get_memory_total(d->sysInfo);
 }
 
-QStringList SystemInfo::modaliases() const
+QList<QAnyStringView> SystemInfo::modaliases() const
 {
     return valueWrap(as_system_info_get_modaliases(d->sysInfo));
 }
 
-QString SystemInfo::modaliasToSyspath(const QString &modalias)
+QAnyStringView SystemInfo::modaliasToSyspath(QAnyStringView modalias)
 {
-    return valueWrap(as_system_info_modalias_to_syspath(d->sysInfo, qPrintable(modalias)));
+    return valueWrap(as_system_info_modalias_to_syspath(d->sysInfo, stringViewToChar(modalias)));
 }
 
-bool SystemInfo::hasDeviceMatchingModalias(const QString &modaliasGlob)
+bool SystemInfo::hasDeviceMatchingModalias(QAnyStringView modaliasGlob)
 {
-    return as_system_info_has_device_matching_modalias(d->sysInfo, qPrintable(modaliasGlob));
+    return as_system_info_has_device_matching_modalias(d->sysInfo, stringViewToChar(modaliasGlob));
 }
 
-QString SystemInfo::deviceNameForModalias(const QString &modalias, bool allowFallback)
+QAnyStringView SystemInfo::deviceNameForModalias(QAnyStringView modalias, bool allowFallback)
 {
     g_autoptr(GError) error = nullptr;
-    QString result;
+    QAnyStringView result;
 
     result = valueWrap(as_system_info_get_device_name_for_modalias(d->sysInfo,
-                                                                   qPrintable(modalias),
+                                                                   stringViewToChar(modalias),
                                                                    allowFallback,
                                                                    &error));
     if (error != nullptr)
@@ -184,7 +184,7 @@ void SystemInfo::setDisplayLength(Relation::DisplaySideKind kind, ulong valueDip
                                        valueDip);
 }
 
-QString SystemInfo::lastError() const
+QAnyStringView SystemInfo::lastError() const
 {
     return d->lastError;
 }

--- a/qt/systeminfo.h
+++ b/qt/systeminfo.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include <QSharedDataPointer>
-#include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include "relation.h"
 #include "appstreamqt_export.h"
@@ -45,22 +45,22 @@ class APPSTREAMQT_EXPORT SystemInfo {
          */
         _AsSystemInfo *asSystemInfo() const;
 
-        QString osId() const;
-        QString osCid() const;
-        QString osName() const;
-        QString osVersion() const;
-        QString osHomepage() const;
+        QAnyStringView osId() const;
+        QAnyStringView osCid() const;
+        QAnyStringView osName() const;
+        QAnyStringView osVersion() const;
+        QAnyStringView osHomepage() const;
 
-        QString kernelName() const;
-        QString kernelVersion() const;
+        QAnyStringView kernelName() const;
+        QAnyStringView kernelVersion() const;
 
         ulong memoryTotal() const;
 
-        QStringList modaliases() const;
-        QString modaliasToSyspath(const QString &modalias);
+        QList<QAnyStringView> modaliases() const;
+        QAnyStringView modaliasToSyspath(QAnyStringView modalias);
 
-        bool hasDeviceMatchingModalias(const QString &modaliasGlob);
-        QString deviceNameForModalias(const QString &modalias, bool allowFallback);
+        bool hasDeviceMatchingModalias(QAnyStringView modaliasGlob);
+        QAnyStringView deviceNameForModalias(QAnyStringView modalias, bool allowFallback);
 
         CheckResult hasInputControl(Relation::ControlKind kind);
         void setInputControl(Relation::ControlKind kind, bool found);
@@ -71,7 +71,7 @@ class APPSTREAMQT_EXPORT SystemInfo {
         /**
          * \return The last error message received.
          */
-        QString lastError() const;
+        QAnyStringView lastError() const;
 
     private:
         QSharedDataPointer<SystemInfoData> d;

--- a/qt/tests/asqt-pool-test.cpp
+++ b/qt/tests/asqt-pool-test.cpp
@@ -54,7 +54,7 @@ void PoolReadTest::testRead01()
     pool->setFlags(flags);
 
     // use clean caches
-    pool->overrideCacheLocations(cacheDir.path(), nullptr);
+    pool->overrideCacheLocations(cacheDir.path().toUtf8(), QAnyStringView(nullptr));
 
     // read metadata
     bool ret = pool->load();

--- a/qt/translation.cpp
+++ b/qt/translation.cpp
@@ -56,7 +56,7 @@ public:
     AsTranslation* m_translation;
 };
 
-AppStream::Translation::Kind AppStream::Translation::stringToKind(const QString& kindString)
+AppStream::Translation::Kind AppStream::Translation::stringToKind(QAnyStringView kindString)
 {
     if (kindString == QLatin1String("gettext")) {
         return AppStream::Translation::KindGettext;
@@ -66,7 +66,7 @@ AppStream::Translation::Kind AppStream::Translation::stringToKind(const QString&
     return AppStream::Translation::KindUnknown;
 }
 
-QString AppStream::Translation::kindToString(AppStream::Translation::Kind kind)
+QAnyStringView AppStream::Translation::kindToString(AppStream::Translation::Kind kind)
 {
     if (kind == AppStream::Translation::KindGettext) {
         return QLatin1String("gettext");
@@ -116,18 +116,18 @@ void AppStream::Translation::setKind(AppStream::Translation::Kind kind)
     as_translation_set_kind(d->m_translation, (AsTranslationKind) kind);
 }
 
-QString AppStream::Translation::id() const
+QAnyStringView AppStream::Translation::id() const
 {
     return valueWrap(as_translation_get_id(d->m_translation));
 }
 
-void AppStream::Translation::setId(const QString& id)
+void AppStream::Translation::setId(QAnyStringView id)
 {
-    as_translation_set_id(d->m_translation, qPrintable(id));
+    as_translation_set_id(d->m_translation, stringViewToChar(id));
 }
 
 QDebug operator<<(QDebug s, const AppStream::Translation& translation)
 {
-    s.nospace() << "AppStream::Translation(" << translation.id() << ")";
+    s.nospace() << "AppStream::Translation(" << translation.id().toString() << ")";
     return s.space();
 }

--- a/qt/translation.h
+++ b/qt/translation.h
@@ -22,7 +22,7 @@
 #define APPSTREAMQT_TRANSLATION_H
 
 #include <QSharedDataPointer>
-#include <QString>
+#include <QAnyStringView>
 #include <QObject>
 #include "appstreamqt_export.h"
 
@@ -47,8 +47,8 @@ class APPSTREAMQT_EXPORT Translation {
         Translation(const Translation& category);
         ~Translation();
 
-        static Kind stringToKind(const QString& kindString);
-        static QString kindToString(Kind kind);
+        static Kind stringToKind(QAnyStringView kindString);
+        static QAnyStringView kindToString(Kind kind);
 
         Translation& operator=(const Translation& category);
         bool operator==(const Translation& r) const;
@@ -61,8 +61,8 @@ class APPSTREAMQT_EXPORT Translation {
         Kind kind() const;
         void setKind(Kind kind);
 
-        QString id() const;
-        void setId(const QString& id);
+        QAnyStringView id() const;
+        void setId(QAnyStringView id);
 
     private:
         QSharedDataPointer<TranslationData> d;

--- a/qt/utils.cpp
+++ b/qt/utils.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2019 Matthias Klumpp <matthias@tenstral.net>
  *
@@ -22,18 +23,18 @@
 #include "appstream.h"
 #include "chelpers.h"
 
-QString AppStream::Utils::currentDistroComponentId()
+QAnyStringView AppStream::Utils::currentDistroComponentId()
 {
     return QString::fromUtf8(as_get_current_distro_component_id());
 }
 
 
-QString AppStream::Utils::currentAppStreamVersion()
+QAnyStringView AppStream::Utils::currentAppStreamVersion()
 {
     return QString::fromUtf8(as_version_string());
 }
 
-int AppStream::Utils::vercmpSimple(const QString &a, const QString &b)
+int AppStream::Utils::vercmpSimple(QAnyStringView a, QAnyStringView b)
 {
-    return as_vercmp (qPrintable(a), qPrintable(b), AS_VERCMP_FLAG_NONE);
+    return as_vercmp (stringViewToChar(a), stringViewToChar(b), AS_VERCMP_FLAG_NONE);
 }

--- a/qt/utils.cpp
+++ b/qt/utils.cpp
@@ -25,13 +25,13 @@
 
 QAnyStringView AppStream::Utils::currentDistroComponentId()
 {
-    return QString::fromUtf8(as_get_current_distro_component_id());
+    return valueWrap(as_get_current_distro_component_id());
 }
 
 
 QAnyStringView AppStream::Utils::currentAppStreamVersion()
 {
-    return QString::fromUtf8(as_version_string());
+    return valueWrap(as_version_string());
 }
 
 int AppStream::Utils::vercmpSimple(QAnyStringView a, QAnyStringView b)

--- a/qt/utils.h
+++ b/qt/utils.h
@@ -20,18 +20,18 @@
 #ifndef APPSTREAMQT_UTILS_H
 #define APPSTREAMQT_UTILS_H
 
-#include <QStringList>
+#include <QAnyStringView>
 #include "appstreamqt_export.h"
 
 namespace AppStream {
 
 namespace Utils {
 
-APPSTREAMQT_EXPORT QString currentDistroComponentId();
+APPSTREAMQT_EXPORT QAnyStringView currentDistroComponentId();
 
-APPSTREAMQT_EXPORT QString currentAppStreamVersion();
+APPSTREAMQT_EXPORT QAnyStringView currentAppStreamVersion();
 
-APPSTREAMQT_EXPORT int vercmpSimple(const QString &a, const QString &b);
+APPSTREAMQT_EXPORT int vercmpSimple(QAnyStringView a, QAnyStringView b);
 
 }
 


### PR DESCRIPTION
This was discussed a bit at #445 , so I thought to actually implement it to see how it actually would work.
I use QAnyStringView instead of the more specific QUtf8StringView because the former has the size_bytes() method that is the siplest way to copy it to a UTF-8 char*.
However, a QString can be implicitly converted to a QAnyStringView, so any software that used to work with the old version of the library will compile, but since the library expects all QAnyStringView s to be in UTF-8, it won't work.
We could try to check if the string is UTF-16 or UTF-8 and then do the conversion if needed.
We could also use QUtf8StringView, if we manipulate how the view is created so it includes the null character:
```
const char* utf8_bytes = "áé科";
auto view = QUtf8StringView(utf8_bytes, strlen(utf8_bytes) + 1);
const char *utf8_bytes2 = view.data()
```
As an upside, it would save a copy. But it would require anyone passing QUtf8StringView s to the library to do this as well.
We could also use QUtf8StringView's iterator to copy and reassemble the Unicode codepoints in UTF-8