### PR TITLE
Docs: Mention that <summary/> tag can be translated

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -194,6 +194,7 @@
 		<listitem>
 			<para>
 			A short summary of what this component does. If the component is "PackageKit", the summary could be "Provides a package-management abstraction layer".
+			This element is translatable.
 			</para>
 		</listitem>
 		</varlistentry>


### PR DESCRIPTION
Not sure if this is correct, but `appstreamcli validate` doesn't complain about it.