### PR TITLE
docs: List AppStreamCompose as related to AppStream

### DIFF
--- a/docs/api/appstream.toml.in
+++ b/docs/api/appstream.toml.in
@@ -25,6 +25,13 @@ dependencies = [
   description = "A modern, easy-to-use VFS API"
   docs_url = "https://docs.gtk.org/gio/"
 
+related = ["AppStreamCompose-1.0"]
+
+  [related."AppStreamCompose-1.0"]
+  name = "AppStreamCompose"
+  description = "Library to compose AppStream catalog metadata"
+  docs_url = "https://www.freedesktop.org/software/appstream/docs/compose-api/"
+
 [theme]
 name = "basic"
 show_index_summary = true


### PR DESCRIPTION
Improve discoverability of the AppStreamCompose API in AppStream API docs, in a similar way as it's done between Glib, GIO and GObject in their docs.