### PR TITLE
Add support for heading in app description 

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -247,6 +247,9 @@
 			<para>Unordered list (<literal>ul</literal>), with list items (<literal>li</literal>)</para>
 			</listitem>
 			<listitem>
+			<para>Heading (<literal>heading</literal>)</para>
+			</listitem>
+			<listitem>
 			<para>
 				Within paragraphs and list items, emphasis (<literal>em</literal>) and inline code (<literal>code</literal>) text styles are supported.
 				The emphasis is commonly rendered in italic, while inline code is shown in a monospaced font.

--- a/src/as-utils.c
+++ b/src/as-utils.c
@@ -259,6 +259,28 @@ as_description_markup_convert (const gchar *markup, AsMarkupKind to_kind, GError
 			} else {
 				g_string_append_printf (str, "%s\n", clean_text);
 			}
+		} else if ((g_strcmp0 ((gchar*) iter->name, "heading") == 0)) {
+			g_autofree gchar *clean_text = NULL;
+			g_autofree gchar *text_content = as_xml_get_node_value_raw (iter);
+			g_auto(GStrv) spl = NULL;
+
+			/* Apparently the element is empty, which is odd. But we better add it instead
+			 * of completely ignoring it. */
+			if (text_content == NULL)
+				text_content = g_strdup ("");
+
+			/* remove extra whitespaces and linebreaks */
+			clean_text = as_sanitize_text_spaces (text_content);
+
+			if (str->len > 0)
+				g_string_append (str, "\n");
+
+			spl = as_markup_strsplit_words (clean_text, 100);
+			if (spl != NULL) {
+				for (guint i = 0; spl[i] != NULL; i++) {
+					g_string_append_printf (str, "## %s\n", clean_text);
+				}
+			}
 		} else if ((g_strcmp0 ((gchar*) iter->name, "ul") == 0) || (g_strcmp0 ((gchar*) iter->name, "ol") == 0)) {
 			g_autofree gchar *item_c = NULL;
 			gboolean is_ordered_list = g_strcmp0 ((gchar*) iter->name, "ol") == 0;

--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -2091,7 +2091,7 @@ as_validator_check_release (AsValidator *validator, xmlNode *node, AsFormatStyle
 		}
 
 		/* checks if the description is put outside a description tag */
-		if (as_str_equal0 (node_name, "p") || as_str_equal0 (node_name, "ol") || as_str_equal0 (node_name, "ul") || as_str_equal0 (node_name, "li")) {
+		if (as_str_equal0 (node_name, "p") || as_str_equal0 (node_name, "ol") || as_str_equal0 (node_name, "ul") || as_str_equal0 (node_name, "li") || as_str_equal0 (node_name, "heading")) {
 			as_validator_add_issue (validator, node, "release-description-outside-tag", node_name);
 			continue;
 		}


### PR DESCRIPTION
This is useful for adding some organization inside a long description. h1 is not allowed since this should be the title of the application, and this should not be handled by the app itself.

E.g. this would make sense for the description in https://apps.kde.org/zanshin/