### PR TITLE
Use io.github for ID example

### DIFF
--- a/docs/xml/metainfo-component.xml
+++ b/docs/xml/metainfo-component.xml
@@ -1169,7 +1169,7 @@
 		</para>
 		<para>
 			The element should have a <literal>id</literal> property, containing a unique ID to identify the respective developer. It is recommended to use a reverse-DNS
-			name, like <code>org.gnome</code> or <code>com.github.ximion</code>, as ID to achieve a higher chance of uniqueness.
+			name, like <code>org.gnome</code> or <code>io.github.ximion</code>, as ID to achieve a higher chance of uniqueness.
 		</para>
 		<para>
 			Every <literal>developer</literal> element must have a <literal>name</literal> tag as child, which contains a translatable name for the


### PR DESCRIPTION
Github very specifically puts all user hosted websites under `github.io` as its a completely different domain than `github.com` which controls all officially hosted websites.

Using `io.github` for an ID makes it explicitly clear it is not associated with an official Github project which certainly could be packaged.