### PR TITLE
Add ignore-empty option to validate

### DIFF
--- a/tools/appstreamcli.c
+++ b/tools/appstreamcli.c
@@ -115,6 +115,7 @@ static gboolean optn_explain = FALSE;
 static gboolean optn_no_net = FALSE;
 static gboolean optn_validate_strict = FALSE;
 static gchar *optn_issue_overrides = NULL;
+static gboolean optn_ignore_empty = FALSE;
 
 /**
  * General options for validation.
@@ -159,6 +160,13 @@ const GOptionEntry validate_options[] = {
 	  G_OPTION_ARG_STRING, &optn_issue_overrides,
 	  /* TRANSLATORS: ascli flag description for: --override  when validating XML files */
 	  N_ ("Override the severities of selected issue tags."),
+	  NULL },
+	{ "ignore-empty",
+	  (gchar) 0,
+	  0, G_OPTION_ARG_NONE,
+	  &optn_ignore_empty,
+	  /* TRANSLATORS: ascli flag description for: --ignore-empty (used by the "validate" command) */
+	  N_ ("Don't exit with a error when no files are given"),
 	  NULL },
 
 	{ NULL }
@@ -477,6 +485,7 @@ as_client_run_validate (const gchar *command, char **argv, int argc)
 					     optn_explain,
 					     optn_validate_strict,
 					     !optn_no_net,
+					     optn_ignore_empty,
 					     optn_issue_overrides);
 	} else {
 		return ascli_validate_files_format (&argv[2],
@@ -484,6 +493,7 @@ as_client_run_validate (const gchar *command, char **argv, int argc)
 						    optn_format,
 						    optn_validate_strict,
 						    !optn_no_net,
+						    optn_ignore_empty,
 						    optn_issue_overrides);
 	}
 }

--- a/tools/ascli-actions-validate.c
+++ b/tools/ascli-actions-validate.c
@@ -381,6 +381,7 @@ ascli_validate_files (gchar **argv,
 		      gboolean explain,
 		      gboolean validate_strict,
 		      gboolean use_net,
+		      gboolean ignore_empty,
 		      const gchar *overrides_str)
 {
 	gboolean ret = TRUE;
@@ -392,8 +393,12 @@ ascli_validate_files (gchar **argv,
 	g_autoptr(GPtrArray) metainfo_files = NULL;
 
 	if (argc < 1) {
-		g_printerr ("%s\n", _("You need to specify at least one file to validate!"));
-		return ASCLI_EXIT_CODE_FAILED;
+		if (ignore_empty) {
+			return ASCLI_EXIT_CODE_SUCCESS;
+		} else {
+			g_printerr ("%s\n", _("You need to specify at least one file to validate!"));
+			return ASCLI_EXIT_CODE_FAILED;
+		}
 	}
 
 	validator = as_validator_new ();
@@ -475,6 +480,7 @@ ascli_validate_files_format (gchar **argv,
 			     const gchar *format,
 			     gboolean validate_strict,
 			     gboolean use_net,
+			     gboolean ignore_empty,
 			     const gchar *overrides_str)
 {
 	if (g_strcmp0 (format, "text") == 0) {
@@ -487,6 +493,7 @@ ascli_validate_files_format (gchar **argv,
 					     TRUE, /* explain */
 					     validate_strict,
 					     use_net,
+					     ignore_empty,
 					     overrides_str);
 	}
 
@@ -496,8 +503,12 @@ ascli_validate_files_format (gchar **argv,
 		g_autofree gchar *yaml_result = NULL;
 
 		if (argc < 1) {
-			g_print ("%s\n", _("You need to specify at least one file to validate!"));
-			return 1;
+			if (ignore_empty) {
+				return ASCLI_EXIT_CODE_SUCCESS;
+			} else {
+				g_print ("%s\n", _("You need to specify at least one file to validate!"));
+				return ASCLI_EXIT_CODE_FAILED;
+			}
 		}
 
 		validator = as_validator_new ();

--- a/tools/ascli-actions-validate.h
+++ b/tools/ascli-actions-validate.h
@@ -31,12 +31,14 @@ gint ascli_validate_files (gchar      **argv,
 			   gboolean	pedantic,
 			   gboolean	validate_strict,
 			   gboolean	use_net,
+			   gboolean	ignore_empty,
 			   const gchar *overrides_str);
 gint ascli_validate_files_format (gchar	     **argv,
 				  gint	       argc,
 				  const gchar *format,
 				  gboolean     validate_strict,
 				  gboolean     use_net,
+				  gboolean     ignore_empty,
 				  const gchar *overrides_str);
 
 gint ascli_validate_tree (const gchar *root_dir,


### PR DESCRIPTION
If you run `appstreamcli validate` with no files given, it will exit with a `You need to specify at least one file to validate!` error. With this new option it no longer throws a error.

This is useful for scenarios like
```
find -name "*.metainfo.xml" | xargs appstreamcli validate --explain
```