### PR TITLE
Clear issues from previous validations when validating multiple files

### DIFF
--- a/tools/ascli-actions-validate.c
+++ b/tools/ascli-actions-validate.c
@@ -436,6 +436,9 @@ ascli_validate_files (gchar **argv,
 			  &pedantic_count)
 			  ? ret
 			  : FALSE;
+
+		/* remove issues from a potential previous use of this validator */
+		as_validator_clear_issues (validator);
 	}
 
 	if (ret) {


### PR DESCRIPTION
This is needed when we validate multiple files in a single run.

### Without Fix:

```
$ appstreamcli validate /etc/passwd /etc/group
passwd
  E: ~:~: xml-markup-invalid
       Could not parse XML data: Entity: line 1: parser error : Start tag expected, '<' not
       found
       root:x:0:0:root:/root:/bin/bash
       ^

group
  E: ~:~: xml-markup-invalid
       Could not parse XML data: Entity: line 1: parser error : Start tag expected, '<' not
       found
       root:x:0:
       ^

passwd
  E: ~:~: xml-markup-invalid
       Could not parse XML data: Entity: line 1: parser error : Start tag expected, '<' not
       found
       root:x:0:0:root:/root:/bin/bash
       ^

✘ Validation failed: errors: 3
```

### With Fix:

```
$ appstreamcli validate /etc/passwd /etc/group
passwd
  E: ~:~: xml-markup-invalid
       Could not parse XML data: Entity: line 1: parser error : Start tag expected, '<' not
       found
       root:x:0:0:root:/root:/bin/bash
       ^

group
  E: ~:~: xml-markup-invalid
       Could not parse XML data: Entity: line 1: parser error : Start tag expected, '<' not
       found
       root:x:0:
       ^

✘ Validation failed: errors: 2
```