### PR TITLE
Add GUI environment IDs for macOS and Microsoft Windows

### DIFF
--- a/data/desktop-style-ids.txt
+++ b/data/desktop-style-ids.txt
@@ -9,10 +9,12 @@ gnome       GNOME
 gnome:dark  GNOME (Dark)
 lxde        LXDE
 lxqt        LXQt
+macos       macOS
 mate        Mate
 pantheon    Pantheon
 plasma      KDE Plasma
 razor       Razor
 rox         Rox
 unity       Unity
+windows     Microsoft Windows
 xfce        Xfce

--- a/src/as-desktop-env-data.h
+++ b/src/as-desktop-env-data.h
@@ -89,6 +89,8 @@ AsGUIEnvStyleData as_gui_env_style_data[] = {
 	{ "lxde", N_("LXDE") },
 	/* TRANSLATORS: Name of the "lxqt" visual environment style. */
 	{ "lxqt", N_("LXQt") },
+	/* TRANSLATORS: Name of the "macos" visual environment style. */
+	{ "macos", N_("macOS") },
 	/* TRANSLATORS: Name of the "mate" visual environment style. */
 	{ "mate", N_("Mate") },
 	/* TRANSLATORS: Name of the "pantheon" visual environment style. */
@@ -101,6 +103,8 @@ AsGUIEnvStyleData as_gui_env_style_data[] = {
 	{ "rox", N_("Rox") },
 	/* TRANSLATORS: Name of the "unity" visual environment style. */
 	{ "unity", N_("Unity") },
+	/* TRANSLATORS: Name of the "windows" visual environment style. */
+	{ "windows", N_("Microsoft Windows") },
 	/* TRANSLATORS: Name of the "xfce" visual environment style. */
 	{ "xfce", N_("Xfce") },
 	{ NULL, NULL },


### PR DESCRIPTION
Thanks for adding support for screenshot environments!

This adds IDs for macOS and Microsoft Windows.