### PR TITLE
Add Plasma Mobile to desktop-style-ids.txt

### DIFF
--- a/data/desktop-style-ids.txt
+++ b/data/desktop-style-ids.txt
@@ -1,20 +1,21 @@
 # List of recognized GUI environments
 # ID            Human-readable name
 #
-cinnamon    Cinnamon
-dde         Deepin
-ede         EDE
-endless     Endless
-gnome       GNOME
-gnome:dark  GNOME (Dark)
-lxde        LXDE
-lxqt        LXQt
-macos       macOS
-mate        Mate
-pantheon    Pantheon
-plasma      KDE Plasma
-razor       Razor
-rox         Rox
-unity       Unity
-windows     Microsoft Windows
-xfce        Xfce
+cinnamon      Cinnamon
+dde           Deepin
+ede           EDE
+endless       Endless
+gnome         GNOME
+gnome:dark    GNOME (Dark)
+lxde          LXDE
+lxqt          LXQt
+macos         macOS
+mate          Mate
+pantheon      Pantheon
+plasma        KDE Plasma
+plasma-mobile KDE Plasma Mobile
+razor         Razor
+rox           Rox
+unity         Unity
+windows       Microsoft Windows
+xfce          Xfce

--- a/data/desktop-style-ids.txt
+++ b/data/desktop-style-ids.txt
@@ -13,7 +13,7 @@ macos         macOS
 mate          Mate
 pantheon      Pantheon
 plasma        KDE Plasma
-plasma-mobile KDE Plasma Mobile
+plasma-mobile Plasma Mobile
 razor         Razor
 rox           Rox
 unity         Unity

--- a/src/as-desktop-env-data.h
+++ b/src/as-desktop-env-data.h
@@ -97,6 +97,8 @@ AsGUIEnvStyleData as_gui_env_style_data[] = {
 	{ "pantheon", N_("Pantheon") },
 	/* TRANSLATORS: Name of the "plasma" visual environment style. */
 	{ "plasma", N_("KDE Plasma") },
+	/* TRANSLATORS: Name of the "plasma-mobile" visual environment style. */
+	{ "plasma-mobile", N_("KDE Plasma Mobile") },
 	/* TRANSLATORS: Name of the "razor" visual environment style. */
 	{ "razor", N_("Razor") },
 	/* TRANSLATORS: Name of the "rox" visual environment style. */

--- a/src/as-desktop-env-data.h
+++ b/src/as-desktop-env-data.h
@@ -98,7 +98,7 @@ AsGUIEnvStyleData as_gui_env_style_data[] = {
 	/* TRANSLATORS: Name of the "plasma" visual environment style. */
 	{ "plasma", N_("KDE Plasma") },
 	/* TRANSLATORS: Name of the "plasma-mobile" visual environment style. */
-	{ "plasma-mobile", N_("KDE Plasma Mobile") },
+	{ "plasma-mobile", N_("Plasma Mobile") },
 	/* TRANSLATORS: Name of the "razor" visual environment style. */
 	{ "razor", N_("Razor") },
 	/* TRANSLATORS: Name of the "rox" visual environment style. */


### PR DESCRIPTION
As discussed in #611 this PR adds Plasma Mobile to the list of desktop style ids.

Let me know if anything is missing