### PR TITLE
Explain metainfo-ancient error in more detail

### DIFF
--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -772,7 +772,8 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	{ "metainfo-ancient",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */
-	  N_("The metainfo file uses an ancient version of the AppStream specification, which can not be validated. Please migrate it to version 0.6 (or higher), which uses a <component> root tag instead of <application> among other things."),
+	  N_("The metainfo file uses an ancient version of the AppStream specification, which can not be validated. Please migrate it to version 0.6 (or higher). "
+	  "Modern files use the `component` root tag and include many other changes, so check changes carefully when modernizing the data."),
 	},
 
 	{ "root-tag-unknown",

--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -772,7 +772,7 @@ AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	{ "metainfo-ancient",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  /* TRANSLATORS: Please do not translate AppStream tag and property names (in backticks). */
-	  N_("The metainfo file uses an ancient version of the AppStream specification, which can not be validated. Please migrate it to version 0.6 (or higher)."),
+	  N_("The metainfo file uses an ancient version of the AppStream specification, which can not be validated. Please migrate it to version 0.6 (or higher), which uses a <component> root tag instead of <application> among other things."),
 	},
 
 	{ "root-tag-unknown",


### PR DESCRIPTION
I tried to validate https://github.com/LibreSprite/LibreSprite/blob/4dac17fd198288d91c07592373449dcdddaf7e24/desktop/libresprite.appdata.xml and got this error:

```
$ flatpak run org.freedesktop.appstream.cli validate --explain desktop/libresprite.metainfo.xml
E: ~:2: metainfo-ancient
   The metainfo file uses an ancient version of the AppStream specification, which can not be
   validated. Please migrate it to version 0.6 (or higher).

✘ Validation failed: errors: 1
```

I compared it to a valid metainfo file to see the differences at a glance.
I think adding the explanation regarding the different root tag would be helpful.