### PR TITLE
qt: Bring back Utils::currentDistroComponentId

### DIFF
--- a/qt/utils.cpp
+++ b/qt/utils.cpp
@@ -22,6 +22,11 @@
 #include "appstream.h"
 #include "chelpers.h"
 
+QString AppStream::Utils::currentDistroComponentId()
+{
+    return QString::fromUtf8(as_get_current_distro_component_id());
+}
+
 QString AppStream::Utils::currentAppStreamVersion()
 {
     return QString::fromUtf8(as_version_string());

--- a/qt/utils.h
+++ b/qt/utils.h
@@ -29,6 +29,8 @@ namespace AppStream
 namespace Utils
 {
 
+APPSTREAMQT_EXPORT QString currentDistroComponentId();
+
 APPSTREAMQT_EXPORT QString currentAppStreamVersion();
 
 APPSTREAMQT_EXPORT int vercmpSimple(const QString &a, const QString &b);


### PR DESCRIPTION
It looks like it whas accidentally removed in
8cc4db43c386f0f8201fc7da9e14fa9ee9314998.