### PR TITLE
qt: Component::customValue should be const

### DIFF
--- a/qt/component.cpp
+++ b/qt/component.cpp
@@ -708,6 +708,11 @@ QHash<QString, QString> AppStream::Component::custom() const
     return result;
 }
 
+QString AppStream::Component::customValue(const QString &key) const
+{
+    return valueWrap(as_component_get_custom_value(d->cpt, qPrintable(key)));
+}
+
 QString AppStream::Component::customValue(const QString &key)
 {
     return valueWrap(as_component_get_custom_value(d->cpt, qPrintable(key)));

--- a/qt/component.h
+++ b/qt/component.h
@@ -253,7 +253,8 @@ public:
     void setMergeKind(MergeKind kind);
 
     QHash<QString, QString> custom() const;
-    QString customValue(const QString &key);
+    QString customValue(const QString &key) const;
+    [[deprecated]] QString customValue(const QString &key); //TODO Remove when we break ABI
     bool insertCustomValue(const QString &key, const QString &value);
 
     QList<AppStream::ContentRating> contentRatings() const;


### PR DESCRIPTION
Since it was omitted, add the const and overload the method for now.