### PR TITLE
Add support for specifying the platform of a given screenshot

### DIFF
--- a/docs/xml/catalog-xmldata.xml
+++ b/docs/xml/catalog-xmldata.xml
@@ -431,6 +431,9 @@
 						on the image shown. The tag is translatable.
 					</para>
 					<para>
+						Optionally, a screenshot can contain a <code><![CDATA[<platform>]]></code> tag, describing which platform the screenshot is for.
+					</para>
+					<para>
 						For <code><![CDATA[<screenshot>]]></code> tags that contain <literal>video</literal> elements, a catalog metadata generator may impose any restrictions to them,
 						including completely removing them from the output, imposing filesize limits, etc.
 						Upstream metainfo files should not rely on the videos being present and must always have a static screenhot for the software component as well.

--- a/qt/screenshot.cpp
+++ b/qt/screenshot.cpp
@@ -106,6 +106,16 @@ void Screenshot::setCaption(const QString& caption, const QString& lang)
     as_screenshot_set_caption(d->m_scr, qPrintable(caption), lang.isEmpty()? NULL : qPrintable(lang));
 }
 
+QString Screenshot::platform() const
+{
+    return valueWrap(as_screenshot_get_platform(d->m_scr));
+}
+
+void Screenshot::setPlatform(const QString& platform)
+{
+    as_screenshot_set_platform(d->m_scr, qPrintable(platform));
+}
+
 QList<Image> Screenshot::images() const
 {
     QList<Image> res;

--- a/qt/screenshot.h
+++ b/qt/screenshot.h
@@ -42,7 +42,8 @@ class ScreenshotData;
  */
 
 class APPSTREAMQT_EXPORT Screenshot {
-Q_GADGET
+    Q_GADGET
+    Q_PROPERTY(QString platform READ platform WRITE setPlatform)
 public:
     enum MediaKind {
         MediaKindUnknown,
@@ -88,6 +89,9 @@ public:
      */
     QString caption() const;
     void setCaption(const QString& caption, const QString& lang = {});
+
+    QString platform() const;
+    void setPlatform(const QString &platform);
 
 private:
     QSharedDataPointer<ScreenshotData> d;

--- a/src/as-screenshot.h
+++ b/src/as-screenshot.h
@@ -111,6 +111,10 @@ GPtrArray			*as_screenshot_get_videos (AsScreenshot *screenshot);
 void				as_screenshot_add_video (AsScreenshot *screenshot,
 							 AsVideo *video);
 
+const gchar			*as_screenshot_get_platform (AsScreenshot *screenshot);
+void				as_screenshot_set_platform (AsScreenshot *screenshot,
+								const gchar *platform);
+
 const gchar			*as_screenshot_get_active_locale (AsScreenshot *screenshot);
 void				as_screenshot_set_active_locale (AsScreenshot *screenshot,
 									const gchar *locale);


### PR DESCRIPTION
Fix #390

Questions is if we should reuse the triplet for the platform of the artifact which aren't that relevant or specify a bunch of platforms (gnome, gnome-mobile, android, plasma desktop, plasma mobile, windows, macos, ...) as standard values and allow the app developer to also put other values for e.g. some obscure os like haiku.