### PR TITLE
Fix tweaking of appstream.pc when building as subproject

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -221,7 +221,7 @@ sed_prog = find_program('sed')
 pc_fixup = run_command(sed_prog,
                        '-i ""',
                        '/^Requires.private\|^Libs.private/ d',
-                       join_paths(meson.project_build_root(), 'meson-private', 'appstream.pc'),
+                       join_paths(meson.global_build_root(), 'meson-private', 'appstream.pc'),
                        check: false)
 if pc_fixup.returncode() != 0
     error('Unable to fix up the .pc file:\n' + pc_fixup.stderr())


### PR DESCRIPTION
Building libadwaita via jhbuild with meson-0.64.0,

  meson.build:227:4: ERROR: Problem encountered: Unable to fix up the .pc file:
  sed: can't read /home/jhbuild/.cache/jhbuild/build/libadwaita/subprojects/appstream/meson-private/appstream.pc: No such file or directory

The generated file is found at /home/jhbuild/.cache/jhbuild/build/libadwaita/meson-private/appstream.pc

Use the global build root to find this file and fix the build failure.