### PR TITLE
Add FreeBSD CI using Cirrus CI.

### DIFF
--- a/.cirrus-ci.yml
+++ b/.cirrus-ci.yml
@@ -1,0 +1,17 @@
+task:
+  freebsd_instance:
+    matrix:
+      - image_family: freebsd-13-2-snap
+  env:
+    # /usr/ports/Mk/Uses/localbase.mk localbase:ldflags
+    LOCALBASE: /usr/local
+    CFLAGS: -isystem $LOCALBASE/include
+    CPPFLAGS: $CFLAGS
+    CXXFLAGS: $CFLAGS
+    LDFLAGS: -L$LOCALBASE/lib
+  deps_script:
+    - sed -i.bak 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
+    - env ASSUME_ALWAYS_YES=yes pkg update -f
+    - env ASSUME_ALWAYS_YES=yes pkg install -y snowballstemmer gperf itstool gtk-doc qt6-tools
+  build_script:
+    - tests/ci/run-build.sh

--- a/tests/test-pool.c
+++ b/tests/test-pool.c
@@ -1052,7 +1052,7 @@ main (int argc, char **argv)
 {
 	int ret;
 
-	if (argc == 0) {
+	if (argc == 1) {
 		g_error ("No test directory specified!");
 		return 1;
 	}


### PR DESCRIPTION
Testing is omitted for the moment because AsMonitor tests fail due to FreeBSD-specific bug in glib: https://gitlab.gnome.org/GNOME/glib/-/issues/576

I might also miss some dependencies, so the commit might need amending after the repository enables Cirrus CI.

Obsoletes https://github.com/ximion/appstream/pull/485 PR