### PR TITLE
sysinfo: Swap arguments of g_pattern_match_simple

### DIFF
--- a/src/as-system-info.c
+++ b/src/as-system-info.c
@@ -672,7 +672,7 @@ as_system_info_has_device_matching_modalias (AsSystemInfo *sysinfo, const gchar 
 		if (g_strcmp0 (modalias, modalias_glob) == 0)
 			return TRUE;
 
-		if (g_pattern_match_simple (modalias, modalias_glob))
+		if (g_pattern_match_simple (modalias_glob, modalias))
 			return TRUE;
 	}
 


### PR DESCRIPTION
According to the [GLib doc](https://docs.gtk.org/glib/func.pattern_match_simple.html) the globbed pattern is the first argument, while the string to test comes after.

This fixes the fact that `as_system_info_has_device_matching_modalias` could return `TRUE` for a 1:1 equality with the pattern, but always returned `FALSE` when using wildcards.