### PR TITLE
bundle: add linglong as a new type of Bundle

### DIFF
--- a/docs/xml/catalog-xmldata.xml
+++ b/docs/xml/catalog-xmldata.xml
@@ -597,6 +597,7 @@
 							<listitem><para><code>snap</code> - For <ulink url="https://snapcraft.io/">Snappy</ulink> snap bundles.</para></listitem>
 							<listitem><para><code>tarball</code> - For plain and possibly compressed tarballs.</para></listitem>
 							<listitem><para><code>cabinet</code> - For cabinet firmware deployments.</para></listitem>
+							<listitem><para><code>linglong</code> - For <ulink url="https://linglong.dev/">Linglong</ulink> bundles.</para></listitem>
 						</itemizedlist>
 					</para>
 					<para>

--- a/qt/bundle.h
+++ b/qt/bundle.h
@@ -56,7 +56,8 @@ public:
         KindAppImage,
         KindSnap,
         KindTarball,
-        KindCabinet
+        KindCabinet,
+        KindLinglong
     };
     Q_ENUM(Kind)
 

--- a/src/as-bundle.c
+++ b/src/as-bundle.c
@@ -68,6 +68,8 @@ as_bundle_kind_to_string (AsBundleKind kind)
 		return "tarball";
 	if (kind == AS_BUNDLE_KIND_CABINET)
 		return "cabinet";
+	if (kind == AS_BUNDLE_KIND_LINGLONG)
+		return "linglong";
 	return "unknown";
 }
 
@@ -96,6 +98,8 @@ as_bundle_kind_from_string (const gchar *bundle_str)
 		return AS_BUNDLE_KIND_TARBALL;
 	if (g_strcmp0 (bundle_str, "cabinet") == 0)
 		return AS_BUNDLE_KIND_CABINET;
+	if (g_strcmp0 (bundle_str, "linglong") == 0)
+		return AS_BUNDLE_KIND_LINGLONG;
 	return AS_BUNDLE_KIND_UNKNOWN;
 }
 

--- a/src/as-bundle.h
+++ b/src/as-bundle.h
@@ -53,6 +53,7 @@ struct _AsBundleClass {
  * @AS_BUNDLE_KIND_SNAP:	A Snap/Snappy bundle
  * @AS_BUNDLE_KIND_TARBALL:	A (maybe compressed) tarball.
  * @AS_BUNDLE_KIND_CABINET:	Cabinet firmware deployment
+ * @AS_BUNDLE_KIND_LINGLONG:	A Linglong bundle
  *
  * The bundle type.
  **/
@@ -65,6 +66,7 @@ typedef enum {
 	AS_BUNDLE_KIND_SNAP,
 	AS_BUNDLE_KIND_TARBALL,
 	AS_BUNDLE_KIND_CABINET,
+	AS_BUNDLE_KIND_LINGLONG,
 	/*< private >*/
 	AS_BUNDLE_KIND_LAST
 } AsBundleKind;


### PR DESCRIPTION
This is a preparation for adding AppStream metadata support for linglong packages. Thus 'linglong' can be used as a valid bundle type in its AppStream catalog metadata.

cc @black-desk