### PR TITLE
pool: Add missing Q_EMIT keyword

### DIFF
--- a/qt/pool.cpp
+++ b/qt/pool.cpp
@@ -60,7 +60,7 @@ static inline ComponentBox absorbResultToCBox(AsComponentBox *cbox)
 
 static void pool_changed_cb(AsPool *cpool, AppStream::Pool *qpool)
 {
-    qpool->changed();
+    Q_EMIT qpool->changed();
 }
 
 static void pool_ready_async_cb(AsPool *cpool, GAsyncResult *result, gpointer user_data)


### PR DESCRIPTION
Not that Q_EMIT macro functionally does anything at all, but it is conventional to put it in front of signals.