### PR TITLE
meson: Pass -D_DARWIN_C_SOURCE on darwin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,11 @@ if host_machine.system() != 'netbsd'
     add_project_arguments('-D_POSIX_C_SOURCE=201710L', language: 'c')
 endif
 
+if host_machine.system() == 'darwin'
+    # See https://github.com/ximion/appstream/issues/551
+    add_project_arguments('-D_DARWIN_C_SOURCE', language: 'c')
+endif
+
 if cc.get_id() == 'clang'
     # Clang doesn't understand autofree helpers on GMutexLocker and thinks
     # these variables are irrelevant, so this warning when used with Clang

--- a/src/as-system-info.c
+++ b/src/as-system-info.c
@@ -47,12 +47,6 @@
 #include <dirent.h>
 #include <glib.h>
 
-#if defined(__APPLE__)
-typedef unsigned int u_int;
-typedef unsigned char u_char;
-typedef unsigned short u_short;
-#endif
-
 #if defined(__linux__)
 #include <sys/sysinfo.h>
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)


### PR DESCRIPTION
This is probably a follow-up for 02ee2d0daa ("fix macos build") and unbreaks the build on Nixpkgs x86_64-darwin. I don't know why, probably due to using even older SDKs? :upside_down_face: 

https://github.com/NixOS/nixpkgs/runs/19486840382
https://logs.ofborg.org/?key=nixos/nixpkgs.273297&attempt_id=05115a28-17b2-4d53-b0e9-d6c2f6a02b63

```
> In file included from ../src/as-system-info.c:60:
> In file included from /nix/store/51c1k4sj0irwgyvkgbyhqi0ggilyh3j2-Libsystem-1238.60.2/include/sys/sysctl.h:83:
> /nix/store/51c1k4sj0irwgyvkgbyhqi0ggilyh3j2-Libsystem-1238.60.2/include/sys/ucred.h:91:2: error: unknown type name 'u_long'
>         u_long  cr_ref;                 /* reference count */
>         ^
> 1 error generated.
> ninja: build stopped: subcommand failed.
```

Update: Instead of adding another typedef, apply the suggestions on pull request 556 to pass `-D_DARWIN_C_SOURCE`, which seems to work fine for us too.