### PR TITLE
Make Qt6 dependency a system dependency.

### DIFF
--- a/qt/meson.build
+++ b/qt/meson.build
@@ -6,7 +6,12 @@ add_languages('cpp', native: true)
 add_languages('cpp', native: false)
 
 qt = import('qt6')
-qt_dep = dependency('qt6', modules: ['Core'], version: '>= 6.2.4')
+qt_dep = dependency(
+    'qt6',
+    modules: ['Core'],
+    version: '>= 6.2.4',
+    include_type: 'system'
+)
 
 asqt_src = [
     'bundle.cpp',

--- a/qt/tests/meson.build
+++ b/qt/tests/meson.build
@@ -1,6 +1,10 @@
 # Meson definition for AppStream Qt Tests
 
-qt_test_dep = dependency('qt6', modules: ['Core', 'Test'])
+qt_test_dep = dependency(
+    'qt6',
+    modules: ['Core', 'Test'],
+    include_type: 'system'
+)
 
 testpaths_h = configuration_data()
 testpaths_h.set_quoted('AS_SAMPLE_DATA_PATH', join_paths(source_root, 'tests', 'samples', 'catalog'))


### PR DESCRIPTION
Disables warning checks on include files found in Qt 6 headers.

Fixes building against Qt 6.5.0 on archlinux.