### PR TITLE
i18n: update Catalan translation

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -27,16 +27,15 @@ msgstr ""
 "Project-Id-Version: appstream\n"
 "Report-Msgid-Bugs-To: appstream@lists.freedesktop.org\n"
 "POT-Creation-Date: 2024-04-24 20:20+0200\n"
-"PO-Revision-Date: 2022-09-16 05:17+0000\n"
-"Last-Translator: Maite Guix <maite.guix@gmail.com>\n"
-"Language-Team: Catalan <https://hosted.weblate.org/projects/appstream/"
-"translations/ca/>\n"
+"PO-Revision-Date: 2024-05-19 01:04+0200\n"
+"Last-Translator: Ícar N. S. <icar.nin@protonmail.com>\n"
+"Language-Team: Catalan <https://hosted.weblate.org/projects/appstream/translations/ca/>\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1-dev\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #: data/org.freedesktop.appstream.cli.metainfo.xml:8
 msgid "AppStream CLI"
@@ -47,37 +46,14 @@ msgid "An utility to work with AppStream metadata"
 msgstr "Una utilitat per a treballar amb les metadades AppStream"
 
 #: data/org.freedesktop.appstream.cli.metainfo.xml:12
-msgid ""
-"AppStream is a metadata specification which permits software components to "
-"provide information about themselves to automated systems and end-users "
-"before the software is actually installed. The AppStream project provides "
-"facilities to easily access and transform this metadata, as well as a few "
-"additional services for building feature-rich software centers and similar "
-"applications that make use of software metadata."
+msgid "AppStream is a metadata specification which permits software components to provide information about themselves to automated systems and end-users before the software is actually installed. The AppStream project provides facilities to easily access and transform this metadata, as well as a few additional services for building feature-rich software centers and similar applications that make use of software metadata."
 msgstr ""
-"AppStream és una especificació de metadades que permet als components de "
-"programari proporcionar informació sobre si mateixos als sistemes "
-"automatitzats i als usuaris finals abans que el programari s'instal·li "
-"realment. El projecte AppStream proporciona instal·lacions per a accedir i "
-"transformar fàcilment aquestes metadades, així com alguns serveis "
-"addicionals per a la construcció de centres de programari rics en funcions i "
-"aplicacions similars que fan ús de metadades de programari."
+"AppStream és una especificació de metadades que permet als components de programari proporcionar informació sobre si mateixos als sistemes automatitzats i als usuaris finals abans que el programari s'instal·li realment. El projecte AppStream proporciona instal·lacions per a accedir i transformar fàcilment aquestes metadades, així com alguns serveis addicionals per a la construcció de centres de programari rics en funcions i aplicacions similars "
+"que fan ús de metadades de programari."
 
 #: data/org.freedesktop.appstream.cli.metainfo.xml:18
-msgid ""
-"The <em>appstreamcli</em> command-line tool allows to read, write, and "
-"transform AppStream XML or YAML metadata as well as to validate it for "
-"compliance with the specification. It also provides easy access to the "
-"system metadata pool, for example to query for software that provides a "
-"specific Mediatype handler or for installing software by its component "
-"identifier."
-msgstr ""
-"L'eina de línia d'ordres <em>appstreamcli</em> permet llegir, escriure i "
-"transformar metadades APPStream XML o YAML, així com validar-les per al "
-"compliment de l'especificació. També proporciona un fàcil accés al conjunt "
-"de metadades del sistema, per exemple per a consultar programari que "
-"proporciona un controlador de Mediatype específic o per a instal·lar "
-"programari pel seu identificador de components."
+msgid "The <em>appstreamcli</em> command-line tool allows to read, write, and transform AppStream XML or YAML metadata as well as to validate it for compliance with the specification. It also provides easy access to the system metadata pool, for example to query for software that provides a specific Mediatype handler or for installing software by its component identifier."
+msgstr "L'eina de línia d'ordres <em>appstreamcli</em> permet llegir, escriure i transformar metadades APPStream XML o YAML, així com validar-les per al compliment de l'especificació. També proporciona un fàcil accés al conjunt de metadades del sistema, per exemple per a consultar programari que proporciona un controlador de Mediatype específic o per a instal·lar programari pel seu identificador de components."
 
 #: src/as-cache.c:904
 #, c-format
@@ -395,7 +371,8 @@ msgid "Office"
 msgstr "Ofimàtica"
 
 #. TRANSLATORS: this is the main category for Add-ons
-#. TRANSLATORS: Addons are extensions for existing software components, e.g. support for more visual effects for a video editor
+#. TRANSLATORS: Addons are extensions for existing software components, e.g.
+#. support for more visual effects for a video editor
 #: src/as-category.c:324 tools/ascli-utils.c:418
 msgid "Add-ons"
 msgstr "Extensions"
@@ -454,513 +431,602 @@ msgstr "Tothom"
 msgid "Early Childhood"
 msgstr "Infantesa"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:835
 msgid "No cartoon violence"
 msgstr "Sense violència de personatges animats"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:837
 msgid "Cartoon characters in unsafe situations"
 msgstr "Personatges animats en situacions insegures"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:839
 msgid "Cartoon characters in aggressive conflict"
 msgstr "Personatges animats en conflictes agressius"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:841
 msgid "Graphic violence involving cartoon characters"
 msgstr "Violència gràfica amb personatges animats"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:846
 msgid "No fantasy violence"
 msgstr "Sense violència fantàstica"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:848
 msgid "Characters in unsafe situations easily distinguishable from reality"
-msgstr ""
-"Personatges en situacions insegures fàcilment distingibles de la realitat"
+msgstr "Personatges en situacions insegures fàcilment distingibles de la realitat"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:850
 msgid "Characters in aggressive conflict easily distinguishable from reality"
-msgstr ""
-"Personatges en conflictes agressius fàcilment distingibles de la realitat"
+msgstr "Personatges en conflictes agressius fàcilment distingibles de la realitat"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:852
 msgid "Graphic violence easily distinguishable from reality"
 msgstr "Violència gràfica fàcilment distingible de la realitat"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:857
 msgid "No realistic violence"
 msgstr "Sense violència realista"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:859
 msgid "Mildly realistic characters in unsafe situations"
 msgstr "Personatges mig reals en situacions insegures"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:861
 msgid "Depictions of realistic characters in aggressive conflict"
 msgstr "Representacions de personatges realistes en conflictes agressius"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:863
 msgid "Graphic violence involving realistic characters"
 msgstr "Violència gràfica amb personatges realistes"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:868
 msgid "No bloodshed"
 msgstr "Sense matances"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:870
 msgid "Unrealistic bloodshed"
 msgstr "Matances no realistes"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:872
 msgid "Realistic bloodshed"
 msgstr "Matances realistes"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:874
 msgid "Depictions of bloodshed and the mutilation of body parts"
 msgstr "Representacions de matances i mutilacions de parts del cos"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:879
 msgid "No sexual violence"
 msgstr "Sense violència sexual"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:883
 msgid "Rape or other violent sexual behavior"
 msgstr "Violació o altres comportaments sexuals violents"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:888
 msgid "No references to alcohol"
 msgstr "Sense referències a l'alcohol"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:890
 msgid "References to alcoholic beverages"
 msgstr "Referències a begudes alcohòliques"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:892
 msgid "Use of alcoholic beverages"
 msgstr "Ús de begudes alcohòliques"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:898
 msgid "No references to illicit drugs"
 msgstr "Sense referències a drogues il·legals"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:900
 msgid "References to illicit drugs"
 msgstr "Referències a drogues il·legals"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:902
 msgid "Use of illicit drugs"
 msgstr "Ús de drogues il·legals"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:908
 msgid "No references to tobacco products"
 msgstr "Sense referències als productes del tàbac"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:910
 msgid "References to tobacco products"
 msgstr "Referències als productes del tàbac"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:912
 msgid "Use of tobacco products"
 msgstr "Ús de productes del tàbac"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:918
 msgid "No nudity of any sort"
 msgstr "Sense nuesa de cap tipus"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:920
 msgid "Brief artistic nudity"
 msgstr "Nuesa artística breu"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:922
 msgid "Prolonged nudity"
 msgstr "Nuesa prolongada"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:924
 msgid "Explicit nudity involving visible sexual organs"
-msgstr ""
+msgstr "Nuesa explícita amb òrgans sexuals visibles"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:929
 msgid "No references to or depictions of sexual nature"
 msgstr "Sense referències o representacions sexuals"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:931
 msgid "Provocative references or depictions"
 msgstr "Referències o representacions provocatives"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:933
 msgid "Sexual references or depictions"
 msgstr "Referències o representacions sexuals"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:935
 msgid "Graphic sexual behavior"
 msgstr "Comportament sexual gràfic"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:940
 msgid "No profanity of any kind"
 msgstr "Sense blasfèmia de cap tipus"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:942
 msgid "Mild or infrequent use of profanity"
 msgstr "Ús lleu o poc freqüent de la blasfèmia"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:944
 msgid "Moderate use of profanity"
 msgstr "Ús moderat de la blasfèmia"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:946
 msgid "Strong or frequent use of profanity"
 msgstr "Ús extensiu o freqüent de la blasfèmia"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:951
 msgid "No inappropriate humor"
 msgstr "Sense humor inapropiat"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:953
 msgid "Slapstick humor"
 msgstr "Humor vulgar"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:955
 msgid "Vulgar or bathroom humor"
 msgstr "Humor groller"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:957
 msgid "Mature or sexual humor"
 msgstr "Humor adult o sexual"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:962
 msgid "No discriminatory language of any kind"
 msgstr "Sense llenguatge discriminatori de cap tipus"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:964
 msgid "Negativity towards a specific group of people"
 msgstr "Negatiu respecte a un grup específic de gent"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:966
 msgid "Discrimination designed to cause emotional harm"
 msgstr "Discriminació pensada per a causar dany emocional"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:968
 msgid "Explicit discrimination based on gender, sexuality, race or religion"
 msgstr "Discriminació explicita basada en gènere, sexualitat, raça o religió"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:973
 msgid "No advertising of any kind"
 msgstr "Sense publicitat de cap tipus"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:975
 msgid "Product placement"
 msgstr "﻿Emplaçament de producte"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:977
 msgid "Explicit references to specific brands or trademarked products"
-msgstr ""
-"Referències explícites a marques específiques o productes de marques "
-"registrades"
+msgstr "Referències explícites a marques específiques o productes de marques registrades"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:979
 msgid "Users are encouraged to purchase specific real-world items"
 msgstr "S'anima als usuaris a comprar coses específiques del món real"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:984
 msgid "No gambling of any kind"
 msgstr "Sense apostes de cap tipus"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:986
 msgid "Gambling on random events using tokens or credits"
 msgstr "Apostes en esdeveniments aleatoris utilitzant testimonis o crèdits"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:988
 msgid "Gambling using “play” money"
 msgstr "Apostes usant moneda virtual al joc"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:990
 msgid "Gambling using real money"
 msgstr "Apostes usant diners reals"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:995
 msgid "No ability to spend money"
 msgstr "Sense possibilitat de gastar diners"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:997
 msgid "Users are encouraged to donate real money"
 msgstr "S'anima als usuaris a comprar coses específiques del món real"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1000
 msgid "Ability to spend real money in-app"
 msgstr "Possibilitat de gastar diners de veritat al joc"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1005
 msgid "No way to chat with other users"
 msgstr "Sense possibilitat de fer xat amb els altres usuaris"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1007
 msgid "User-to-user interactions without chat functionality"
 msgstr "Interaccions usuari a usuari sense funcionalitat xat"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1009
 msgid "Moderated chat functionality between users"
 msgstr "Funcionalitat de xat no supervisada entre usuaris"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1011
 msgid "Uncontrolled chat functionality between users"
 msgstr "Funcionalitat de xat no supervisada entre usuaris"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1016
 msgid "No way to talk with other users"
 msgstr "Sense possibilitat de parlar amb els altres usuaris"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1019
-#, fuzzy
 msgid "Moderated audio or video chat functionality between users"
-msgstr "Funcionalitat de xat d'àudio o vídeo no supervisada entre usuaris"
+msgstr "Funcionalitat de xat d'àudio o vídeo moderada entre usuaris"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1021
 msgid "Uncontrolled audio or video chat functionality between users"
 msgstr "Funcionalitat de xat d'àudio o vídeo no supervisada entre usuaris"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1026
 msgid "No sharing of social network usernames or email addresses"
-msgstr ""
-"No es comparteixen els noms d'usuari de la xarxa social ni les adreces de "
-"correu electrònic"
+msgstr "No es comparteixen els noms d'usuari de la xarxa social ni les adreces de correu electrònic"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1030
 msgid "Sharing social network usernames or email addresses"
-msgstr ""
-"Compartició de noms d'usuari de la xarxa social o adreces de correu "
-"electrònic"
+msgstr "Compartició de noms d'usuari de la xarxa social o adreces de correu electrònic"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1035
 msgid "No sharing of user information with third parties"
 msgstr "No es comparteix informació de l'usuari amb terceres parts"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1037
 msgid "Checking for the latest application version"
 msgstr "Comprova si hi ha una versió més nova de l'aplicació"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1039
 msgid "Sharing diagnostic data that does not let others identify the user"
-msgstr ""
-"La compartició de dades de diagnòstic no permet a altres identificar l'usuari"
+msgstr "La compartició de dades de diagnòstic no permet a altres identificar l'usuari"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1041
 msgid "Sharing information that lets others identify the user"
-msgstr ""
-"La compartició de dades de diagnòstic permet a altres identificar l'usuari"
+msgstr "La compartició de dades de diagnòstic permet a altres identificar l'usuari"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1046
 msgid "No sharing of physical location with other users"
 msgstr "No es comparteix la ubicació física amb altres usuaris"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1050
 msgid "Sharing physical location with other users"
 msgstr "Es comparteix la ubicació física amb altres usuaris"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1071
 msgid "No references to homosexuality"
 msgstr "Sense referències a homosexualitat"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1073
 msgid "Indirect references to homosexuality"
 msgstr "Referències indirectes a l'homosexualitat"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1075
 msgid "Kissing between people of the same gender"
 msgstr "Petons entre persones del mateix sexe"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1077
 msgid "Graphic sexual behavior between people of the same gender"
 msgstr "Comportament sexual gràfic entre gent del mateix sexe"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1082
 msgid "No references to prostitution"
 msgstr "Sense referències a la prostitució"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1084
 msgid "Indirect references to prostitution"
 msgstr "Referències indirectes a la prostitució"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1086
 msgid "Direct references to prostitution"
 msgstr "Referències directes a la prostitució"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1088
 msgid "Graphic depictions of the act of prostitution"
 msgstr "Representacions gràfiques de l'acte de prostitució"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1093
 msgid "No references to adultery"
 msgstr "Sense referències a l'adulteri"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1095
 msgid "Indirect references to adultery"
 msgstr "Referències indirectes a l'adulteri"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1097
 msgid "Direct references to adultery"
 msgstr "Referències directes a l'adulteri"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1099
 msgid "Graphic depictions of the act of adultery"
 msgstr "Representacions gràfiques de l'acte d'adulteri"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1104
 msgid "No sexualized characters"
 msgstr "Sense personatges sexualitzats"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1107
 msgid "Scantily clad human characters"
 msgstr "Personatges humans lleugers de roba"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1109
 msgid "Overtly sexualized human characters"
 msgstr "Personatges humans obertament sexualitzats"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1114
 msgid "No references to desecration"
 msgstr "Sense referències a la profanació"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1116
 msgid "Depictions of or references to historical desecration"
 msgstr "Representacions o referències històriques de profanació"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1118
 msgid "Depictions of modern-day human desecration"
 msgstr "Representacions d'avui en dia de profanació"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1120
 msgid "Graphic depictions of modern-day desecration"
 msgstr "Representacions gràfiques d'avui en dia de profanació"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1125
 msgid "No visible dead human remains"
 msgstr "Sense restes mortals humanes visibles"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1127
 msgid "Visible dead human remains"
 msgstr "Restes mortals humanes visibles"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1129
 msgid "Dead human remains that are exposed to the elements"
 msgstr "Restes mortals humanes són exposades als elements"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1131
 msgid "Graphic depictions of desecration of human bodies"
 msgstr "Representacions gràfiques de profanació de cossos humans"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1136
 msgid "No references to slavery"
 msgstr "Sense referències a l'esclavitud"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1138
 msgid "Depictions of or references to historical slavery"
 msgstr "Representacions o referències històriques d'esclavitud"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1140
 msgid "Depictions of modern-day slavery"
 msgstr "Representacions de l'esclavitud d’avui en dia"
 
-#. TRANSLATORS: content rating description, see https://hughsie.github.io/oars/
+#. TRANSLATORS: content rating description, see
+#. https://hughsie.github.io/oars/
 #: src/as-content-rating.c:1142
 msgid "Graphic depictions of modern-day slavery"
 msgstr "Representacions gràfiques de l'esclavitud avui en dia"
@@ -982,13 +1048,15 @@ msgstr "No s'ha pogut baixar el fitxer: %s"
 msgid "URL was not found on the server."
 msgstr "No s'ha trobat l'adreça URL al servidor."
 
-#. TRANSLATORS: We received an uexpected HTTP status code while talking to a server, likely an error
+#. TRANSLATORS: We received an uexpected HTTP status code while talking to a
+#. server, likely an error
 #: src/as-curl.c:183
 #, c-format
 msgid "Unexpected status code: %ld"
 msgstr "Codi d'estat inesperat: %ld"
 
-#. TRANSLATORS: We tried to download from an URL, but the retrieved data was empty
+#. TRANSLATORS: We tried to download from an URL, but the retrieved data was
+#. empty
 #: src/as-curl.c:420
 #, c-format
 msgid "Retrieved file size was zero."
@@ -998,116 +1066,114 @@ msgstr "La mida del fitxer recuperat era zero."
 #. TRANSLATORS: Name of the "cinnamon" visual environment style.
 #: src/as-desktop-env-data.h:43 src/as-desktop-env-data.h:77
 msgid "Cinnamon"
-msgstr ""
+msgstr "Cinnamon"
 
 #. TRANSLATORS: Name of the "DDE" desktop environment.
 #. TRANSLATORS: Name of the "dde" visual environment style.
 #: src/as-desktop-env-data.h:45 src/as-desktop-env-data.h:79
 msgid "Deepin"
-msgstr ""
+msgstr "Deepin"
 
 #. TRANSLATORS: Name of the "EDE" desktop environment.
 #. TRANSLATORS: Name of the "ede" visual environment style.
 #: src/as-desktop-env-data.h:47 src/as-desktop-env-data.h:81
 msgid "EDE"
-msgstr ""
+msgstr "EDE"
 
 #. TRANSLATORS: Name of the "Endless" desktop environment.
 #. TRANSLATORS: Name of the "endless" visual environment style.
 #: src/as-desktop-env-data.h:49 src/as-desktop-env-data.h:83
-#, fuzzy
 msgid "Endless"
-msgstr "Paquet"
+msgstr "Endless"
 
 #. TRANSLATORS: Name of the "GNOME" desktop environment.
 #. TRANSLATORS: Name of the "gnome" visual environment style.
 #: src/as-desktop-env-data.h:51 src/as-desktop-env-data.h:85
 msgid "GNOME"
-msgstr ""
+msgstr "GNOME"
 
 #. TRANSLATORS: Name of the "KDE" desktop environment.
 #. TRANSLATORS: Name of the "Plasma" desktop environment.
 #. TRANSLATORS: Name of the "plasma" visual environment style.
-#: src/as-desktop-env-data.h:53 src/as-desktop-env-data.h:63
-#: src/as-desktop-env-data.h:99
+#: src/as-desktop-env-data.h:53 src/as-desktop-env-data.h:63 src/as-desktop-env-data.h:99
 msgid "KDE Plasma"
-msgstr ""
+msgstr "KDE Plasma"
 
 #. TRANSLATORS: Name of the "LXDE" desktop environment.
 #. TRANSLATORS: Name of the "lxde" visual environment style.
 #: src/as-desktop-env-data.h:55 src/as-desktop-env-data.h:89
 msgid "LXDE"
-msgstr ""
+msgstr "LXDE"
 
 #. TRANSLATORS: Name of the "LXQt" desktop environment.
 #. TRANSLATORS: Name of the "lxqt" visual environment style.
 #: src/as-desktop-env-data.h:57 src/as-desktop-env-data.h:91
 msgid "LXQt"
-msgstr ""
+msgstr "LXQt"
 
 #. TRANSLATORS: Name of the "MATE" desktop environment.
 #: src/as-desktop-env-data.h:59
 msgid "MATE"
-msgstr ""
+msgstr "MATE"
 
 #. TRANSLATORS: Name of the "Pantheon" desktop environment.
 #. TRANSLATORS: Name of the "pantheon" visual environment style.
 #: src/as-desktop-env-data.h:61 src/as-desktop-env-data.h:97
 msgid "Pantheon"
-msgstr ""
+msgstr "Pantheon"
 
 #. TRANSLATORS: Name of the "Razor" desktop environment.
 #. TRANSLATORS: Name of the "razor" visual environment style.
 #: src/as-desktop-env-data.h:65 src/as-desktop-env-data.h:103
 msgid "Razor"
-msgstr ""
+msgstr "Razor"
 
 #. TRANSLATORS: Name of the "ROX" desktop environment.
 #: src/as-desktop-env-data.h:67
 msgid "ROX"
-msgstr ""
+msgstr "ROX"
 
 #. TRANSLATORS: Name of the "Unity" desktop environment.
 #. TRANSLATORS: Name of the "unity" visual environment style.
 #: src/as-desktop-env-data.h:69 src/as-desktop-env-data.h:107
 msgid "Unity"
-msgstr ""
+msgstr "Unity"
 
 #. TRANSLATORS: Name of the "XFCE" desktop environment.
 #. TRANSLATORS: Name of the "xfce" visual environment style.
 #: src/as-desktop-env-data.h:71 src/as-desktop-env-data.h:111
 msgid "Xfce"
-msgstr ""
+msgstr "Xfce"
 
 #. TRANSLATORS: Name of the "gnome:dark" visual environment style.
 #: src/as-desktop-env-data.h:87
 msgid "GNOME (Dark)"
-msgstr ""
+msgstr "GNOME (Fosc)"
 
 #. TRANSLATORS: Name of the "macos" visual environment style.
 #: src/as-desktop-env-data.h:93
 msgid "macOS"
-msgstr ""
+msgstr "macOS"
 
 #. TRANSLATORS: Name of the "mate" visual environment style.
 #: src/as-desktop-env-data.h:95
 msgid "Mate"
-msgstr ""
+msgstr "Mate"
 
 #. TRANSLATORS: Name of the "plasma-mobile" visual environment style.
 #: src/as-desktop-env-data.h:101
 msgid "Plasma Mobile"
-msgstr ""
+msgstr "Plasma Mòbil"
 
 #. TRANSLATORS: Name of the "rox" visual environment style.
 #: src/as-desktop-env-data.h:105
 msgid "Rox"
-msgstr ""
+msgstr "Rox"
 
 #. TRANSLATORS: Name of the "windows" visual environment style.
 #: src/as-desktop-env-data.h:109
 msgid "Microsoft Windows"
-msgstr ""
+msgstr "Microsoft Windows"
 
 #. TRANSLATORS: List of "grey-listed" words sperated with ";"
 #. Do not translate this list directly. Instead,
@@ -1186,481 +1252,484 @@ msgstr "Component"
 
 #: src/as-relation.c:1350
 msgid "pointing device (e.g. a mouse)"
-msgstr ""
+msgstr "dispositiu de punter (p. ex. un ratolí)"
 
 #: src/as-relation.c:1352
-#, fuzzy
 msgid "keyboard"
-msgstr "Tauler"
+msgstr "teclat"
 
 #: src/as-relation.c:1354
 msgid "gamepad"
-msgstr ""
+msgstr "comandament de videojocs"
 
 #: src/as-relation.c:1356
 msgid "tv remote"
-msgstr ""
+msgstr "comandament a distància de TV"
 
 #: src/as-relation.c:1358
 msgid "graphics tablet"
-msgstr ""
+msgstr "tauleta gràfica"
 
-#. TRANSLATORS: The placeholder is replaced with an input device name, e.g. "gamepad"
+#. TRANSLATORS: The placeholder is replaced with an input device name, e.g.
+#. "gamepad"
 #: src/as-relation.c:1363
-#, fuzzy, c-format
+#, c-format
 msgid "This software requires a %s for input."
-msgstr "Aquesta etiqueta requereix una propietat de tipus."
+msgstr "Aquesta programari requereix un/a %s com a mètode d'entrada."
 
 #: src/as-relation.c:1368
-#, fuzzy
 msgid "This software requires a touch input device."
-msgstr "Aquesta etiqueta requereix una propietat de tipus."
+msgstr "Aquesta programari requereix un dispositiu d'entrada tàctil."
 
 #: src/as-relation.c:1370
 msgid "This software requires a microphone to be controlled via voice input."
-msgstr ""
+msgstr "Aquest programari requereix un micròfon per ser controlat mitjançant l'entrada de veu."
 
 #: src/as-relation.c:1372
 msgid "This software requires a camera for input control."
-msgstr ""
+msgstr "Aquest programari requereix una càmera per al control de l'entrada."
 
 #: src/as-relation.c:1374
-#, fuzzy
 msgid "This software requires a method for console input."
-msgstr "Aquesta etiqueta requereix una propietat de tipus."
+msgstr "Aquesta programari requereix una un mètode d'entrada per la consola."
 
-#. TRANSLATORS: The placeholder is replaced with an input device name, e.g. "gamepad"
+#. TRANSLATORS: The placeholder is replaced with an input device name, e.g.
+#. "gamepad"
 #: src/as-relation.c:1379
 #, c-format
 msgid "This software recommends a %s for input."
-msgstr ""
+msgstr "Aquest programari recomana un/a %s per a l'entrada."
 
 #: src/as-relation.c:1384
 msgid "This software recommends a touch input device."
-msgstr ""
+msgstr "Aquest programari recomana un dispositiu d'entrada tàctil."
 
 #: src/as-relation.c:1386
 msgid "This software recommends a microphone to be controlled via voice input."
-msgstr ""
+msgstr "Aquest programari recomana un micròfon per ser controlar per l'entrada de veu."
 
 #: src/as-relation.c:1389
 msgid "This software recommends a camera for input control."
-msgstr ""
+msgstr "Aquest programari recomana una càmera per al control d'entrada."
 
 #: src/as-relation.c:1392
 msgid "This software recommends a method for console input."
-msgstr ""
+msgstr "Aquest programari recomana un mètode per a l'entrada per consola."
 
 #: src/as-relation.c:1397
 msgid "pointing devices (e.g. mice)"
-msgstr ""
+msgstr "dispositius de punter (p. ex. ratolins)"
 
 #: src/as-relation.c:1399
 msgid "keyboards"
-msgstr ""
+msgstr "teclats"
 
 #: src/as-relation.c:1401
 msgid "gamepads"
-msgstr ""
+msgstr "comandaments de videojocs"
 
 #: src/as-relation.c:1403
 msgid "tv remotes"
-msgstr ""
+msgstr "comandaments a distància de TV"
 
 #: src/as-relation.c:1405
 msgid "graphics tablets"
-msgstr ""
+msgstr "tauletes gràfiques"
 
-#. TRANSLATORS: The placeholder is replaced with a plural input device name, e.g. "gamepads"
+#. TRANSLATORS: The placeholder is replaced with a plural input device name,
+#. e.g. "gamepads"
 #: src/as-relation.c:1409
 #, c-format
 msgid "This software supports %s."
-msgstr ""
+msgstr "Aquest programari suporta %s."
 
 #: src/as-relation.c:1413
 msgid "This software supports touch input."
-msgstr ""
+msgstr "Aquest programari suporta l'entrada tàctil."
 
 #: src/as-relation.c:1415
 msgid "This software can be controlled via voice input."
-msgstr ""
+msgstr "Aquest programari es pot controlar mitjançant l'entrada de veu."
 
 #: src/as-relation.c:1417
 msgid "This software can be controlled via a camera."
-msgstr ""
+msgstr "Aquest programari es pot controlar a través d'una càmera."
 
 #: src/as-relation.c:1420
 msgid "This software supports operation via console commands."
-msgstr ""
+msgstr "Aquest programari admet l'operació mitjançant ordres de consola."
 
 #: src/as-relation.c:1433
 msgid "Pointing device (e.g. a mouse or touchpad) found."
-msgstr ""
+msgstr "S'ha trobat un dispositiu de punter (p. ex. un ratolí o un ratolí tàctil)."
 
 #: src/as-relation.c:1435
 msgid "Physical keyboard found."
-msgstr ""
+msgstr "S'ha trobat un teclat físic."
 
 #: src/as-relation.c:1437
 msgid "Gamepad found."
-msgstr ""
+msgstr "S'ha trobat un comandament de videojocs."
 
 #: src/as-relation.c:1439
 msgid "TV remote found."
-msgstr ""
+msgstr "S'ha trobat un comandament a distància de TV."
 
 #: src/as-relation.c:1441
 msgid "Graphics tablet found."
-msgstr ""
+msgstr "S'ha trobat una tauleta gràfica."
 
 #: src/as-relation.c:1444
 msgid "Touch input device found."
-msgstr ""
+msgstr "S'ha trobat un dispositiu d'entrada tàctil."
 
 #: src/as-relation.c:1446
 msgid "Microphone for voice input control found."
-msgstr ""
+msgstr "S'ha trobat un micròfon per al control d'entrada per veu."
 
 #: src/as-relation.c:1448
 msgid "Camera for input control found."
-msgstr ""
+msgstr "S'ha trobat una càmera per al control de l'entrada."
 
 #: src/as-relation.c:1450
 msgid "Console interface available."
-msgstr ""
+msgstr "Interfície per consola disponible."
 
 #: src/as-relation.c:1511
 #, c-format
 msgid "Software '%s' was found"
-msgstr ""
+msgstr "S'ha trobat el programari «%s»"
 
 #: src/as-relation.c:1520
 #, c-format
 msgid "Required software component '%s' is missing."
-msgstr ""
+msgstr "Falta el component de programari necessari «%s»."
 
 #: src/as-relation.c:1524
 #, c-format
 msgid "Recommended software component '%s' is missing."
-msgstr ""
+msgstr "Falta el component de programari recomanat «%s»."
 
 #: src/as-relation.c:1528
-#, fuzzy, c-format
+#, c-format
 msgid "Found supported software component '%s'."
-msgstr "S'han trobat %i components."
+msgstr "S'ha trobat el component de programari compatible «%s»."
 
 #: src/as-relation.c:1561
 #, c-format
 msgid "Found hardware that is supported by this software: '%s'"
-msgstr ""
+msgstr "S'ha trobat maquinari compatible amb aquest programari: «%s»"
 
 #: src/as-relation.c:1570
 #, c-format
 msgid "Required hardware for this software was not found on this system: '%s'"
-msgstr ""
+msgstr "No s'ha trobat el maquinari necessari per a aquest programari al sistema: «%s»"
 
 #: src/as-relation.c:1575
 #, c-format
-msgid ""
-"Recommended hardware for this software was not found on this system: '%s'"
-msgstr ""
+msgid "Recommended hardware for this software was not found on this system: '%s'"
+msgstr "No s'ha trobat el maquinari recomanat per a aquest programari al sistema: «%s»"
 
 #: src/as-relation.c:1580
 #, c-format
 msgid "This software supports hardware not present in this system: '%s'"
-msgstr ""
+msgstr "Aquest programari admet maquinari no present al sistema: «%s»"
 
 #: src/as-relation.c:1619
 #, c-format
 msgid "This software requires a %s kernel, but this system is running %s."
-msgstr ""
+msgstr "Aquest programari requereix un nucli %s, però aquest sistema està executant %s."
 
 #: src/as-relation.c:1625
 #, c-format
 msgid "This software recommends a %s kernel, but this system is running %s."
-msgstr ""
+msgstr "Aquest programari recomana un nucli %s, però aquest sistema està executant %s."
 
 #: src/as-relation.c:1631
-#, fuzzy, c-format
+#, c-format
 msgid "This software only supports a %s kernel, but may run on %s anyway."
-msgstr "Aquesta etiqueta requereix una propietat de tipus."
+msgstr "Aquest programari és compatible només amb un nucli %s, però podria funcionar amb el %s."
 
-#. TRANSLATORS: We checked a kernel dependency, the first placeholder is the required kernel name,
-#. second is comparison operator (e.g. >=), third is the expected version number fourth the current kernel name
+#. TRANSLATORS: We checked a kernel dependency, the first placeholder is the
+#. required kernel name,
+#. second is comparison operator (e.g. >=), third is the expected version
+#. number fourth the current kernel name
 #. and fifth is the version we are running.
 #: src/as-relation.c:1661
 #, c-format
 msgid "This software requires %s %s %s, but this system is running %s %s."
-msgstr ""
+msgstr "Aquest programari requereix %s %s %s, però aquest sistema està executant %s %s."
 
-#. TRANSLATORS: We checked a kernel dependency, the first placeholder is the required kernel name,
-#. second is comparison operator (e.g. >=), third is the expected version number fourth the current kernel name
+#. TRANSLATORS: We checked a kernel dependency, the first placeholder is the
+#. required kernel name,
+#. second is comparison operator (e.g. >=), third is the expected version
+#. number fourth the current kernel name
 #. and fifth is the version we are running.
 #: src/as-relation.c:1673
 #, c-format
 msgid "The use of %s %s %s is recommended, but this system is running %s %s."
-msgstr ""
+msgstr "Es recomana l'ús de %s %s %s, però aquest sistema està executant %s %s."
 
-#. TRANSLATORS: We checked a kernel dependency, the first placeholder is the kernel name,
-#. second is comparison operator (e.g. >=), third is the expected version number.
+#. TRANSLATORS: We checked a kernel dependency, the first placeholder is the
+#. kernel name,
+#. second is comparison operator (e.g. >=), third is the expected version
+#. number.
 #: src/as-relation.c:1684
-#, fuzzy, c-format
+#, c-format
 msgid "This software supports %s %s %s."
-msgstr "Aquesta etiqueta requereix una propietat de tipus."
+msgstr "Aquest programari és compatible amb %s %s %s."
 
-#. TRANSLATORS: We checked a kernel dependency, with success, the first placeholder is the current kernel name, second is its version number.
+#. TRANSLATORS: We checked a kernel dependency, with success, the first
+#. placeholder is the current kernel name, second is its version number.
 #: src/as-relation.c:1702
 #, c-format
 msgid "Kernel %s %s is supported."
-msgstr ""
+msgstr "El nucli %s %s és compatible."
 
-#. TRANSLATORS: We checked a memory dependency, the first placeholder is the comparison operator (e.g. >=),
-#. second is the expected amount of memory and fourth is the amount of memory we have.
+#. TRANSLATORS: We checked a memory dependency, the first placeholder is the
+#. comparison operator (e.g. >=),
+#. second is the expected amount of memory and fourth is the amount of memory
+#. we have.
 #: src/as-relation.c:1736
 #, c-format
-msgid ""
-"This software requires %s %.2f GiB of memory, but this system has %.2f GiB."
-msgstr ""
+msgid "This software requires %s %.2f GiB of memory, but this system has %.2f GiB."
+msgstr "Aquest programari requereix %s %.2f GiB de memòria, però aquest sistema en té %.2f ."
 
-#. TRANSLATORS: We checked a memory dependency, the first placeholder is the comparison operator (e.g. >=),
-#. second is the expected amount of memory and fourth is the amount of memory we have.
+#. TRANSLATORS: We checked a memory dependency, the first placeholder is the
+#. comparison operator (e.g. >=),
+#. second is the expected amount of memory and fourth is the amount of memory
+#. we have.
 #: src/as-relation.c:1745
 #, c-format
-msgid ""
-"This software recommends %s %.2f GiB of memory, but this system has %.2f GiB."
-msgstr ""
+msgid "This software recommends %s %.2f GiB of memory, but this system has %.2f GiB."
+msgstr "Aquest programari recomana %s %.2f GiB de memòria, però aquest sistema en té %.2f GiB."
 
-#. TRANSLATORS: We checked a memory dependency, the first placeholder is the comparison operator (e.g. >=),
+#. TRANSLATORS: We checked a memory dependency, the first placeholder is the
+#. comparison operator (e.g. >=),
 #. second is the expected amount of memory.
 #: src/as-relation.c:1754
-#, fuzzy, c-format
+#, c-format
 msgid "This software supports %s %.2f GiB of memory."
-msgstr "Aquesta etiqueta requereix una propietat de tipus."
+msgstr "Aquest programari és compatible amb %s %.2f GiB de memòria."
 
 #: src/as-relation.c:1770
 msgid "This system has sufficient memory for this software."
-msgstr ""
+msgstr "El sistema té prou memòria per a aquest programari."
 
 #: src/as-relation.c:1834
-#, fuzzy
 msgid "This software needs a display for graphical content."
-msgstr "Aquesta etiqueta requereix una propietat de tipus."
+msgstr "Aquest programari necessita una pantalla pel contingut gràfic."
 
-#. TRANSLATORS: We checked a display size dependency, the first placeholder is the comparison operator (e.g. >=),
+#. TRANSLATORS: We checked a display size dependency, the first placeholder is
+#. the comparison operator (e.g. >=),
 #. second is the expected size and third is the size the current device has.
 #: src/as-relation.c:1862
 #, c-format
-msgid ""
-"This software requires a display with its longest edge being %s %lu px in "
-"size, but the display of this device has %lu px."
-msgstr ""
+msgid "This software requires a display with its longest edge being %s %lu px in size, but the display of this device has %lu px."
+msgstr "Aquest programari requereix una pantalla amb la seva vora més llarga de %s %lu px de mida, però la pantalla d'aquest dispositiu té %lu px."
 
-#. TRANSLATORS: We checked a display size dependency, the first placeholder is the comparison operator (e.g. >=),
+#. TRANSLATORS: We checked a display size dependency, the first placeholder is
+#. the comparison operator (e.g. >=),
 #. second is the expected size and third is the size the current device has.
 #: src/as-relation.c:1871
 #, c-format
-msgid ""
-"This software requires a display with its shortest edge being %s %lu px in "
-"size, but the display of this device has %lu px."
-msgstr ""
+msgid "This software requires a display with its shortest edge being %s %lu px in size, but the display of this device has %lu px."
+msgstr "Aquest programari requereix una pantalla amb la seva vora més curta de %s %lu px de mida, però la pantalla d'aquest dispositiu té %lu px."
 
-#. TRANSLATORS: We checked a display size dependency, the first placeholder is the comparison operator (e.g. >=),
+#. TRANSLATORS: We checked a display size dependency, the first placeholder is
+#. the comparison operator (e.g. >=),
 #. second is the expected size and third is the size the current device has.
 #: src/as-relation.c:1881
 #, c-format
-msgid ""
-"This software recommends a display with its longest edge being %s %lu px in "
-"size, but the display of this device has %lu px."
-msgstr ""
+msgid "This software recommends a display with its longest edge being %s %lu px in size, but the display of this device has %lu px."
+msgstr "Aquest programari recomana una pantalla amb la seva vora més llarga amb %s %lu px de mida, però la pantalla d'aquest dispositiu té %lu px."
 
-#. TRANSLATORS: We checked a display size dependency, the first placeholder is the comparison operator (e.g. >=),
+#. TRANSLATORS: We checked a display size dependency, the first placeholder is
+#. the comparison operator (e.g. >=),
 #. second is the expected size and third is the size the current device has.
 #: src/as-relation.c:1890
 #, c-format
-msgid ""
-"This software recommends a display with its shortest edge being %s %lu px in "
-"size, but the display of this device has %lu px."
-msgstr ""
+msgid "This software recommends a display with its shortest edge being %s %lu px in size, but the display of this device has %lu px."
+msgstr "Aquest programari recomana una pantalla amb la seva vora més curta de %s %lu px de mida, però la pantalla d'aquest dispositiu té %lu px."
 
 #: src/as-relation.c:1902
 msgid "Display size is sufficient for this software."
-msgstr ""
+msgstr "La mida de la pantalla és suficient per a aquest programari."
 
 #: src/as-relation.c:1919
 #, c-format
-msgid ""
-"Satisfiability check for relation items of type '%s' is not implemented yet."
-msgstr ""
+msgid "Satisfiability check for relation items of type '%s' is not implemented yet."
+msgstr "Encara no s'ha implementat la comprovació de satisfacció per als elements de relació de tipus «%s»."
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:38
 msgid "Affero General Public License v1.0 only"
-msgstr ""
+msgstr "Llicència Pública General Affero només v1.0"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:40
 msgid "Affero General Public License v1.0 or later"
-msgstr ""
+msgstr "Llicència Pública General Affero v1.0 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:43
 msgid "GNU Affero General Public License v3.0 only"
-msgstr ""
+msgstr "Llicència Pública General GNU Affero només v3.0"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:45
 msgid "GNU Affero General Public License v3.0 or later"
-msgstr ""
+msgstr "Llicència Pública General GNU Affero v3.0 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:266
 msgid "GNU Free Documentation License v1.1 only - invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.1 només - invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:268
 msgid "GNU Free Documentation License v1.1 or later - invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.1 o posterior - invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:270
 msgid "GNU Free Documentation License v1.1 only - no invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.1 només - sense invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:272
 msgid "GNU Free Documentation License v1.1 or later - no invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.1 o posterior - sense invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:274
 msgid "GNU Free Documentation License v1.1 only"
-msgstr ""
+msgstr "Llicència de documentació lliure GNU v1.1 només"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:276
 msgid "GNU Free Documentation License v1.1 or later"
-msgstr ""
+msgstr "Llicència de documentació lliure GNU v1.1 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:279
 msgid "GNU Free Documentation License v1.2 only - invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure GNU v1.2 només - invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:281
 msgid "GNU Free Documentation License v1.2 or later - invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.2 o posterior - invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:283
 msgid "GNU Free Documentation License v1.2 only - no invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.2 només - sense invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:285
 msgid "GNU Free Documentation License v1.2 or later - no invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.2 o posterior - sense invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:287
 msgid "GNU Free Documentation License v1.2 only"
-msgstr ""
+msgstr "Llicència de documentació lliure GNU v1.2 només"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:289
 msgid "GNU Free Documentation License v1.2 or later"
-msgstr ""
+msgstr "Llicència de documentació lliure GNU v1.2 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:292
 msgid "GNU Free Documentation License v1.3 only - invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.3 només - invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:294
 msgid "GNU Free Documentation License v1.3 or later - invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.3 o posterior - invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:296
 msgid "GNU Free Documentation License v1.3 only - no invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.3 només - sense invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:298
 msgid "GNU Free Documentation License v1.3 or later - no invariants"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.3 o posterior - sense invariants"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:300
 msgid "GNU Free Documentation License v1.3 only"
-msgstr ""
+msgstr "Llicència de documentació lliure GNU v1.3 només"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:302
 msgid "GNU Free Documentation License v1.3 or later"
-msgstr ""
+msgstr "Llicència de documentació lliure de GNU v1.3 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:306 src/as-spdx-data.h:310
 msgid "GNU General Public License v1.0 only"
-msgstr ""
+msgstr "Llicència Pública General GNU només v1.0"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:308 src/as-spdx-data.h:312
 msgid "GNU General Public License v1.0 or later"
-msgstr ""
+msgstr "Llicència Pública General GNU v1.0 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:314 src/as-spdx-data.h:318
 msgid "GNU General Public License v2.0 only"
-msgstr ""
+msgstr "Llicència Pública General GNU només v2.0"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:316 src/as-spdx-data.h:320
 msgid "GNU General Public License v2.0 or later"
-msgstr ""
+msgstr "Llicència Pública General GNU v2.0 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:327 src/as-spdx-data.h:331
 msgid "GNU General Public License v3.0 only"
-msgstr ""
+msgstr "Llicència Pública General GNU v3.0 només"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:329 src/as-spdx-data.h:333
 msgid "GNU General Public License v3.0 or later"
-msgstr ""
+msgstr "Llicència Pública General GNU v3.0 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:390 src/as-spdx-data.h:394
 msgid "GNU Library General Public License v2 only"
-msgstr ""
+msgstr "Llicència Pública General de la Biblioteca GNU només v2"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:392 src/as-spdx-data.h:396
 msgid "GNU Library General Public License v2 or later"
-msgstr ""
+msgstr "Llicència Pública General de la Biblioteca GNU v2 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:398 src/as-spdx-data.h:402
 msgid "GNU Lesser General Public License v2.1 only"
-msgstr ""
+msgstr "Llicència Pública General Menor GNU només v2.1"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:400 src/as-spdx-data.h:404
 msgid "GNU Lesser General Public License v2.1 or later"
-msgstr ""
+msgstr "Llicència Pública General Menor GNU v2.1 o posterior"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:406 src/as-spdx-data.h:410
 msgid "GNU Lesser General Public License v3.0 only"
-msgstr ""
+msgstr "Llicència Pública General Menor GNU v3.0 només"
 
 #. TRANSLATORS: Please do not translate the license name itself.
 #: src/as-spdx-data.h:408 src/as-spdx-data.h:412
 msgid "GNU Lesser General Public License v3.0 or later"
-msgstr ""
+msgstr "Llicència Pública General Menor GNU v3.0 o posterior"
 
 #: src/as-validator-issue-tag.h:42
 msgid "This tag requires a type property."
@@ -1671,652 +1740,360 @@ msgid "Tags of this name are not permitted in this section."
 msgstr "Etiquetes amb aquest nom no es permeten en aquesta secció."
 
 #: src/as-validator-issue-tag.h:52
-msgid ""
-"A <description/> tag must not be localized in metainfo files (upstream "
-"metadata). Localize the individual paragraphs instead."
-msgstr ""
-"No s'ha de regionalitzar l'etiqueta <description/> als fitxers de "
-"metainformació (metadades originals). En lloc d'això, regionalitzeu els "
-"paràgrafs individuals."
+msgid "A <description/> tag must not be localized in metainfo files (upstream metadata). Localize the individual paragraphs instead."
+msgstr "No s'ha de regionalitzar l'etiqueta <description/> als fitxers de metainformació (metadades originals). En lloc d'això, regionalitzeu els paràgrafs individuals."
 
 #: src/as-validator-issue-tag.h:58
-#, fuzzy
-msgid ""
-"This element (paragraph, list, etc.) of a <description/> tag must not be "
-"localized individually in catalog metadata. Localize the whole <description/"
-"> tag instead. The AppStream metadata catalog generator (e.g. `appstream-"
-"generator`) will already do the right thing when compiling the data."
-msgstr ""
-"Aquest element (paràgraf, llista, etc.) d'una etiqueta <description/> no "
-"s'ha de localitzar individualment a les metadades de la col·lecció. "
-"Localitza l'etiqueta <description/> sencera. El generador de metadades de la "
-"col·lecció d'AppStream (per exemple, «appstream-generator») ja farà el "
-"correcte a l'hora de compilar les dades."
+msgid "This element (paragraph, list, etc.) of a <description/> tag must not be localized individually in catalog metadata. Localize the whole <description/> tag instead. The AppStream metadata catalog generator (e.g. `appstream-generator`) will already do the right thing when compiling the data."
+msgstr "Aquest element (paràgraf, llista, etc.) d'una etiqueta <description/> no s'ha de traduir individualment a les metadades de la col·lecció. Traduïu l'etiqueta <description/> sencera. El generador de metadades de la col·lecció d'AppStream (per exemple, «appstream-generator») ja farà el correcte a l'hora de compilar les dades."
 
 #: src/as-validator-issue-tag.h:64
-msgid ""
-"AppStream descriptions support only a limited set of tags to format text: "
-"Paragraphs (<p/>) and lists (<ul/>, <ol/>). This description markup contains "
-"an invalid XML tag that would not be rendered correctly in applications "
-"supporting the metainfo specification."
-msgstr ""
-"Les descripcions d'AppStream admeten només un conjunt limitat d'etiquetes "
-"del format de text: paràgrafs (<p/>) i llistes (<ul/>, <ol/>). Aquesta conté "
-"una etiqueta XML no vàlida que no es representarà correctament en "
-"aplicacions compatibles amb l'especificació de metainformació."
+msgid "AppStream descriptions support only a limited set of tags to format text: Paragraphs (<p/>) and lists (<ul/>, <ol/>). This description markup contains an invalid XML tag that would not be rendered correctly in applications supporting the metainfo specification."
+msgstr "Les descripcions d'AppStream admeten només un conjunt limitat d'etiquetes del format de text: paràgrafs (<p/>) i llistes (<ul/>, <ol/>). Aquesta conté una etiqueta XML no vàlida que no es representarà correctament en aplicacions compatibles amb l'especificació de metainformació."
 
 #: src/as-validator-issue-tag.h:70
-msgid ""
-"This description paragraph contains invalid markup. Currently, only <em/> "
-"and <code/> are permitted."
-msgstr ""
-"Aquest paràgraf de descripció conté marques no vàlides. Actualment només <em/"
-"> i <code/> estan permeses."
+msgid "This description paragraph contains invalid markup. Currently, only <em/> and <code/> are permitted."
+msgstr "Aquest paràgraf de descripció conté marques no vàlides. Actualment només <em/> i <code/> estan permeses."
 
 #: src/as-validator-issue-tag.h:75
 msgid "Enumerations must only have list items (<li/>) as children."
-msgstr ""
-"Les enumeracions només han de tenir elements de llista (<li/>) com a "
-"elements secundaris."
+msgstr "Les enumeracions només han de tenir elements de llista (<li/>) com a elements secundaris."
 
 #: src/as-validator-issue-tag.h:80
-msgid ""
-"The enumeration must not be translated as a whole. In MetaInfo files, "
-"translate individual items (<li/> elements) instead."
-msgstr ""
+msgid "The enumeration must not be translated as a whole. In MetaInfo files, translate individual items (<li/> elements) instead."
+msgstr "L'enumeració no ha de traduir-se en conjunt. En els fitxers MetaInfo, traduïu elements individuals (elements <li/>)."
 
 #: src/as-validator-issue-tag.h:86
-msgid ""
-"The first `description/p` paragraph of this component might be too short (< "
-"80 characters). Please consider starting with a longer paragraph to improve "
-"how the description looks like in software centers and to provide more "
-"detailed information on this component immediately in the first paragraph."
-msgstr ""
-"El primer paràgraf de «description/p» d'aquest component pot ser massa curt "
-"(< 80 caràcters). Considera començar amb un paràgraf més llarg per a "
-"millorar l'aspecte de la descripció als centres de programari i per a "
-"proporcionar informació més detallada sobre aquest component immediatament "
-"al primer paràgraf."
+msgid "The first `description/p` paragraph of this component might be too short (< 80 characters). Please consider starting with a longer paragraph to improve how the description looks like in software centers and to provide more detailed information on this component immediately in the first paragraph."
+msgstr "El primer paràgraf de «description/p» d'aquest component pot ser massa curt (< 80 caràcters). Considera començar amb un paràgraf més llarg per a millorar l'aspecte de la descripció als centres de programari i per a proporcionar informació més detallada sobre aquest component immediatament al primer paràgraf."
 
 #: src/as-validator-issue-tag.h:93
-msgid ""
-"The description line does not start with a capitalized word, project name or "
-"number."
-msgstr ""
-"La línia de descripció no comença amb una paraula en majúscules, un nom de "
-"projecte ni un número."
+msgid "The description line does not start with a capitalized word, project name or number."
+msgstr "La línia de descripció no comença amb una paraula en majúscules, un nom de projecte ni un número."
 
 #: src/as-validator-issue-tag.h:98
-msgid ""
-"The description contains a web URL in plain text. This is not allowed, "
-"please use the <url/> tag instead to share links."
-msgstr ""
-"La descripció conté una adreça URL en text pla. Això no està permès, "
-"utilitzeu l'etiqueta <url/> per a compartir enllaços."
+msgid "The description contains a web URL in plain text. This is not allowed, please use the <url/> tag instead to share links."
+msgstr "La descripció conté una adreça URL en text pla. Això no està permès, utilitzeu l'etiqueta <url/> per a compartir enllaços."
 
 #: src/as-validator-issue-tag.h:103
 msgid "This tag is not translatable."
 msgstr "Aquesta etiqueta no és traduïble."
 
 #: src/as-validator-issue-tag.h:108
-msgid ""
-"This tag must only appear once in this context. Having multiple tags of this "
-"kind is not valid."
-msgstr ""
-"Aquesta etiqueta només ha d'aparèixer una vegada en aquest context. Tenir "
-"diverses etiquetes d'aquest tipus no és vàlid."
+msgid "This tag must only appear once in this context. Having multiple tags of this kind is not valid."
+msgstr "Aquesta etiqueta només ha d'aparèixer una vegada en aquest context. Tenir diverses etiquetes d'aquest tipus no és vàlid."
 
 #: src/as-validator-issue-tag.h:113
-msgid ""
-"The mentioned tag is empty, which is highly likely not intended as it should "
-"have content."
-msgstr ""
-"L'etiqueta esmentada és buida, molt probablement no estava previst ja que "
-"hauria de tenir contingut."
+msgid "The mentioned tag is empty, which is highly likely not intended as it should have content."
+msgstr "L'etiqueta esmentada és buida, molt probablement no estava previst ja que hauria de tenir contingut."
 
 #: src/as-validator-issue-tag.h:118
-#, fuzzy
-msgid ""
-"The mentioned tag has text content, even though it must not contain text."
-msgstr ""
-"El component té un conjunt de valors prioritari. Això no està permès als "
-"fitxers metainfo."
+msgid "The mentioned tag has text content, even though it must not contain text."
+msgstr "L'etiqueta mencionada conté text, tot i que no hauria."
 
 #: src/as-validator-issue-tag.h:123
-msgid ""
-"The component ID is required to follow a reverse domain-name scheme for its "
-"name. See the AppStream specification for details."
-msgstr ""
-"El component-ID és necessari per a seguir un esquema de nom de domini invers "
-"per al seu nom. Consulta l'especificació d'AppStream per a més detalls."
+msgid "The component ID is required to follow a reverse domain-name scheme for its name. See the AppStream specification for details."
+msgstr "El component-ID és necessari per a seguir un esquema de nom de domini invers per al seu nom. Consulta l'especificació d'AppStream per a més detalls."
 
 #: src/as-validator-issue-tag.h:128
 msgid ""
-"The component ID is not a reverse domain-name. Please update the ID to avoid "
-"future issues and be compatible with all AppStream implementations.\n"
-"You may also consider to update the name of the accompanying .desktop file "
-"to follow the latest version of the Desktop-Entry specification and use a "
-"rDNS name for it as well. In any case, do not forget to mention the new "
-"desktop-entry in a <launchable/> tag for this component to keep the "
-"application launchable from software centers and the .desktop file data "
-"associated with the metainfo data."
+"The component ID is not a reverse domain-name. Please update the ID to avoid future issues and be compatible with all AppStream implementations.\n"
+"You may also consider to update the name of the accompanying .desktop file to follow the latest version of the Desktop-Entry specification and use a rDNS name for it as well. In any case, do not forget to mention the new desktop-entry in a <launchable/> tag for this component to keep the application launchable from software centers and the .desktop file data associated with the metainfo data."
 msgstr ""
-"El component-ID no és un nom de domini invers. Actualitza l'ID per a evitar "
-"problemes futurs i ser compatibles amb totes les implementacions "
-"d'AppStream.\n"
-"També podeu considerar actualitzar el nom del fitxer .desktop que "
-"l'acompanya per seguir l'última versió de l'especificació d’entrades "
-"d’escriptori i utilitzar un nom rDNS per a això també. En qualsevol cas, no "
-"us oblideu d'esmentar la nova entrada d'escriptori en una etiqueta "
-"<launchable/> per a aquest component per mantenir l'aplicació es pot llançar "
-"des dels centres de programari i les dades de fitxers .desktop associats a "
-"les dades metainfo."
+"El component-ID no és un nom de domini invers. Actualitza l'ID per a evitar problemes futurs i ser compatibles amb totes les implementacions d'AppStream.\n"
+"També podeu considerar actualitzar el nom del fitxer .desktop que l'acompanya per seguir l'última versió de l'especificació d’entrades d’escriptori i utilitzar un nom rDNS per a això també. En qualsevol cas, no us oblideu d'esmentar la nova entrada d'escriptori en una etiqueta <launchable/> per a aquest component per mantenir l'aplicació es pot llançar des dels centres de programari i les dades de fitxers .desktop associats a les dades metainfo."
 
 #: src/as-validator-issue-tag.h:136
-msgid ""
-"The component ID might not follow the reverse domain-name schema (the TLD "
-"used by it is not known to the validator)."
-msgstr ""
-"És possible que el component-ID no segueixi l'esquema de nom de domini "
-"invers (el TLD utilitzat per ell no és conegut pel validador)."
+msgid "The component ID might not follow the reverse domain-name schema (the TLD used by it is not known to the validator)."
+msgstr "És possible que el component-ID no segueixi l'esquema de nom de domini invers (el TLD utilitzat per ell no és conegut pel validador)."
 
 #: src/as-validator-issue-tag.h:141
-msgid ""
-"The component ID contains an invalid character. Only ASCII characters, dots "
-"and numbers are permitted."
-msgstr ""
-"El component-ID conté un caràcter no vàlid. Només es permeten caràcters "
-"ASCII, punts i números ."
+msgid "The component ID contains an invalid character. Only ASCII characters, dots and numbers are permitted."
+msgstr "El component-ID conté un caràcter no vàlid. Només es permeten caràcters ASCII, punts i números ."
 
 #: src/as-validator-issue-tag.h:146
 msgid "The component ID starts with punctuation. This is not allowed."
-msgstr ""
-"L'ID del component comença amb un signe de puntuació. Això no es permet."
+msgstr "L'ID del component comença amb un signe de puntuació. Això no es permet."
 
 #: src/as-validator-issue-tag.h:151
-#, fuzzy
-msgid ""
-"The component ID contains a hyphen/minus in its domain part. Using a hyphen "
-"is strongly discouraged to improve interoperability with other tools such as "
-"D-Bus. A good option is to replace any hyphens with underscores (`_`). "
-"Hyphens are only allowed in the last segment of a component ID."
-msgstr ""
-"L’identificador del component conté un guió/signe menys. L'ús d'un guió és "
-"molt descoratjador, per a millorar la interoperabilitat amb altres eines com "
-"el D-Bus. Una bona opció és reemplaçar qualsevol guió per subratllat («_»)."
+msgid "The component ID contains a hyphen/minus in its domain part. Using a hyphen is strongly discouraged to improve interoperability with other tools such as D-Bus. A good option is to replace any hyphens with underscores (`_`). Hyphens are only allowed in the last segment of a component ID."
+msgstr "L’identificador del component conté un guió/signe menys a la part del seu domini. L'ús d'un guió està fortament desaconsellat per a millorar la interoperabilitat amb altres eines com el D-Bus. Una bona opció és reemplaçar qualsevol guió per guions baixos («_»). Els guions només estan permesos a l'últim segment de l'identificador del component."
 
 #: src/as-validator-issue-tag.h:157
-msgid ""
-"The component ID contains a segment starting with a number. Starting a "
-"segment of the reverse-DNS ID with a number is strongly discouraged, to keep "
-"interoperability with other tools such as D-Bus. Ideally, prefix these "
-"segments with an underscore."
-msgstr ""
-"El component-ID conté un segment que comença amb un número. Iniciar un "
-"segment de l'ID DNS invers amb un número és molt descoratjador, per a "
-"mantenir la interoperabilitat amb altres eines com D-Bus. Idealment, "
-"prefixeu aquests segments amb un subratllat."
+msgid "The component ID contains a segment starting with a number. Starting a segment of the reverse-DNS ID with a number is strongly discouraged, to keep interoperability with other tools such as D-Bus. Ideally, prefix these segments with an underscore."
+msgstr "El component-ID conté un segment que comença amb un número. Iniciar un segment de l'ID DNS invers amb un número és molt descoratjador, per a mantenir la interoperabilitat amb altres eines com D-Bus. Idealment, prefixeu aquests segments amb un subratllat."
 
 #: src/as-validator-issue-tag.h:163
 msgid "The component ID should only contain lowercase characters."
-msgstr ""
-"L'identificador del component ID només ha de contenir caràcters en minúscula."
+msgstr "L'identificador del component ID només ha de contenir caràcters en minúscula."
 
 #: src/as-validator-issue-tag.h:168
-msgid ""
-"The domain part of the rDNS component ID (first two parts) must only contain "
-"lowercase characters."
-msgstr ""
-"La part de domini de l'identificador del component rDNS (les dues primeres "
-"parts) només ha de contenir caràcters en minúscula."
+msgid "The domain part of the rDNS component ID (first two parts) must only contain lowercase characters."
+msgstr "La part de domini de l'identificador del component rDNS (les dues primeres parts) només ha de contenir caràcters en minúscula."
 
 #: src/as-validator-issue-tag.h:173
-msgid ""
-"The component is part of the Freedesktop project, but its ID does not start "
-"with fd.o's reverse-DNS name (\"org.freedesktop\")."
-msgstr ""
-"El component forma part del projecte Freedesktop, però el seu ID no comença "
-"amb el nom de DNS invers fd.o («org.freedesktop»)."
+msgid "The component is part of the Freedesktop project, but its ID does not start with fd.o's reverse-DNS name (\"org.freedesktop\")."
+msgstr "El component forma part del projecte Freedesktop, però el seu ID no comença amb el nom de DNS invers fd.o («org.freedesktop»)."
 
 #: src/as-validator-issue-tag.h:178
-#, fuzzy
-msgid ""
-"The component is part of the KDE project, but its ID does not start with "
-"KDE's reverse-DNS name (\"org.kde\")."
-msgstr ""
-"El component forma part del projecte KDE, però el seu identificador no "
-"comença amb el nom DNS invers KDEs («org.kde»)."
+msgid "The component is part of the KDE project, but its ID does not start with KDE's reverse-DNS name (\"org.kde\")."
+msgstr "El component forma part del projecte KDE, però el seu identificador no comença amb el nom DNS invers del KDE («org.kde»)."
 
 #: src/as-validator-issue-tag.h:183
-#, fuzzy
-msgid ""
-"The component is part of the GNOME project, but its ID does not start with "
-"GNOME's reverse-DNS name (\"org.gnome\")."
-msgstr ""
-"El component forma part del projecte GNOME, però el seu identificador no "
-"comença amb el nom DNS invers GNOMEs («org.gnome»)."
+msgid "The component is part of the GNOME project, but its ID does not start with GNOME's reverse-DNS name (\"org.gnome\")."
+msgstr "El component forma part del projecte GNOME, però el seu identificador no comença amb el nom DNS invers del GNOME («org.gnome»)."
 
 #: src/as-validator-issue-tag.h:188
 msgid "The SPDX license expression is invalid and could not be parsed."
 msgstr "L'expressió de llicència SPDX no és vàlida i no s'ha pogut analitzar."
 
 #: src/as-validator-issue-tag.h:193
-msgid ""
-"The license ID was not found in the SPDX database. Please check that the "
-"license ID is written in an SPDX-conformant way and is a valid free software "
-"license."
-msgstr ""
-"L’identificador de llicència no s'ha trobat a la base de dades SPDX. "
-"Comprova que l'identificador de llicència està escrit conforme a SPDX i que "
-"és una llicència de programari lliure vàlida."
+msgid "The license ID was not found in the SPDX database. Please check that the license ID is written in an SPDX-conformant way and is a valid free software license."
+msgstr "L’identificador de llicència no s'ha trobat a la base de dades SPDX. Comprova que l'identificador de llicència està escrit conforme a SPDX i que és una llicència de programari lliure vàlida."
 
 #: src/as-validator-issue-tag.h:199
-msgid ""
-"The metadata itself seems to be licensed under a complex collection of "
-"licenses. Please license the data under a simple permissive license, like "
-"FSFAP, MIT or CC0-1.0 to allow distributors to include it in mixed data "
-"collections without the risk of license violations due to mutually "
-"incompatible licenses."
-msgstr ""
-"Les metadades en si semblen estar llicenciades sota una complexa col·lecció "
-"de llicències. Si us plau, llicencia les dades sota una llicència permissiva "
-"simple, com FSFAP, MIT o CC0-1.0 per a permetre als distribuïdors incloure-"
-"les en col·leccions mixtes de dades sense el risc de violacions de "
-"llicències a causa de llicències mútuament incompatibles."
+msgid "The metadata itself seems to be licensed under a complex collection of licenses. Please license the data under a simple permissive license, like FSFAP, MIT or CC0-1.0 to allow distributors to include it in mixed data collections without the risk of license violations due to mutually incompatible licenses."
+msgstr "Les metadades en si semblen estar llicenciades sota una complexa col·lecció de llicències. Si us plau, llicencia les dades sota una llicència permissiva simple, com FSFAP, MIT o CC0-1.0 per a permetre als distribuïdors incloure-les en col·leccions mixtes de dades sense el risc de violacions de llicències a causa de llicències mútuament incompatibles."
 
 #: src/as-validator-issue-tag.h:205
-msgid ""
-"The metadata itself does not seem to be licensed under a permissive license. "
-"Please license the data under a permissive license, like FSFAP, CC0-1.0 or "
-"0BSD to allow distributors to include it in mixed data collections without "
-"the risk of license violations due to mutually incompatible licenses."
-msgstr ""
-"Les metadades en si no semblen estar llicenciades sota una llicència "
-"permissiva. Si us plau, llicencia les dades sota una llicència permissiva, "
-"com ara FSFAP, CC0-1.0 o 0BSD per a permetre als distribuïdors incloure-les "
-"en col·leccions mixtes de dades sense el risc de violacions de llicències a "
-"causa de llicències mútuament incompatibles."
+msgid "The metadata itself does not seem to be licensed under a permissive license. Please license the data under a permissive license, like FSFAP, CC0-1.0 or 0BSD to allow distributors to include it in mixed data collections without the risk of license violations due to mutually incompatible licenses."
+msgstr "Les metadades en si no semblen estar llicenciades sota una llicència permissiva. Si us plau, llicencia les dades sota una llicència permissiva, com ara FSFAP, CC0-1.0 o 0BSD per a permetre als distribuïdors incloure-les en col·leccions mixtes de dades sense el risc de violacions de llicències a causa de llicències mútuament incompatibles."
 
 #: src/as-validator-issue-tag.h:211
-msgid ""
-"The update-contact does not appear to be a valid email address (escaping of "
-"`@` is only allowed as `_at_` or `_AT_`)."
-msgstr ""
-"El contacte nou no sembla ser una adreça de correu electrònic vàlida (per a "
-"obviar «@» només es permet «_at_» o «_AT_»)."
+msgid "The update-contact does not appear to be a valid email address (escaping of `@` is only allowed as `_at_` or `_AT_`)."
+msgstr "El contacte nou no sembla ser una adreça de correu electrònic vàlida (per a obviar «@» només es permet «_at_» o «_AT_»)."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:217
-msgid ""
-"The `environment` property is set to an unrecognized graphical environment/"
-"style combination."
-msgstr ""
+msgid "The `environment` property is set to an unrecognized graphical environment/style combination."
+msgstr "La propietat `environment` està establerta a una combinació de l'entorn gràfic/estil no reconeguda."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:223
 msgid "The `width` property must be a positive integer."
-msgstr ""
+msgstr "La propietat `width` ha de ser un enter positiu."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:229
 msgid "The `height` property must be a positive integer."
-msgstr ""
+msgstr "La propietat `height` ha de ser un enter positiu."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:235
 msgid "The `scale` property must be a positive integer."
-msgstr ""
+msgstr "La propietat `scale` ha de ser un enter positiu."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:241
-#, fuzzy
 msgid "The image type must be either `source` or `thumbnail`."
-msgstr ""
-"El conjunt de valors com a tipus d'artefacte no és vàlid. Ha de ser «source» "
-"o «binary»."
+msgstr "El tipus d'imatge ha de ser `source` o `thumbnail`."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:247
 msgid "The `width` property must be present if the image type is `thumbnail`."
-msgstr ""
+msgstr "La propietat `width` ha d'estar present si el tipus d'imatge és `thumbnail`."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:253
 msgid "The `height` property must be present if the image type is `thumbnail`."
-msgstr ""
+msgstr "La propietat `height` ha d'estar present si el tipus d'imatge és `thumbnail`."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:259
 msgid "There can only be one `source` image per screenshot and language."
-msgstr ""
+msgstr "Només pot haver-hi una imatge `source` per captura de pantalla i idioma."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:265
-#, fuzzy
-msgid ""
-"A screenshot must have at least one untranslated image of type `source`."
-msgstr ""
-"Una captura de pantalla ha de contenir almenys una imatge o un vídeo per a "
-"ser útil. Si us plau, afegiu-hi una <image/>."
+msgid "A screenshot must have at least one untranslated image of type `source`."
+msgstr "Una captura de pantalla ha de tenir almenys una imatge no traduïda del tipus `source`."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:271
-msgid ""
-"A screenshot must have at least one untranslated image of type `source`, "
-"which could not be found. Instead, a tag with an `en` locale (`xml:lang=en`) "
-"was found, which is likely intended to be the translatable image. Please "
-"remove the XML localization attribute in this case."
-msgstr ""
+msgid "A screenshot must have at least one untranslated image of type `source`, which could not be found. Instead, a tag with an `en` locale (`xml:lang=en`) was found, which is likely intended to be the translatable image. Please remove the XML localization attribute in this case."
+msgstr "Una captura de pantalla ha de tenir almenys una imatge sense traduir del tipus `source`, que no s'ha pogut trobar. En canvi, s'ha trobat una etiqueta amb una configuració regional `en` (`xml:lang=en`), que probablement pretén ser la imatge traduïble. Si us plau, suprimiu l'atribut de localització XML en aquest cas."
 
 #: src/as-validator-issue-tag.h:278
-msgid ""
-"Unable to reach the screenshot image on its remote location - does the image "
-"exist?"
-msgstr ""
-"No es pot accedir a la imatge de captura de pantalla de la seva ubicació "
-"remota; existeix la imatge?"
+msgid "Unable to reach the screenshot image on its remote location - does the image exist?"
+msgstr "No es pot accedir a la imatge de captura de pantalla de la seva ubicació remota; existeix la imatge?"
 
 #: src/as-validator-issue-tag.h:283
-msgid ""
-"Unable to reach the screenshot video on its remote location - does the video "
-"file exist?"
-msgstr ""
-"No es pot accedir al vídeo de captura de pantalla de la seva ubicació "
-"remota; existeix el fitxer de vídeo?"
+msgid "Unable to reach the screenshot video on its remote location - does the video file exist?"
+msgstr "No es pot accedir al vídeo de captura de pantalla de la seva ubicació remota; existeix el fitxer de vídeo?"
 
 #: src/as-validator-issue-tag.h:288
-msgid ""
-"Consider using a secure (HTTPS) URL to reference this screenshot image or "
-"video."
-msgstr ""
-"Considereu d'utilitzar un URL segur (HTTPS) per a fer referència a aquesta "
-"captura d'imatge o de vídeo."
+msgid "Consider using a secure (HTTPS) URL to reference this screenshot image or video."
+msgstr "Considereu d'utilitzar un URL segur (HTTPS) per a fer referència a aquesta captura d'imatge o de vídeo."
 
 #: src/as-validator-issue-tag.h:293
-#, fuzzy
-msgid ""
-"A screenshot must have at least one image that has a scaling factor of 1."
-msgstr ""
-"Una captura de pantalla ha de contenir almenys una imatge o un vídeo per a "
-"ser útil. Si us plau, afegiu-hi una <image/>."
+msgid "A screenshot must have at least one image that has a scaling factor of 1."
+msgstr "Una captura de pantalla ha de contenir almenys una imatge que té una factor d'escalada de 1."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:299
-msgid ""
-"A screenshot must contain at least one image or video in order to be useful. "
-"Please add an <image/> to it."
-msgstr ""
-"Una captura de pantalla ha de contenir almenys una imatge o un vídeo per a "
-"ser útil. Si us plau, afegiu-hi una <image/>."
+msgid "A screenshot must contain at least one image or video in order to be useful. Please add an <image/> to it."
+msgstr "Una captura de pantalla ha de contenir almenys una imatge o un vídeo per a ser útil. Si us plau, afegiu-hi una <image/>."
 
 #: src/as-validator-issue-tag.h:304
-msgid ""
-"A screenshot must contain either images or videos, but not both at the same "
-"time. Please use this screenshot exclusively for either static images or for "
-"videos."
-msgstr ""
-"Una captura de pantalla ha de contenir imatges o vídeos, però no tots dos "
-"alhora. Si us plau, utilitzeu aquesta captura de pantalla exclusivament per "
-"a imatges estàtiques o per a vídeos."
+msgid "A screenshot must contain either images or videos, but not both at the same time. Please use this screenshot exclusively for either static images or for videos."
+msgstr "Una captura de pantalla ha de contenir imatges o vídeos, però no tots dos alhora. Si us plau, utilitzeu aquesta captura de pantalla exclusivament per a imatges estàtiques o per a vídeos."
 
 #: src/as-validator-issue-tag.h:310
 msgid "The screenshot does not have a caption text. Consider adding one."
-msgstr ""
-"La captura de pantalla no té text de llegenda. Penseu en afegir-ne una."
+msgstr "La captura de pantalla no té text de llegenda. Penseu en afegir-ne una."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:316
-msgid ""
-"The screenshot video does not specify which video codec was used in a "
-"`codec` property."
-msgstr ""
-"El vídeo de captura de pantalla no especifica quin còdec de vídeo s'ha "
-"utilitzat en una propietat «codec»."
+msgid "The screenshot video does not specify which video codec was used in a `codec` property."
+msgstr "El vídeo de captura de pantalla no especifica quin còdec de vídeo s'ha utilitzat en una propietat «codec»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:322
-msgid ""
-"The screenshot video does not specify which container format was used in a "
-"`container` property."
-msgstr ""
-"El vídeo de captura de pantalla no especifica quin format de contenidor s'ha "
-"utilitzat en una propietat «container»."
+msgid "The screenshot video does not specify which container format was used in a `container` property."
+msgstr "El vídeo de captura de pantalla no especifica quin format de contenidor s'ha utilitzat en una propietat «container»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:328
-msgid ""
-"The selected video codec is not supported by AppStream and software centers "
-"may not be able to play the video. Only the AV1 and VP9 codecs are currently "
-"supported, using `av1` and `vp9` as values for the `codec` property."
-msgstr ""
-"L'AppStream no admet el còdec de vídeo seleccionat i és possible que els "
-"centres de programari no puguin reproduir el vídeo. Actualment només "
-"s'admeten els còdecs AV1 i VP9, utilitzant «av1» i «vp9» com a valors per a "
-"la propietat «codec»."
+msgid "The selected video codec is not supported by AppStream and software centers may not be able to play the video. Only the AV1 and VP9 codecs are currently supported, using `av1` and `vp9` as values for the `codec` property."
+msgstr "L'AppStream no admet el còdec de vídeo seleccionat i és possible que els centres de programari no puguin reproduir el vídeo. Actualment només s'admeten els còdecs AV1 i VP9, utilitzant «av1» i «vp9» com a valors per a la propietat «codec»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:335
-msgid ""
-"The selected video container format is not supported by AppStream and "
-"software centers may not be able to play the video. Only the WebM and "
-"Matroska video containers are currently supported, using `webm` and `mkv` as "
-"values for the `container` property."
-msgstr ""
-"L'AppStream no admet el format de contenidor de vídeo seleccionat i és "
-"possible que els centres de programari no puguin reproduir el vídeo. "
-"Actualment només s'admeten els contenidors de vídeo WebM i Matroska, "
-"utilitzant «webm» i «mkv» com a valors per a la propietat «container»."
+msgid "The selected video container format is not supported by AppStream and software centers may not be able to play the video. Only the WebM and Matroska video containers are currently supported, using `webm` and `mkv` as values for the `container` property."
+msgstr "L'AppStream no admet el format de contenidor de vídeo seleccionat i és possible que els centres de programari no puguin reproduir el vídeo. Actualment només s'admeten els contenidors de vídeo WebM i Matroska, utilitzant «webm» i «mkv» com a valors per a la propietat «container»."
 
 #: src/as-validator-issue-tag.h:341
-msgid ""
-"For videos, only the WebM and Matroska (.mkv) container formats are "
-"currently supported. The file extension of the referenced video does not "
-"belong to either of these formats."
-msgstr ""
-"Per a vídeos, de moment només són admesos els formats contenidors WebM i "
-"Matroska (.mkv). L'extensió del fitxer del vídeo en qüestió no pertany a cap "
-"d'aquests formats."
+msgid "For videos, only the WebM and Matroska (.mkv) container formats are currently supported. The file extension of the referenced video does not belong to either of these formats."
+msgstr "Per a vídeos, de moment només són admesos els formats contenidors WebM i Matroska (.mkv). L'extensió del fitxer del vídeo en qüestió no pertany a cap d'aquests formats."
 
 #: src/as-validator-issue-tag.h:347
-msgid ""
-"The default screenshot of a software component must not be a video. Use a "
-"static image as default screenshot and set the video as a secondary "
-"screenshot."
-msgstr ""
-"La captura de pantalla per defecte d'un component de programari no ha de ser "
-"un vídeo. Utilitzeu una imatge estàtica com a captura de pantalla per "
-"defecte i definiu el vídeo com una captura de pantalla secundària."
+msgid "The default screenshot of a software component must not be a video. Use a static image as default screenshot and set the video as a secondary screenshot."
+msgstr "La captura de pantalla per defecte d'un component de programari no ha de ser un vídeo. Utilitzeu una imatge estàtica com a captura de pantalla per defecte i definiu el vídeo com una captura de pantalla secundària."
 
 #: src/as-validator-issue-tag.h:352
 msgid "No screenshot is marked as default."
-msgstr ""
+msgstr "No s'ha marcat cap captura de pantalla com a predeterminada."
 
 #: src/as-validator-issue-tag.h:357
-msgid ""
-"Found an unknown tag in a requires/recommends group. This is likely an "
-"error, because a component relation of this type is unknown."
-msgstr ""
-"S'ha trobat una etiqueta desconeguda en un grup de requeriments/"
-"recomanacions. Això és probablement un error, perquè es desconeix una "
-"relació de components d'aquest tipus."
+msgid "Found an unknown tag in a requires/recommends group. This is likely an error, because a component relation of this type is unknown."
+msgstr "S'ha trobat una etiqueta desconeguda en un grup de requeriments/recomanacions. Això és probablement un error, perquè es desconeix una relació de components d'aquest tipus."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:363
-msgid ""
-"A `requires` or `recommends` item requires a value to denote a valid "
-"relation."
-msgstr ""
-"Un element que «requires» o «recommends» requereix un valor per a denotar "
-"una relació vàlida."
+msgid "A `requires` or `recommends` item requires a value to denote a valid relation."
+msgstr "Un element que «requires» o «recommends» requereix un valor per a denotar una relació vàlida."
 
-#. TRANSLATORS: `version` is an AppStream XML property. Please do not translate it.
+#. TRANSLATORS: `version` is an AppStream XML property. Please do not
+#. translate it.
 #: src/as-validator-issue-tag.h:369
-msgid ""
-"Found `version` property on required/recommended item of a type that should "
-"not have or require a version."
-msgstr ""
-"S'ha trobat la propietat «version» en l'element requerit/recomanat d'un "
-"tipus que no hauria de tenir ni requerir una versió."
+msgid "Found `version` property on required/recommended item of a type that should not have or require a version."
+msgstr "S'ha trobat la propietat «version» en l'element requerit/recomanat d'un tipus que no hauria de tenir ni requerir una versió."
 
-#. TRANSLATORS: `version` and `compare` are AppStream XML properties. Please do not translate them.
+#. TRANSLATORS: `version` and `compare` are AppStream XML properties. Please
+#. do not translate them.
 #: src/as-validator-issue-tag.h:375
-msgid ""
-"Found `version` property on this required/recommended item, but not "
-"`compare` property. It is recommended to explicitly define a comparison "
-"operation."
-msgstr ""
-"S'ha trobat la propietat «version» en aquest element requerit/recomanat, "
-"però no la propietat «compare». Cal definir explícitament una operació de "
-"comparació."
+msgid "Found `version` property on this required/recommended item, but not `compare` property. It is recommended to explicitly define a comparison operation."
+msgstr "S'ha trobat la propietat «version» en aquest element requerit/recomanat, però no la propietat «compare». Cal definir explícitament una operació de comparació."
 
-#. TRANSLATORS: `eq/ne/lt/gt/le/ge` are AppStream XML values. Please do not translate them.
+#. TRANSLATORS: `eq/ne/lt/gt/le/ge` are AppStream XML values. Please do not
+#. translate them.
 #: src/as-validator-issue-tag.h:381
-msgid ""
-"Invalid comparison operation on relation item. Only one of `eq/ne/lt/gt/le/"
-"ge` is permitted."
-msgstr ""
-"L'operació de comparació no és vàlida a l'element de relació. Només es "
-"permet una de «eq/ne/lt/gt/le/ge»."
+msgid "Invalid comparison operation on relation item. Only one of `eq/ne/lt/gt/le/ge` is permitted."
+msgstr "L'operació de comparació no és vàlida a l'element de relació. Només es permet una de «eq/ne/lt/gt/le/ge»."
 
 #: src/as-validator-issue-tag.h:386
-msgid ""
-"The relation item has a comparison operation set, but does not support any "
-"comparisons."
-msgstr ""
-"L'element de relació té un conjunt d'operacions de comparació, però no admet "
-"comparacions."
+msgid "The relation item has a comparison operation set, but does not support any comparisons."
+msgstr "L'element de relació té un conjunt d'operacions de comparació, però no admet comparacions."
 
 #: src/as-validator-issue-tag.h:391
-msgid ""
-"This relation item has already been defined once for this or a different "
-"relation type. Please do not redefine relations."
-msgstr ""
-"Aquest element de relació ja ha estat definit una vegada per a aquesta o un "
-"tipus de relació diferent. Si us plau, no redefineixis les relacions."
+msgid "This relation item has already been defined once for this or a different relation type. Please do not redefine relations."
+msgstr "Aquest element de relació ja ha estat definit una vegada per a aquesta o un tipus de relació diferent. Si us plau, no redefineixis les relacions."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:397
-msgid ""
-"Found a memory size relation in a `requires` tag. This means users will not "
-"be able to even install the component without having enough RAM. This is "
-"usually not intended and you want to use `memory` in the `recommends` tag "
-"instead."
-msgstr ""
-"S'ha trobat una relació de mida de memòria en una etiqueta «requires». Això "
-"significa que els usuaris no podran ni tan sols instal·lar el component "
-"sense prou RAM. En general això no és intencionat, proveu d’utilitzar "
-"«memory» a l'etiqueta «recommends»."
+msgid "Found a memory size relation in a `requires` tag. This means users will not be able to even install the component without having enough RAM. This is usually not intended and you want to use `memory` in the `recommends` tag instead."
+msgstr "S'ha trobat una relació de mida de memòria en una etiqueta «requires». Això significa que els usuaris no podran ni tan sols instal·lar el component sense prou RAM. En general això no és intencionat, proveu d’utilitzar «memory» a l'etiqueta «recommends»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:404
-msgid ""
-"Found a user input control relation in a `requires` tag. This means users "
-"will not be able to even install the component without having the defined "
-"input control available on the system. This is usually not intended and you "
-"want to use `control` in the `recommends` tag instead."
-msgstr ""
-"S'ha trobat una relació de control d'entrada de l'usuari en una etiqueta "
-"«requires». Això significa que els usuaris no podran ni tan sols instal·lar "
-"el component sense tenir el control d'entrada definit disponible al sistema. "
-"En general això no és intencionat, proveu d’utilitzar «control» a l’etiqueta "
-"«recommends»."
+msgid "Found a user input control relation in a `requires` tag. This means users will not be able to even install the component without having the defined input control available on the system. This is usually not intended and you want to use `control` in the `recommends` tag instead."
+msgstr "S'ha trobat una relació de control d'entrada de l'usuari en una etiqueta «requires». Això significa que els usuaris no podran ni tan sols instal·lar el component sense tenir el control d'entrada definit disponible al sistema. En general això no és intencionat, proveu d’utilitzar «control» a l’etiqueta «recommends»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:411
-msgid ""
-"This `control` item defines an unknown input method and is invalid. Check "
-"the specification for a list of permitted values."
-msgstr ""
-"Aquest element de «control» defineix un mètode d'entrada desconegut i no és "
-"vàlid. Comproveu l'especificació d'una llista de valors permesos."
+msgid "This `control` item defines an unknown input method and is invalid. Check the specification for a list of permitted values."
+msgstr "Aquest element de «control» defineix un mètode d'entrada desconegut i no és vàlid. Comproveu l'especificació d'una llista de valors permesos."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:417
-#, fuzzy
-msgid ""
-"This `display_length` item contains an invalid display length. Its value "
-"must be a positive integer value denoting logical pixels. Please refer to "
-"the AppStream specification for more information on this tag."
-msgstr ""
-"Aquest element «display_length» conté una longitud de visualització no "
-"vàlida. El seu valor ha de ser una cadena abreujada, o un valor enter "
-"positiu que denoti píxels lògics. Consulteu l'especificació d'AppStream per "
-"a obtenir més informació sobre aquesta etiqueta."
+msgid "This `display_length` item contains an invalid display length. Its value must be a positive integer value denoting logical pixels. Please refer to the AppStream specification for more information on this tag."
+msgstr "Aquest element `display_length` conté una longitud de visualització no vàlida. El seu valor ha de ser un enter positiu que denoti els píxels lògics. Si us plau, consulteu l'especificació d'AppStream per a obtenir més informació sobre aquesta etiqueta."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:424
-msgid ""
-"This `side` property of this `display_length` item contains an invalid "
-"value. It must either be `shortest` or `longest`, or unset to imply "
-"`shortest` to make the item value refer to either the shortest or longest "
-"side of the display."
-msgstr ""
-"La propietat «side» de «display_length» conté un valor no vàlid. Ha de ser "
-"«shortest», «longest» o sense definir per a implicar «shortest» i fer que el "
-"valor de l'element es refereixi al costat més curt o més llarg de la "
-"pantalla."
+msgid "This `side` property of this `display_length` item contains an invalid value. It must either be `shortest` or `longest`, or unset to imply `shortest` to make the item value refer to either the shortest or longest side of the display."
+msgstr "La propietat «side» de «display_length» conté un valor no vàlid. Ha de ser «shortest», «longest» o sense definir per a implicar «shortest» i fer que el valor de l'element es refereixi al costat més curt o més llarg de la pantalla."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:431
-msgid ""
-"This `hardware` item contains an invalid value. It should be a Computer "
-"Hardware ID (CHID) UUID without braces."
-msgstr ""
-"Aquest element «hardware» conté un valor no vàlid. Ha de ser un UUID "
-"d'identificador de maquinari d'ordinador (CHID) sense claus."
+msgid "This `hardware` item contains an invalid value. It should be a Computer Hardware ID (CHID) UUID without braces."
+msgstr "Aquest element «hardware» conté un valor no vàlid. Ha de ser un UUID d'identificador de maquinari d'ordinador (CHID) sense claus."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:437
-msgid ""
-"A `memory` item must only contain a non-zero integer value, depicting a "
-"system memory size in mebibyte (MiB)"
-msgstr ""
-"Un element de `memory` només ha de contenir un valor enter no nul, que "
-"representa una mida de memòria del sistema en mebibyte (MiB)"
+msgid "A `memory` item must only contain a non-zero integer value, depicting a system memory size in mebibyte (MiB)"
+msgstr "Un element de `memory` només ha de contenir un valor enter no nul, que representa una mida de memòria del sistema en mebibyte (MiB)"
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:443
 msgid "The set tag value is not valid for an `internet` relation."
-msgstr ""
-"El valor de l'etiqueta establert no és vàlid per a una relació `internet`."
+msgstr "El valor de l'etiqueta establert no és vàlid per a una relació `internet`."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:449
-msgid ""
-"The `bandwidth_mbitps` property is not allowed when using `offline-only` as "
-"value."
-msgstr ""
+msgid "The `bandwidth_mbitps` property is not allowed when using `offline-only` as value."
+msgstr "La propietat `bandwidth_mbitps` no està permesa quan s'utilitza `offline-only` com a valor."
 
 #: src/as-validator-issue-tag.h:454
-msgid ""
-"The value of this property must be a positive integer value, describing the "
-"minimum required bandwidth in mbit/s."
-msgstr ""
-"El valor d'aquesta propietat ha de ser un valor enter positiu, descrivint "
-"l'ample de banda mínim requerit en mbit/s."
+msgid "The value of this property must be a positive integer value, describing the minimum required bandwidth in mbit/s."
+msgstr "El valor d'aquesta propietat ha de ser un valor enter positiu, descrivint l'ample de banda mínim requerit en mbit/s."
 
 #: src/as-validator-issue-tag.h:459
-msgid ""
-"The set component type is not a recognized, valid AppStream component type."
-msgstr ""
-"El tipus de component establert no és un tipus de component AppStream "
-"reconegut i vàlid."
+msgid "The set component type is not a recognized, valid AppStream component type."
+msgstr "El tipus de component establert no és un tipus de component AppStream reconegut i vàlid."
 
 #: src/as-validator-issue-tag.h:464
-msgid ""
-"The component has a priority value set. This is not allowed in metainfo "
-"files."
-msgstr ""
-"El component té un conjunt de valors prioritari. Això no està permès als "
-"fitxers metainfo."
+msgid "The component has a priority value set. This is not allowed in metainfo files."
+msgstr "El component té un conjunt de valors prioritari. Això no està permès als fitxers metainfo."
 
 #: src/as-validator-issue-tag.h:469
-msgid ""
-"The component has a `merge` method defined. This is not allowed in metainfo "
-"files."
-msgstr ""
-"El component té definit un mètode de «merge». Això no està permès als "
-"fitxers metainfo."
+msgid "The component has a `merge` method defined. This is not allowed in metainfo files."
+msgstr "El component té definit un mètode de «merge». Això no està permès als fitxers metainfo."
 
 #: src/as-validator-issue-tag.h:474
 msgid "The component is missing an ID (<id/> tag)."
@@ -2327,32 +2104,20 @@ msgid "The component is missing a name (<name/> tag)."
 msgstr "Al component li falta un nom (etiqueta <name/>)."
 
 #: src/as-validator-issue-tag.h:484
-msgid ""
-"The name of this component is excessively long and can likely not be "
-"displayed properly in most layouts."
-msgstr ""
+msgid "The name of this component is excessively long and can likely not be displayed properly in most layouts."
+msgstr "El nom d'aquest component és massa llarg i probablement no es pot mostrar correctament a la majoria de les disposicions de pantalla."
 
 #: src/as-validator-issue-tag.h:489
 msgid "The component is missing a summary (<summary/> tag)."
 msgstr "Al component li falta un resum (etiqueta <summary/>)."
 
 #: src/as-validator-issue-tag.h:494
-msgid ""
-"The <id/> tag still contains a `type` property, probably from an old "
-"conversion to the recent metainfo format."
-msgstr ""
-"L'etiqueta <id/> encara conté una propietat «type», probablement d'una "
-"conversió antiga al format metainfo recent."
+msgid "The <id/> tag still contains a `type` property, probably from an old conversion to the recent metainfo format."
+msgstr "L'etiqueta <id/> encara conté una propietat «type», probablement d'una conversió antiga al format metainfo recent."
 
 #: src/as-validator-issue-tag.h:499
-msgid ""
-"The `pkgname` tag appears multiple times. You should evaluate creating a "
-"metapackage containing the metainfo and .desktop files in order to avoid "
-"defining multiple package names per component."
-msgstr ""
-"L'etiqueta «pkgname» apareix diverses vegades. Hauríeu d'avaluar la creació "
-"d'un metaembalatge que contingui els metainfo i els fitxers .desktop per a "
-"evitar definir diversos noms de paquets per component."
+msgid "The `pkgname` tag appears multiple times. You should evaluate creating a metapackage containing the metainfo and .desktop files in order to avoid defining multiple package names per component."
+msgstr "L'etiqueta «pkgname» apareix diverses vegades. Hauríeu d'avaluar la creació d'un metaembalatge que contingui els metainfo i els fitxers .desktop per a evitar definir diversos noms de paquets per component."
 
 #: src/as-validator-issue-tag.h:504
 msgid "The component name should (likely) not end with a dot (`.`)."
@@ -2364,81 +2129,55 @@ msgstr "El resum del component no ha d'acabar amb un punt («.»)."
 
 #: src/as-validator-issue-tag.h:514
 msgid "The component summary must not contain tabs or linebreaks."
-msgstr ""
-"El resum del component no ha de contenir tabulacions ni salts de línia."
+msgstr "El resum del component no ha de contenir tabulacions ni salts de línia."
 
 #: src/as-validator-issue-tag.h:519
 msgid "The summary must not contain any URL. Use the `<url/>` tags for links."
-msgstr ""
-"El resum no ha de contenir cap URL. Utilitzeu les etiquetes «<url/>» per als "
-"enllaços."
+msgstr "El resum no ha de contenir cap URL. Utilitzeu les etiquetes «<url/>» per als enllaços."
 
 #: src/as-validator-issue-tag.h:524
-msgid ""
-"The summary text does not start with a capitalized word, project name or "
-"number."
-msgstr ""
-"El text del resum no comença amb una paraula en majúscules, un nom de "
-"projecte ni un número ."
+msgid "The summary text does not start with a capitalized word, project name or number."
+msgstr "El text del resum no comença amb una paraula en majúscules, un nom de projecte ni un número ."
 
 #: src/as-validator-issue-tag.h:529
-msgid ""
-"The summary text is very long, and will likely not be displayed properly "
-"everywhere."
-msgstr ""
+msgid "The summary text is very long, and will likely not be displayed properly everywhere."
+msgstr "El resum és molt llarg, i probablement no es mostrarà correctament a tot arreu."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:535
-msgid ""
-"Icons of type `stock` or `cached` must not contain an URL, a full or an "
-"relative path to the icon. Only file basenames or stock names are allowed."
-msgstr ""
-"Les icones del tipus «stock» o «cached» no han de contenir una adreça URL, "
-"un camí complet o relatiu a la icona. Només es permeten noms base de fitxer "
-"o noms d'estocs."
+msgid "Icons of type `stock` or `cached` must not contain an URL, a full or an relative path to the icon. Only file basenames or stock names are allowed."
+msgstr "Les icones del tipus «stock» o «cached» no han de contenir una adreça URL, un camí complet o relatiu a la icona. Només es permeten noms base de fitxer o noms d'estocs."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:542
 msgid "Icons of type `remote` must contain an URL to the referenced icon."
-msgstr ""
-"Les icones del tipus «remote» han de contenir una adreça URL a la icona "
-"referenciada."
+msgstr "Les icones del tipus «remote» han de contenir una adreça URL a la icona referenciada."
 
 #: src/as-validator-issue-tag.h:547
 msgid "Unable to reach remote icon at the given web location - does it exist?"
-msgstr ""
-"No es pot accedir a la icona remota a la ubicació web donada; existeix?"
+msgstr "No es pot accedir a la icona remota a la ubicació web donada; existeix?"
 
 #: src/as-validator-issue-tag.h:552
 msgid "Consider using a secure (HTTPS) URL for the remote icon link."
-msgstr ""
-"Considereu d'utilitzar un URL segur (HTTPS) per a l'enllaç de la icona "
-"remota."
+msgstr "Considereu d'utilitzar un URL segur (HTTPS) per a l'enllaç de la icona remota."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:558
-msgid ""
-"Metainfo files may only contain icons of type `stock` or `remote`, the set "
-"type is not allowed."
-msgstr ""
-"Els fitxers metainfo només poden contenir icones del tipus «stock» o "
-"«remote», no es permet el tipus de conjunt."
+msgid "Metainfo files may only contain icons of type `stock` or `remote`, the set type is not allowed."
+msgstr "Els fitxers metainfo només poden contenir icones del tipus «stock» o «remote», no es permet el tipus de conjunt."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:564
-msgid ""
-"Invalid `type` property for this `url` tag. URLs of this type are not known "
-"in the AppStream specification."
-msgstr ""
-"La propietat «type» no és vàlida per a aquesta etiqueta «URL». Les URL "
-"d'aquest tipus no es coneixen a l'especificació d'AppStream."
+msgid "Invalid `type` property for this `url` tag. URLs of this type are not known in the AppStream specification."
+msgstr "La propietat «type» no és vàlida per a aquesta etiqueta «URL». Les URL d'aquest tipus no es coneixen a l'especificació d'AppStream."
 
 #: src/as-validator-issue-tag.h:569
-msgid ""
-"Unable to reach remote location that this URL references - does it exist?"
-msgstr ""
-"No es pot accedir a la ubicació remota a la qual fa referència aquesta "
-"adreça URL; existeix?"
+msgid "Unable to reach remote location that this URL references - does it exist?"
+msgstr "No es pot accedir a la ubicació remota a la qual fa referència aquesta adreça URL; existeix?"
 
 #: src/as-validator-issue-tag.h:574
 msgid "Consider using a secure (HTTPS) URL for this web link."
@@ -2449,316 +2188,200 @@ msgid "A web URL was expected for this value."
 msgstr "S'esperava una adreça URL per a aquest valor."
 
 #: src/as-validator-issue-tag.h:584
-msgid ""
-"This web link uses the FTP protocol. Consider switching to HTTP(S) instead."
-msgstr ""
-"Aquest enllaç web utilitza el protocol FTP. Considereu canviar a HTTP(S)."
+msgid "This web link uses the FTP protocol. Consider switching to HTTP(S) instead."
+msgstr "Aquest enllaç web utilitza el protocol FTP. Considereu canviar a HTTP(S)."
 
 #: src/as-validator-issue-tag.h:589
 msgid "An URL of this type has already been defined."
 msgstr "Ja s'ha definit una URL d'aquest tipus."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:595
-msgid ""
-"This component is missing an `url` element of type `homepage` to link to the "
-"project's homepage."
-msgstr ""
+msgid "This component is missing an `url` element of type `homepage` to link to the project's homepage."
+msgstr "A aquest component falta un element `url` de tipus `homepage` per enllaçar amb la pàgina d'inici del projecte."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:601
-msgid ""
-"The toplevel `developer_name` element is deprecated. Please use the `name` "
-"element in a `developer` block instead."
-msgstr ""
+msgid "The toplevel `developer_name` element is deprecated. Please use the `name` element in a `developer` block instead."
+msgstr "L'element del nivell superior `developer_name` està obsolet. Si us plau, utilitzeu l'element `name` en un bloc `developer`."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:608
-msgid ""
-"This component contains no `developer` element with information about its "
-"author."
-msgstr ""
+msgid "This component contains no `developer` element with information about its author."
+msgstr "Aquest component no conté cap element `developer` amb informació sobre el seu autor."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:614
-msgid ""
-"The `developer` element is missing an `id` property, containing a unique "
-"string ID for the developer. Consider adding a unique ID."
-msgstr ""
+msgid "The `developer` element is missing an `id` property, containing a unique string ID for the developer. Consider adding a unique ID."
+msgstr "A l'element `developer` falta una propietat `id`, que contingui una cadena de text única per al desenvolupador. Considereu afegir un identificador únic."
 
 #: src/as-validator-issue-tag.h:620
-msgid ""
-"The developer-ID is invalid. It should be an rDNS string identifying the "
-"developer, or a Fediverse handle. It must also only contain lowercase ASCII "
-"letters, numbers and punctuation."
-msgstr ""
+msgid "The developer-ID is invalid. It should be an rDNS string identifying the developer, or a Fediverse handle. It must also only contain lowercase ASCII letters, numbers and punctuation."
+msgstr "L'identificador del desenvolupador no és vàlid. Ha de ser una cadena de text rDNS que identifiqui el desenvolupador, o un identificador del Fediverse. També ha de contenir només lletres ASCII minúscules, números i puntuació."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:627
-msgid ""
-"The `developer` block does not have a `name` element with a human-readable "
-"project author name."
-msgstr ""
+msgid "The `developer` block does not have a `name` element with a human-readable project author name."
+msgstr "El bloc `developer` no té un element `name` amb el nom de l'autor del projecte i amb una forma intel·ligible."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:633
-#, fuzzy
 msgid "The `name` child of a `developer` block must not contain a hyperlink."
-msgstr "El <developer_name/> no pot contenir un hipervincle."
+msgstr "L'element `name` fill del bloc `developer` no pot contenir un enllaç."
 
 #: src/as-validator-issue-tag.h:638
-msgid ""
-"The set value is not an identifier for a desktop environment as registered "
-"with Freedesktop.org."
-msgstr ""
-"El valor definit no és un identificador per a un entorn d'escriptori tal com "
-"està registrat amb Freedesktop.org."
+msgid "The set value is not an identifier for a desktop environment as registered with Freedesktop.org."
+msgstr "El valor definit no és un identificador per a un entorn d'escriptori tal com està registrat amb Freedesktop.org."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:644
 msgid "This `launchable` tag has an unknown type and can not be used."
-msgstr ""
-"Aquesta etiqueta «launchable» té un tipus desconegut i no es pot utilitzar."
+msgstr "Aquesta etiqueta «launchable» té un tipus desconegut i no es pot utilitzar."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:650
 msgid "This `bundle` tag has an unknown type and can not be used."
-msgstr ""
-"Aquesta etiqueta «bundle» té un tipus desconegut i no es pot utilitzar."
+msgstr "Aquesta etiqueta «bundle» té un tipus desconegut i no es pot utilitzar."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:656
-#, fuzzy
-msgid ""
-"The `update_contact` tag should not be included in catalog AppStream XML."
-msgstr ""
-"L'etiqueta «update_contact» no s'ha d'incloure a la col·lecció APPStream XML."
+msgid "The `update_contact` tag should not be included in catalog AppStream XML."
+msgstr "L'etiqueta `update_contact` no s'hauria d'incloure a la col·lecció AppStream XML."
 
 #: src/as-validator-issue-tag.h:661
-msgid ""
-"This tag is a GNOME-specific extension to AppStream and not part of the "
-"official specification. Do not expect it to work in all implementations and "
-"in all software centers."
-msgstr ""
-"Aquesta etiqueta és una extensió específica del GNOME a AppStream i no forma "
-"part de l'especificació oficial. No espereu que funcioni en totes les "
-"implementacions i en tots els centres de programari."
+msgid "This tag is a GNOME-specific extension to AppStream and not part of the official specification. Do not expect it to work in all implementations and in all software centers."
+msgstr "Aquesta etiqueta és una extensió específica del GNOME a AppStream i no forma part de l'especificació oficial. No espereu que funcioni en totes les implementacions i en tots els centres de programari."
 
 #: src/as-validator-issue-tag.h:667
-msgid ""
-"Found invalid tag. Non-standard tags should be prefixed with `x-`. AppStream "
-"also provides the <custom/> tag to add arbitrary custom data to metainfo "
-"files. This tag is read by AppStream libraries and may be useful instead of "
-"defining new custom toplevel or `x-`-prefixed tags if you just want to add "
-"custom data to a metainfo file."
-msgstr ""
-"S'ha trobat una etiqueta no vàlida. Les etiquetes no estàndard s'han de "
-"prefixar amb «x-». AppStream també proporciona l'etiqueta <custom/> per a "
-"afegir dades personalitzades arbitràries als fitxers metainfo. Aquesta "
-"etiqueta és llegida per les biblioteques d'AppStream i pot ser útil en lloc "
-"de definir noves etiquetes personalitzades o «x-» amb prefix si només voleu "
-"afegir dades personalitzades a un fitxer metainfo."
+msgid "Found invalid tag. Non-standard tags should be prefixed with `x-`. AppStream also provides the <custom/> tag to add arbitrary custom data to metainfo files. This tag is read by AppStream libraries and may be useful instead of defining new custom toplevel or `x-`-prefixed tags if you just want to add custom data to a metainfo file."
+msgstr "S'ha trobat una etiqueta no vàlida. Les etiquetes no estàndard s'han de prefixar amb «x-». AppStream també proporciona l'etiqueta <custom/> per a afegir dades personalitzades arbitràries als fitxers metainfo. Aquesta etiqueta és llegida per les biblioteques d'AppStream i pot ser útil en lloc de definir noves etiquetes personalitzades o «x-» amb prefix si només voleu afegir dades personalitzades a un fitxer metainfo."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:675
-msgid ""
-"The essential tag `metadata_license` is missing. A license for the metadata "
-"itself always has to be defined."
-msgstr ""
-"Falta l'etiqueta essencial «metadata_license». Sempre s'ha de definir una "
-"llicència per a les metadades."
+msgid "The essential tag `metadata_license` is missing. A license for the metadata itself always has to be defined."
+msgstr "Falta l'etiqueta essencial «metadata_license». Sempre s'ha de definir una llicència per a les metadades."
 
 #: src/as-validator-issue-tag.h:680
-msgid ""
-"The component is missing a long description. Components of this type must "
-"have a long description."
-msgstr ""
-"Al component li falta una descripció llarga. Els components d'aquest tipus "
-"han de tenir una descripció llarga."
+msgid "The component is missing a long description. Components of this type must have a long description."
+msgstr "Al component li falta una descripció llarga. Els components d'aquest tipus han de tenir una descripció llarga."
 
 #: src/as-validator-issue-tag.h:685
-msgid ""
-"It would be useful to add a long description to this font to present it "
-"better to users."
-msgstr ""
-"Seria útil afegir una descripció llarga a aquesta font per a presentar-lo "
-"millor als usuaris."
+msgid "It would be useful to add a long description to this font to present it better to users."
+msgstr "Seria útil afegir una descripció llarga a aquesta font per a presentar-lo millor als usuaris."
 
 #: src/as-validator-issue-tag.h:690
-msgid ""
-"It is recommended to add a long description to this component to present it "
-"better to users."
-msgstr ""
-"Es recomana afegir una descripció llarga a aquest component per a presentar-"
-"lo millor als usuaris."
+msgid "It is recommended to add a long description to this component to present it better to users."
+msgstr "Es recomana afegir una descripció llarga a aquest component per a presentar-lo millor als usuaris."
 
 #: src/as-validator-issue-tag.h:695
-msgid ""
-"This generic component is missing a long description. It may be useful to "
-"add one."
-msgstr ""
-"A aquest component genèric li falta una descripció llarga. Pot ser útil "
-"afegir-ne una."
+msgid "This generic component is missing a long description. It may be useful to add one."
+msgstr "A aquest component genèric li falta una descripció llarga. Pot ser útil afegir-ne una."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:701
-msgid ""
-"This `desktop-application` component is missing a `desktop-id` launchable "
-"tag. This means that this application can not be launched and has no "
-"association with its desktop-entry file. It also means no icon data or "
-"category information from the desktop-entry file will be available, which "
-"will result in this application being ignored entirely."
-msgstr ""
-"A aquest component `desktop-application` li manca una etiqueta de llançament "
-"`desktop-id`. Això vol dir que aquesta aplicació no pot ser llançada i no té "
-"cap associació amb el fitxer d'entrada de l'escriptori. També vol dir que no "
-"hi haurà dades d'icones o informació de categories del fitxer d'entrada de "
-"l'escriptori, cosa que farà que aquesta aplicació sigui ignorada del tot."
+msgid "This `desktop-application` component is missing a `desktop-id` launchable tag. This means that this application can not be launched and has no association with its desktop-entry file. It also means no icon data or category information from the desktop-entry file will be available, which will result in this application being ignored entirely."
+msgstr "A aquest component `desktop-application` li manca una etiqueta de llançament `desktop-id`. Això vol dir que aquesta aplicació no pot ser llançada i no té cap associació amb el fitxer d'entrada de l'escriptori. També vol dir que no hi haurà dades d'icones o informació de categories del fitxer d'entrada de l'escriptori, cosa que farà que aquesta aplicació sigui ignorada del tot."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:710
-msgid ""
-"This `desktop-application` component has no `desktop-id` launchable tag, "
-"however it contains all the necessary information to display the "
-"application. The omission of the launchable entry means that this "
-"application can not be launched directly from installers or software "
-"centers. If this is intended, this information can be ignored, otherwise it "
-"is strongly recommended to add a launchable tag as well."
-msgstr ""
-"Aquest component `desktop-application` no té una etiqueta executable "
-"`desktop-id`, però conté tota la informació necessària per a mostrar "
-"l'aplicació. L'omissió de l'entrada executable vol dir que aquesta aplicació "
-"no es pot executar directament des d'instal·ladors o centres de programari. "
-"Si això és el que es pretén, aquesta informació pot ser ignorada, altrament "
-"és molt recomanable afegir també una etiqueta executable."
+msgid "This `desktop-application` component has no `desktop-id` launchable tag, however it contains all the necessary information to display the application. The omission of the launchable entry means that this application can not be launched directly from installers or software centers. If this is intended, this information can be ignored, otherwise it is strongly recommended to add a launchable tag as well."
+msgstr "Aquest component `desktop-application` no té una etiqueta executable `desktop-id`, però conté tota la informació necessària per a mostrar l'aplicació. L'omissió de l'entrada executable vol dir que aquesta aplicació no es pot executar directament des d'instal·ladors o centres de programari. Si això és el que es pretén, aquesta informació pot ser ignorada, altrament és molt recomanable afegir també una etiqueta executable."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:720
-msgid ""
-"Type `console-application` component, but no information about binaries in "
-"$PATH was provided via a `provides/binary` tag."
-msgstr ""
-"S'ha escrit el component de «console-application», però no s'ha proporcionat "
-"informació sobre binaris a $PATH a través d'una etiqueta «provides/binary»."
+msgid "Type `console-application` component, but no information about binaries in $PATH was provided via a `provides/binary` tag."
+msgstr "S'ha escrit el component de «console-application», però no s'ha proporcionat informació sobre binaris a $PATH a través d'una etiqueta «provides/binary»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:726
-msgid ""
-"This `web-application` component is missing a `launchable` tag of type `url`."
-msgstr ""
-"A aquest component de «web-application» li falta una etiqueta «launchable» "
-"del tipus «url»."
+msgid "This `web-application` component is missing a `launchable` tag of type `url`."
+msgstr "A aquest component de «web-application» li falta una etiqueta «launchable» del tipus «url»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:732
-msgid ""
-"This `web-application` component is missing a `icon` tag to specify a valid "
-"icon."
-msgstr ""
-"A aquest component «web-application» li manca una etiqueta «icon» per a "
-"especificar una icona vàlida."
+msgid "This `web-application` component is missing a `icon` tag to specify a valid icon."
+msgstr "A aquest component «web-application» li manca una etiqueta «icon» per a especificar una icona vàlida."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:738
-msgid ""
-"This `web-application` component is missing categorizations. A `categories` "
-"block is likely missing."
-msgstr ""
-"A aquest component de «web-application» li falten categoritzacions. És "
-"probable que falti un bloc de «categories»."
+msgid "This `web-application` component is missing categorizations. A `categories` block is likely missing."
+msgstr "A aquest component de «web-application» li falten categoritzacions. És probable que falti un bloc de «categories»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:744
-msgid ""
-"Type `font` component, but no font information was provided via a `provides/"
-"font` tag."
-msgstr ""
-"S'ha escrit el component «font», però no s'ha proporcionat informació de "
-"font a través d'una etiqueta «provides/font»."
+msgid "Type `font` component, but no font information was provided via a `provides/font` tag."
+msgstr "S'ha escrit el component «font», però no s'ha proporcionat informació de font a través d'una etiqueta «provides/font»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:750
-msgid ""
-"Type `driver` component, but no modalias information was provided via a "
-"`provides/modalias` tag."
-msgstr ""
-"S'ha escrit el component «driver», però no s'ha proporcionat informació de "
-"modalias a través d'una etiqueta «provides/modalias»."
+msgid "Type `driver` component, but no modalias information was provided via a `provides/modalias` tag."
+msgstr "S'ha escrit el component «driver», però no s'ha proporcionat informació de modalias a través d'una etiqueta «provides/modalias»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:756
-msgid ""
-"An `extends` tag is specified, but the component is not of type `addon`, "
-"`localization` or `repository`."
-msgstr ""
-"S'ha especificat una etiqueta «extends», però el component no és el tipus "
-"«addon», «localization» ni «repository»."
+msgid "An `extends` tag is specified, but the component is not of type `addon`, `localization` or `repository`."
+msgstr "S'ha especificat una etiqueta «extends», però el component no és el tipus «addon», «localization» ni «repository»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:762
 msgid "The component is an addon, but no `extends` tag was specified."
-msgstr ""
-"El component és un complement, però no s'ha especificat cap etiqueta "
-"«extends»."
+msgstr "El component és un complement, però no s'ha especificat cap etiqueta «extends»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:768
-msgid ""
-"This `localization` component is missing an `extends` tag, to specify the "
-"components it adds localization to."
-msgstr ""
-"A aquest component de «localization» li falta una etiqueta «extends», per a "
-"especificar els components als que s’afegeix la localització."
+msgid "This `localization` component is missing an `extends` tag, to specify the components it adds localization to."
+msgstr "A aquest component de «localization» li falta una etiqueta «extends», per a especificar els components als que s’afegeix la localització."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:774
-msgid ""
-"This `localization` component does not define any languages this "
-"localization is for."
-msgstr ""
-"Aquest component de «localization» no defineix per a quin idioma és aquesta "
-"localització."
+msgid "This `localization` component does not define any languages this localization is for."
+msgstr "Aquest component de «localization» no defineix per a quin idioma és aquesta localització."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:780
-msgid ""
-"This `service` component is missing a `launchable` tag of type `service`."
-msgstr ""
-"A aquest component «service» li falta una etiqueta «launchable» del tipus "
-"«service»."
+msgid "This `service` component is missing a `launchable` tag of type `service`."
+msgstr "A aquest component «service» li falta una etiqueta «launchable» del tipus «service»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:786
-msgid ""
-"Suggestions of any type other than `upstream` are not allowed in metainfo "
-"files."
-msgstr ""
-"No es permeten suggeriments de cap tipus que no siguin «upstream» en fitxers "
-"metainfo."
+msgid "Suggestions of any type other than `upstream` are not allowed in metainfo files."
+msgstr "No es permeten suggeriments de cap tipus que no siguin «upstream» en fitxers metainfo."
 
 #: src/as-validator-issue-tag.h:791
-msgid ""
-"The category name is not valid. Refer to the XDG Menu Specification for a "
-"list of valid category names."
-msgstr ""
-"El nom de la categoria no és vàlid. Consulteu l'especificació del menú XDG "
-"per a una llista de noms de categoria vàlids."
+msgid "The category name is not valid. Refer to the XDG Menu Specification for a list of valid category names."
+msgstr "El nom de la categoria no és vàlid. Consulteu l'especificació del menú XDG per a una llista de noms de categoria vàlids."
 
 #: src/as-validator-issue-tag.h:796
-msgid ""
-"All categories for this component have been ignored, either because they "
-"were invalid or because they are of low quality (e.g. custom 'X-' prefixed "
-"or toolkit ones like 'GTK' or 'Qt'). Please fix your category names, or add "
-"more categories."
-msgstr ""
+msgid "All categories for this component have been ignored, either because they were invalid or because they are of low quality (e.g. custom 'X-' prefixed or toolkit ones like 'GTK' or 'Qt'). Please fix your category names, or add more categories."
+msgstr "S'han ignorat totes les categories d'aquest component, ja sigui perquè no eren vàlides o perquè són de baixa qualitat (p. ex. amb prefix «X-», o «GTK», o «Qt»). Si us plau, corregiu els noms de les categories o afegiu-ne més."
 
 #: src/as-validator-issue-tag.h:802
-msgid ""
-"This component is in no valid categories, even though it should be. Please "
-"check its metainfo file and desktop-entry file."
-msgstr ""
-"Aquest component no està en cap categoria vàlida i hauria d'estar. Comproveu "
-"el vostre fitxer metainfo i el vostre fitxer desktop-entry."
+msgid "This component is in no valid categories, even though it should be. Please check its metainfo file and desktop-entry file."
+msgstr "Aquest component no està en cap categoria vàlida i hauria d'estar. Comproveu el vostre fitxer metainfo i el vostre fitxer desktop-entry."
 
 #: src/as-validator-issue-tag.h:807
 msgid "The screenshot caption is too long (should be <= 100 characters)"
@@ -2772,35 +2395,21 @@ msgstr "No es pot llegir el fitxer."
 msgid "The XML of this file is malformed."
 msgstr "L'XML d'aquest fitxer té un format incorrecte."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:823
-#, fuzzy
-msgid ""
-"Invalid tag found in catalog metadata. Only `component` tags are permitted."
-msgstr ""
-"S'ha trobat una etiqueta no vàlida a les metadades de la col·lecció. Només "
-"es permeten les etiquetes «component»."
+msgid "Invalid tag found in catalog metadata. Only `component` tags are permitted."
+msgstr "S'ha trobat una etiqueta no vàlida a les metadades de la col·lecció. Només es permeten les etiquetes `component`."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:829
-#, fuzzy
-msgid ""
-"The metainfo file uses an ancient version of the AppStream specification, "
-"which can not be validated. Please migrate it to version 0.6 (or higher). "
-"Modern files use the `component` root tag and include many other "
-"differences, so check for changes carefully when modernizing the data."
-msgstr ""
-"El fitxer metainfo utilitza una versió antiga de l'especificació "
-"d'AppStream, que no es pot validar. Si us plau, migra'l a la versió 0.6 (o "
-"superior)."
+msgid "The metainfo file uses an ancient version of the AppStream specification, which can not be validated. Please migrate it to version 0.6 (or higher). Modern files use the `component` root tag and include many other differences, so check for changes carefully when modernizing the data."
+msgstr "El fitxer de metadades utilitza una versió antiga de l'especificació d'AppStream, que no es pot validar. Si us plau, migreu-lo a la versió 0.6 (o superior). Els fitxers moderns utilitzen l'etiqueta arrel `component` i inclouen altres diferències, pel que hauríeu de comprovar els canvis minuciosament quan modernitzeu les dades."
 
 #: src/as-validator-issue-tag.h:835
-msgid ""
-"This XML document has an unknown root tag. Maybe this file is not a metainfo "
-"document?"
-msgstr ""
-"Aquest document XML té una etiqueta arrel desconeguda. Potser aquest fitxer "
-"no és un document metainfo?"
+msgid "This XML document has an unknown root tag. Maybe this file is not a metainfo document?"
+msgstr "Aquest document XML té una etiqueta arrel desconeguda. Potser aquest fitxer no és un document metainfo?"
 
 #: src/as-validator-issue-tag.h:840
 msgid "The metainfo filename does not match the component ID."
@@ -2808,73 +2417,39 @@ msgstr "El nom del fitxer de metainfo no coincideix amb l'ID del component."
 
 #: src/as-validator-issue-tag.h:845
 msgid "Unable to load the desktop-entry file associated with this component."
-msgstr ""
-"No s'ha pogut carregar el fitxer d'entrada de l'escriptori associat a aquest "
-"component."
+msgstr "No s'ha pogut carregar el fitxer d'entrada de l'escriptori associat a aquest component."
 
 #: src/as-validator-issue-tag.h:850
 msgid "This component metadata refers to a non-existing .desktop file."
-msgstr ""
-"Aquestes metadades de components es refereixen a un fitxer .desktop no "
-"existent."
+msgstr "Aquestes metadades de components es refereixen a un fitxer .desktop no existent."
 
 #: src/as-validator-issue-tag.h:855
-msgid ""
-"A category defined in the desktop-entry file is not valid. Refer to the XDG "
-"Menu Specification for a list of valid categories."
-msgstr ""
-"Una categoria definida al fitxer d'entrada de l'escriptori no és vàlida. "
-"Consulteu l'especificació del menú XDG per a veure una llista de categories "
-"vàlides."
+msgid "A category defined in the desktop-entry file is not valid. Refer to the XDG Menu Specification for a list of valid categories."
+msgstr "Una categoria definida al fitxer d'entrada de l'escriptori no és vàlida. Consulteu l'especificació del menú XDG per a veure una llista de categories vàlides."
 
 #: src/as-validator-issue-tag.h:860
 msgid "Error while reading some data from the desktop-entry file."
 msgstr "Error en llegir algunes dades del fitxer d'entrada de l'escriptori."
 
 #: src/as-validator-issue-tag.h:865
-msgid ""
-"The value of this desktop-entry field contains invalid or non-printable "
-"UTF-8 characters, which can not be displayed properly."
-msgstr ""
-"El valor d'aquest camp d'entrada de l'escriptori conté caràcters UTF-8 no "
-"vàlids o no imprimibles, que no es poden mostrar correctament."
+msgid "The value of this desktop-entry field contains invalid or non-printable UTF-8 characters, which can not be displayed properly."
+msgstr "El valor d'aquest camp d'entrada de l'escriptori conté caràcters UTF-8 no vàlids o no imprimibles, que no es poden mostrar correctament."
 
 #: src/as-validator-issue-tag.h:870
-msgid ""
-"This desktop-entry field value is quoted, which is likely unintentional."
-msgstr ""
-"El valor d'aquest camp d'entrada de l'escriptori està entrecometes, cosa que "
-"probablement no és intencionada."
+msgid "This desktop-entry field value is quoted, which is likely unintentional."
+msgstr "El valor d'aquest camp d'entrada de l'escriptori està entrecometes, cosa que probablement no és intencionada."
 
 #: src/as-validator-issue-tag.h:875
-msgid ""
-"This desktop-entry file has the 'Hidden' property set. This is wrong for "
-"vendor-installed .desktop files, and nullifies all effects this .desktop "
-"file has (including MIME associations), which most certainly is not "
-"intentional."
-msgstr ""
-"Aquest fitxer desktop-entry té la propietat 'Hidden' establerta. Això és "
-"incorrecte per als fitxers .desktop instal·lats pel proveïdor, i anul·la "
-"tots els efectes que té aquest fitxer .desktop (incloent-hi les associacions "
-"MIME), cosa que segurament no és intencional."
+msgid "This desktop-entry file has the 'Hidden' property set. This is wrong for vendor-installed .desktop files, and nullifies all effects this .desktop file has (including MIME associations), which most certainly is not intentional."
+msgstr "Aquest fitxer desktop-entry té la propietat 'Hidden' establerta. Això és incorrecte per als fitxers .desktop instal·lats pel proveïdor, i anul·la tots els efectes que té aquest fitxer .desktop (incloent-hi les associacions MIME), cosa que segurament no és intencional."
 
 #: src/as-validator-issue-tag.h:881
-msgid ""
-"This desktop-entry file has the 'OnlyShowIn' property set with an empty "
-"value. This might not be intended, as this will hide the application from "
-"all desktops. If you do want to hide the application from all desktops, "
-"using 'NoDisplay=true' is more explicit."
-msgstr ""
-"Aquest fitxer d'entrada d'escriptori té la propietat 'OnlyShowIn' establerta "
-"amb un valor buit. Aquesta podria no ser la intenció, ja que amagarà "
-"l'aplicació de tots els escriptoris. Si voleu ocultar l'aplicació de tots "
-"els escriptoris, utilitzeu 'NoDisplay=true' que és més explícit."
+msgid "This desktop-entry file has the 'OnlyShowIn' property set with an empty value. This might not be intended, as this will hide the application from all desktops. If you do want to hide the application from all desktops, using 'NoDisplay=true' is more explicit."
+msgstr "Aquest fitxer d'entrada d'escriptori té la propietat 'OnlyShowIn' establerta amb un valor buit. Aquesta podria no ser la intenció, ja que amagarà l'aplicació de tots els escriptoris. Si voleu ocultar l'aplicació de tots els escriptoris, utilitzeu 'NoDisplay=true' que és més explícit."
 
 #: src/as-validator-issue-tag.h:887
 msgid "No AppStream metadata was found in this directory or directory tree."
-msgstr ""
-"No s'ha trobat cap metadada appStream en aquest directori o arbre de "
-"directoris."
+msgstr "No s'ha trobat cap metadada appStream en aquest directori o arbre de directoris."
 
 #. pedantic because not everything which has metadata is an application
 #: src/as-validator-issue-tag.h:892
@@ -2882,288 +2457,206 @@ msgid "No XDG applications directory found."
 msgstr "No s'ha trobat cap directori d'aplicacions XDG."
 
 #: src/as-validator-issue-tag.h:897
-msgid ""
-"The metainfo file is stored in a legacy path. Please place it in `/usr/share/"
-"metainfo/`."
-msgstr ""
-"El fitxer metainfo s'emmagatzema en un camí heretat. Poseu-lo a «/usr/share/"
-"metainfo/»."
+msgid "The metainfo file is stored in a legacy path. Please place it in `/usr/share/metainfo/`."
+msgstr "El fitxer metainfo s'emmagatzema en un camí heretat. Poseu-lo a «/usr/share/metainfo/»."
 
 #: src/as-validator-issue-tag.h:902
 msgid "The metainfo file specifies multiple components. This is not allowed."
-msgstr ""
-"El fitxer metainfo especifica diversos components. Això no està permès."
+msgstr "El fitxer metainfo especifica diversos components. Això no està permès."
 
 #: src/as-validator-issue-tag.h:907
-msgid ""
-"The releases are not sorted in a latest to oldest version order. This is "
-"required as some tools will assume that the latest version is always at the "
-"top. Sorting releases also increases overall readability of the metainfo "
-"file."
-msgstr ""
-"Les versions no s'ordenen en una última ordre de versió antiga. Això és "
-"necessari, ja que algunes eines suposaran que l'última versió sempre està a "
-"la part superior. Ordenar les versions també augmenta la llegibilitat "
-"general del fitxer metainfo."
+msgid "The releases are not sorted in a latest to oldest version order. This is required as some tools will assume that the latest version is always at the top. Sorting releases also increases overall readability of the metainfo file."
+msgstr "Les versions no s'ordenen en una última ordre de versió antiga. Això és necessari, ja que algunes eines suposaran que l'última versió sempre està a la part superior. Ordenar les versions també augmenta la llegibilitat general del fitxer metainfo."
 
-#. TRANSLATORS: Please do not translate AppStream tag/property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag/property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:915
-msgid ""
-"The type of the releases block is invalid. It needs to either `embedded` "
-"(the default) or `external`."
-msgstr ""
+msgid "The type of the releases block is invalid. It needs to either `embedded` (the default) or `external`."
+msgstr "El tipus del bloc de llançaments no és vàlid. Necessita o bé `embedded` (el predeterminat) o `external`."
 
 #: src/as-validator-issue-tag.h:920
-msgid ""
-"The URL to an external release metadata file is insecure. This is not "
-"allowed, please use HTTPS URLs only."
-msgstr ""
+msgid "The URL to an external release metadata file is insecure. This is not allowed, please use HTTPS URLs only."
+msgstr "L'URL a un fitxer extern de metadades de llançaments és insegur. Això no està permès, si us plau, utilitzeu només URL HTTPS."
 
 #: src/as-validator-issue-tag.h:925
-#, fuzzy
 msgid "Failed to download release metadata."
-msgstr "No s'ha pogut baixar el fitxer: %s"
+msgstr "No s'han pogut baixar les metadades de llançament."
 
 #: src/as-validator-issue-tag.h:930
-msgid ""
-"A local release metadata file was not found. It is strongly recommended to "
-"validate this metadata together with the main MetaInfo file."
-msgstr ""
+msgid "A local release metadata file was not found. It is strongly recommended to validate this metadata together with the main MetaInfo file."
+msgstr "No s'ha trobat cap fitxer de metadades de llançament localment. És molt recomanable validar aquestes metadades juntament amb el fitxer principal MetaInfo."
 
 #: src/as-validator-issue-tag.h:936
 msgid "The value set as release urgency is not a known urgency value."
-msgstr ""
-"El valor establert com a urgència de versió no és un valor d'urgència "
-"conegut."
+msgstr "El valor establert com a urgència de versió no és un valor d'urgència conegut."
 
 #: src/as-validator-issue-tag.h:941
 msgid "The value set as release type is invalid."
 msgstr "El valor definit com a tipus de versió no és vàlid."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:947
 msgid "The release is missing the `version` property."
 msgstr "Aquesta versió no té la propietat `version`."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:953
-msgid ""
-"The release is missing either the `date` (preferred) or the `timestamp` "
-"property."
-msgstr ""
-"Aquesta versió no té la propietat `date` (preferida) o la propietat "
-"`timestamp`."
+msgid "The release is missing either the `date` (preferred) or the `timestamp` property."
+msgstr "Aquesta versió no té la propietat `date` (preferida) o la propietat `timestamp`."
 
 #: src/as-validator-issue-tag.h:958
 msgid "The release timestamp is invalid."
 msgstr "La data de publicació no és vàlida."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:964
 msgid "The release description must be put inside a `description` tag"
-msgstr ""
+msgstr "La descripció del llançament s'ha de posar dins d'una etiqueta `description`"
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:970
-msgid ""
-"The value set as artifact type is invalid. Must be either `source` or "
-"`binary`."
-msgstr ""
-"El conjunt de valors com a tipus d'artefacte no és vàlid. Ha de ser «source» "
-"o «binary»."
+msgid "The value set as artifact type is invalid. Must be either `source` or `binary`."
+msgstr "El conjunt de valors com a tipus d'artefacte no és vàlid. Ha de ser «source» o «binary»."
 
 #: src/as-validator-issue-tag.h:975
 msgid "The value set as artifact bundle type is invalid."
 msgstr "El conjunt de valors com a tipus de paquet d'artefactes no és vàlid."
 
 #: src/as-validator-issue-tag.h:980
-msgid ""
-"The platform triplet for this release is invalid. It must be in the form of "
-"`architecture-oskernel-osenv` - refer to the AppStream documentation or "
-"information on normalized GNU triplets for more information and valid fields."
-msgstr ""
-"El triplet de plataforma per a aquesta versió no és vàlid. Ha de ser en "
-"forma d’«architecture-oskernel-osenv» - consulteu la documentació "
-"d'AppStream o informació sobre els triplets GNU normalitzats per a obtenir "
-"més informació i camps vàlids."
+msgid "The platform triplet for this release is invalid. It must be in the form of `architecture-oskernel-osenv` - refer to the AppStream documentation or information on normalized GNU triplets for more information and valid fields."
+msgstr "El triplet de plataforma per a aquesta versió no és vàlid. Ha de ser en forma d’«architecture-oskernel-osenv» - consulteu la documentació d'AppStream o informació sobre els triplets GNU normalitzats per a obtenir més informació i camps vàlids."
 
 #: src/as-validator-issue-tag.h:987
 msgid "The selected checksumming algorithm is unsupported or unknown."
-msgstr ""
-"L'algorisme de suma de verificació seleccionat no és compatible o és "
-"desconegut."
+msgstr "L'algorisme de suma de verificació seleccionat no és compatible o és desconegut."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:993
 msgid "The size type is unknown. Must be `download` or `installed`."
 msgstr "El tipus de mida és desconegut. Ha de ser «download» o «installed»."
 
 #: src/as-validator-issue-tag.h:998
-msgid ""
-"The artifact filename must be a file basename, not a (relative or absolute) "
-"path."
-msgstr ""
-"El nom del fitxer d'artefacte ha de ser un nom base de fitxer, no un camí "
-"(relatiu o absolut)."
+msgid "The artifact filename must be a file basename, not a (relative or absolute) path."
+msgstr "El nom del fitxer d'artefacte ha de ser un nom base de fitxer, no un camí (relatiu o absolut)."
 
 #: src/as-validator-issue-tag.h:1003
 msgid "The value set as release issue type is invalid."
 msgstr "El valor definit com a tipus de problema de versió no és vàlid."
 
 #: src/as-validator-issue-tag.h:1008
-msgid ""
-"The issue is tagged at security vulnerability with a CVE number, but its "
-"value does not look like a valid CVE identifier."
-msgstr ""
-"El problema s'etiqueta en vulnerabilitat de seguretat amb un número CVE, "
-"però el seu valor no sembla un identificador CVE vàlid."
+msgid "The issue is tagged at security vulnerability with a CVE number, but its value does not look like a valid CVE identifier."
+msgstr "El problema s'etiqueta en vulnerabilitat de seguretat amb un número CVE, però el seu valor no sembla un identificador CVE vàlid."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1014
-msgid ""
-"This component is missing information about releases. Consider adding a "
-"`releases` tag to describe releases and their changes."
-msgstr ""
-"Falta informació sobre les versions. Considereu afegir una etiqueta "
-"«releases» per a descriure les versions i els seus canvis."
+msgid "This component is missing information about releases. Consider adding a `releases` tag to describe releases and their changes."
+msgstr "Falta informació sobre les versions. Considereu afegir una etiqueta «releases» per a descriure les versions i els seus canvis."
 
 #: src/as-validator-issue-tag.h:1019
-msgid ""
-"The AppStream specification requires a complete, ISO 8601 date string with "
-"at least day-granularity to denote dates. Please ensure the date string is "
-"valid."
-msgstr ""
-"L'especificació d'AppStream requereix una cadena de data ISO 8601 completa "
-"amb granularitat d’almenys dies per a denotar dates. Assegureu-vos que la "
-"cadena de data és vàlida."
+msgid "The AppStream specification requires a complete, ISO 8601 date string with at least day-granularity to denote dates. Please ensure the date string is valid."
+msgstr "L'especificació d'AppStream requereix una cadena de data ISO 8601 completa amb granularitat d’almenys dies per a denotar dates. Assegureu-vos que la cadena de data és vàlida."
 
 #: src/as-validator-issue-tag.h:1025
-msgid ""
-"This component extends, provides, requires or recommends itself, which is "
-"certainly not intended and may confuse users or machines dealing with this "
-"metadata."
-msgstr ""
-"Aquest component s'estén, proporciona, requereix o es recomana a si mateix, "
-"la qual cosa certament no està pensat i pot confondre els usuaris o màquines "
-"que s'ocupen d'aquestes metadades."
+msgid "This component extends, provides, requires or recommends itself, which is certainly not intended and may confuse users or machines dealing with this metadata."
+msgstr "Aquest component s'estén, proporciona, requereix o es recomana a si mateix, la qual cosa certament no està pensat i pot confondre els usuaris o màquines que s'ocupen d'aquestes metadades."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1032
-msgid ""
-"Licenses for `runtime` components are usually too complex to reflect them in "
-"a simple SPDX expression. Consider using a `LicenseRef` and a web URL as "
-"value for this component's `project_license`. E.g. `LicenseRef-free=https://"
-"example.com/licenses.html`"
-msgstr ""
-"Les llicències per a components «runtime» solen ser massa complexes per a "
-"reflectir-les en una expressió SPDX simple. Considereu l'ús d'un "
-"«LicenseRef» i una adreça URL com a valor per a la «project_license» "
-"d'aquest component. Per exemple, «LicenseRef-free=https://example.com/"
-"licenses.html»"
+msgid "Licenses for `runtime` components are usually too complex to reflect them in a simple SPDX expression. Consider using a `LicenseRef` and a web URL as value for this component's `project_license`. E.g. `LicenseRef-free=https://example.com/licenses.html`"
+msgstr "Les llicències per a components «runtime» solen ser massa complexes per a reflectir-les en una expressió SPDX simple. Considereu l'ús d'un «LicenseRef» i una adreça URL com a valor per a la «project_license» d'aquest component. Per exemple, «LicenseRef-free=https://example.com/licenses.html»"
 
 #: src/as-validator-issue-tag.h:1038
-msgid ""
-"Since a `runtime` component is comprised of multiple other software "
-"components, their component-IDs may be listed in a `<provides/>` section for "
-"this runtime."
-msgstr ""
-"Atès que un component «runtime» es compon de diversos components de "
-"programari, els seus ID de components es poden llistar en una secció "
-"«<provides/>» per a aquest temps d'execució."
+msgid "Since a `runtime` component is comprised of multiple other software components, their component-IDs may be listed in a `<provides/>` section for this runtime."
+msgstr "Atès que un component «runtime» es compon de diversos components de programari, els seus ID de components es poden llistar en una secció «<provides/>» per a aquest temps d'execució."
 
 #: src/as-validator-issue-tag.h:1043
-msgid ""
-"The type of the item that the component provides is not known to AppStream."
+msgid "The type of the item that the component provides is not known to AppStream."
 msgstr "AppStream no coneix el tipus d’element que proporciona el component."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1049
-msgid ""
-"The toplevel `mimetypes` tag is deprecated. Please use `mediatype` tags in a "
-"`provides` block instead to indicate that your software provides a media "
-"handler for the given types."
-msgstr ""
-"L'etiqueta «mimetypes» de nivell està obsoleta. Utilitzeu etiquetes de "
-"«mediatype» en un bloc de «provides» per a indicar que el programari "
-"proporciona un controlador multimèdia per als tipus indicats."
+msgid "The toplevel `mimetypes` tag is deprecated. Please use `mediatype` tags in a `provides` block instead to indicate that your software provides a media handler for the given types."
+msgstr "L'etiqueta «mimetypes» de nivell està obsoleta. Utilitzeu etiquetes de «mediatype» en un bloc de «provides» per a indicar que el programari proporciona un controlador multimèdia per als tipus indicats."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1056
-msgid ""
-"This component has no `content_rating` tag to provide age rating "
-"information. You can generate the tag data online by answering a few "
-"questions at https://hughsie.github.io/oars/"
-msgstr ""
-"Aquest component no té cap etiqueta «content_rating» per a proporcionar "
-"informació de classificació d’antiguitat. Podeu generar les dades de "
-"l'etiqueta en línia responent a algunes preguntes a https://hughsie.github."
-"io/oars/"
+msgid "This component has no `content_rating` tag to provide age rating information. You can generate the tag data online by answering a few questions at https://hughsie.github.io/oars/"
+msgstr "Aquest component no té cap etiqueta «content_rating» per a proporcionar informació de classificació d’antiguitat. Podeu generar les dades de l'etiqueta en línia responent a algunes preguntes a https://hughsie.github.io/oars/"
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1063
-msgid ""
-"The `type` attribute of this `content_rating` element is missing or empty."
-msgstr ""
+msgid "The `type` attribute of this `content_rating` element is missing or empty."
+msgstr "Falta o està buit l'atribut `type` d'aquest element `content_rating`."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1069
-msgid ""
-"The `type` attribute of the `content_rating` element has an invalid value."
-msgstr ""
+msgid "The `type` attribute of the `content_rating` element has an invalid value."
+msgstr "L'atribut `type` de l'element `content_rating` té un valor no vàlid."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1075
 msgid "The `content_rating` tag can only contain `content_attribute` children."
-msgstr ""
+msgstr "L'etiqueta `content_rating` només pot contenir fills `content_attribute`."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1081
-msgid ""
-"The `id` attribute of the `content_attribute` element is missing or empty."
-msgstr ""
+msgid "The `id` attribute of the `content_attribute` element is missing or empty."
+msgstr "Falta o està buit l'atribut `id` de l'element `content_attribute`."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1087
-msgid ""
-"The `id` attribute of the `content_attribute` element has an invalid value."
-msgstr ""
+msgid "The `id` attribute of the `content_attribute` element has an invalid value."
+msgstr "El valor de l'atribut `id` de l'element `content_attribute` no és vàlid."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1093
 msgid "The `content_attribute` tag needs a value."
-msgstr ""
+msgstr "L'etiqueta `content_attribute` necessita un valor."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1099
 msgid "The `content_attribute` tag value is unknown."
-msgstr ""
+msgstr "El valor de l'etiqueta `content_attribute` és desconegut."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1105
-#, fuzzy
 msgid "The `content_attribute` tag value is invalid for the given id."
-msgstr ""
-"El valor de l'etiqueta establert no és vàlid per a una relació `internet`."
+msgstr "El valor de l'etiqueta `content_attribute` no és vàlid per l'identificador indicat."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1111
-#, fuzzy
 msgid "A `content_attribute` tag with this ID has already been defined."
-msgstr "Ja s'ha definit una URL d'aquest tipus."
+msgstr "Ja s'ha definit una etiqueta `content_attribute` amb aquest identificador."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1117
 msgid "This `tag` is missing a `namespace` attribute."
 msgstr "A aquesta «tag» li falta un atribut «namespace»."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1123
-msgid ""
-"This tag or its namespace contains invalid characters. Only lower-cased "
-"ASCII letters, numbers, dots, hyphens and underscores are permitted."
-msgstr ""
-"Aquesta etiqueta o el seu espai de noms conté caràcters no vàlids. Només es "
-"permeten lletres ASCII en minúscula, números, punts, guions i guions baixos."
+msgid "This tag or its namespace contains invalid characters. Only lower-cased ASCII letters, numbers, dots, hyphens and underscores are permitted."
+msgstr "Aquesta etiqueta o el seu espai de noms conté caràcters no vàlids. Només es permeten lletres ASCII en minúscula, números, punts, guions i guions baixos."
 
 #: src/as-validator-issue-tag.h:1128
 msgid "The type of this color is not valid."
@@ -3173,90 +2666,71 @@ msgstr "El tipus d'aquest color no és vàlid."
 msgid "The value of this color scheme preference is not valid."
 msgstr "El valor d'aquesta preferència de color no és vàlid."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1139
-msgid ""
-"The name of the color scheme property is wrong. It should be "
-"`scheme_preference`."
-msgstr ""
+msgid "The name of the color scheme property is wrong. It should be `scheme_preference`."
+msgstr "El nom de la propietat de l'esquema de color és incorrecte. Hauria de ser `scheme_preference`."
 
 #: src/as-validator-issue-tag.h:1144
 msgid "This color is not a valid HTML color code."
 msgstr "Aquest color no és un codi de color HTML vàlid."
 
 #: src/as-validator-issue-tag.h:1149
-msgid ""
-"A color for this type/scheme combination was already set. Colors must be "
-"unique per type/scheme."
-msgstr ""
+msgid "A color for this type/scheme combination was already set. Colors must be unique per type/scheme."
+msgstr "Ja s'ha establert un color per a aquesta combinació de tipus i esquema. Els colors han de ser únics per tipus i esquema."
 
 #: src/as-validator-issue-tag.h:1154
-msgid ""
-"The given DOI (Digital Object Identifier) for this reference item is not "
-"valid."
-msgstr ""
+msgid "The given DOI (Digital Object Identifier) for this reference item is not valid."
+msgstr "El DOI (identificador d'objecte digital, de l'anglès) indicat per a aquest element de referència no és vàlid."
 
 #: src/as-validator-issue-tag.h:1159
-msgid ""
-"The value for this citation reference item must be an URL to a CFF (Citation "
-"File Format) file."
-msgstr ""
+msgid "The value for this citation reference item must be an URL to a CFF (Citation File Format) file."
+msgstr "El valor d'aquest element de referència de cita ha de ser un URL a un fitxer CFF (Citation File Format)."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1165
-msgid ""
-"This registry reference item is missing the `name` property to denote the "
-"name of the registry it is about."
-msgstr ""
+msgid "This registry reference item is missing the `name` property to denote the name of the registry it is about."
+msgstr "A aquest element de referència del registre falta la propietat `name` per a denotar el nom del registre del qual es tracta."
 
 #: src/as-validator-issue-tag.h:1170
-msgid ""
-"The registry for this reference item is unknown. This may be due to a typing "
-"error, or the registry needs to be registered with AppStream."
-msgstr ""
+msgid "The registry for this reference item is unknown. This may be due to a typing error, or the registry needs to be registered with AppStream."
+msgstr "El registre d'aquest element de referència és desconegut. Això pot ser a causa d'un error d'escriptura, o el registre ha d'estar registrat amb l'AppStream."
 
 #: src/as-validator-issue-tag.h:1176
-#, fuzzy
 msgid "The reference item is missing a value."
-msgstr "La data de publicació no és vàlida."
+msgstr "A l'ítem de referència falta un valor."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1182
 msgid "The `custom` tag can only contain `value` children."
-msgstr ""
+msgstr "L'etiqueta `custom` només pot contenir fills `value`."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1188
-#, fuzzy
 msgid "This `custom` tag value is missing a `key` attribute."
-msgstr "A aquesta «tag» li falta un atribut «namespace»."
+msgstr "Al valor d'aquesta etiqueta `custom` falta un atribut `key`."
 
 #: src/as-validator-issue-tag.h:1193
 msgid "A key can only be used once."
-msgstr ""
+msgstr "Una clau només es pot utilitzar una vegada."
 
 #: src/as-validator-issue-tag.h:1198
 msgid "This custom value is empty."
-msgstr ""
+msgstr "Aquest valor personalitzat està buit."
 
-#. TRANSLATORS: Please do not translate AppStream tag and property names (in backticks).
+#. TRANSLATORS: Please do not translate AppStream tag and property names (in
+#. backticks).
 #: src/as-validator-issue-tag.h:1204
-#, fuzzy
-msgid ""
-"A `keywords` tag must not be localized in metainfo files (upstream "
-"metadata). Localize the individual keyword entries instead."
-msgstr ""
-"Una etiqueta <keywords/> no s'ha d'ubicar en fitxers de metainformació "
-"(metadades originals). En comptes d'això, ubiqueu els paràgrafs individuals."
+msgid "A `keywords` tag must not be localized in metainfo files (upstream metadata). Localize the individual keyword entries instead."
+msgstr "Una etiqueta `keywords` no s'ha de traduir en fitxers de metainformació (metadades originals). Traduïu les entrades de paraules clau individualment."
 
 #: src/as-validator.c:199
-msgid ""
-"The emitted issue tag is unknown in the tag registry of AppStream. This is a "
-"bug in the validator itself, please report this issue in our bugtracker."
-msgstr ""
-"L'etiqueta de problema emesa és desconeguda al registre d'etiquetes "
-"d'AppStream. Aquest és un error en el propi validador, si us plau, informeu "
-"d'aquest problema al nostre registre d’errors."
+msgid "The emitted issue tag is unknown in the tag registry of AppStream. This is a bug in the validator itself, please report this issue in our bugtracker."
+msgstr "L'etiqueta de problema emesa és desconeguda al registre d'etiquetes d'AppStream. Aquest és un error en el propi validador, si us plau, informeu d'aquest problema al nostre registre d’errors."
 
 #: src/as-validator.c:419
 msgid "URL format is invalid."
@@ -3265,36 +2739,35 @@ msgstr "El format de l'URL no és vàlid."
 #: src/as-validator.c:480 src/as-validator.c:525
 #, c-format
 msgid "The release metadata file '%s' is named incorrectly."
-msgstr ""
+msgstr "El fitxer de metadades de llançament '%s' té un nom incorrecte."
 
-#. TRANSLATORS: The user tried to set an invalid severity for a validator issue tag
+#. TRANSLATORS: The user tried to set an invalid severity for a validator
+#. issue tag
 #: src/as-validator.c:673
 #, c-format
 msgid "The new issue severity for tag '%s' is invalid."
 msgstr "La nova gravetat del problema per a l'etiqueta «%s» no és vàlida."
 
-#. TRANSLATORS: The user tried to override a validator issue tag that we don't know
+#. TRANSLATORS: The user tried to override a validator issue tag that we don't
+#. know
 #: src/as-validator.c:684
 #, c-format
 msgid "The issue tag '%s' is not recognized."
 msgstr "L'etiqueta del problema «%s» no es reconeix."
 
-#. TRANSLATORS: The user tried to override an issue tag and make it non-fatal, even though the tag is not
+#. TRANSLATORS: The user tried to override an issue tag and make it non-fatal,
+#. even though the tag is not
 #. whitelisted for that.
 #: src/as-validator.c:711
 #, c-format
-msgid ""
-"It is not allowed to downgrade the severity of tag '%s' to one that allows "
-"validation to pass."
-msgstr ""
-"No es permet reduir la gravetat de l'etiqueta «%s» a una que permeti passar "
-"la validació."
+msgid "It is not allowed to downgrade the severity of tag '%s' to one that allows validation to pass."
+msgstr "No es permet reduir la gravetat de l'etiqueta «%s» a una que permeti passar la validació."
 
-#. TRANSLATORS: An invalid XML element was found, "Found" refers to the tag name found, "Allowed" to the permitted name.
-#. TRANSLATORS: An invalid XML element was found, "Found" refers to the tag name found, "Allowed" to the permitted names.
-#: src/as-validator.c:870 src/as-validator.c:1484 src/as-validator.c:1660
-#: src/as-validator.c:1883 src/as-validator.c:2529 src/as-validator.c:2551
-#: src/as-validator.c:2675 src/as-validator.c:2998
+#. TRANSLATORS: An invalid XML element was found, "Found" refers to the tag
+#. name found, "Allowed" to the permitted name.
+#. TRANSLATORS: An invalid XML element was found, "Found" refers to the tag
+#. name found, "Allowed" to the permitted names.
+#: src/as-validator.c:870 src/as-validator.c:1484 src/as-validator.c:1660 src/as-validator.c:1883 src/as-validator.c:2529 src/as-validator.c:2551 src/as-validator.c:2675 src/as-validator.c:2998
 #, c-format
 msgid "Found: %s - Allowed: %s"
 msgstr "Trobat: %s - Permès: %s"
@@ -3320,57 +2793,43 @@ msgstr "Mostra la versió de l'aplicació."
 #. TRANSLATORS: ascompose flag description for: --no-net
 #: tools/appstream-compose.c:219
 msgid "Do not use the network at all, not even for URL validity checks."
-msgstr ""
-"No utilitzeu mai la xarxa, ni tan sols per a les comprovacions de validesa "
-"de l'URL."
+msgstr "No utilitzeu mai la xarxa, ni tan sols per a les comprovacions de validesa de l'URL."
 
 #. TRANSLATORS: ascompose flag description for: --print-report
 #: tools/appstream-compose.c:226
-#, fuzzy
 msgid "Set mode of the issue report that is printed to the console."
-msgstr ""
-"Defineix el mode de l'informe de problemes que s'imprimeix a la consola"
+msgstr "Defineix el mode de l'informe de problemes que s'imprimeix a la consola."
 
 #. TRANSLATORS: ascompose flag description for: --prefix
 #: tools/appstream-compose.c:233
-#, fuzzy
 msgid "Override the default prefix (`/usr` by default)."
 msgstr "Substitueix el prefix predeterminat («/usr» per defecte)"
 
 #. TRANSLATORS: ascompose flag description for: --result-root
 #: tools/appstream-compose.c:240
-#, fuzzy
 msgid "Set the result output directory."
-msgstr "Defineix el directori de sortida del resultat"
+msgstr "Defineix el directori de sortida del resultat."
 
-#. TRANSLATORS: ascompose flag description for: --data-dir, `catalog metadata` is an AppStream term
+#. TRANSLATORS: ascompose flag description for: --data-dir, `catalog metadata`
+#. is an AppStream term
 #: tools/appstream-compose.c:247
-#, fuzzy
 msgid "Override the catalog metadata output directory."
-msgstr "Substitueix el directori de sortida de metadades de la col·lecció"
+msgstr "Substitueix el directori de sortida de metadades de la col·lecció."
 
 #. TRANSLATORS: ascompose flag description for: --icons-dir
 #: tools/appstream-compose.c:254
-#, fuzzy
 msgid "Override the icon output directory."
-msgstr "Substitueix el directori de sortida d'icones"
+msgstr "Substitueix el directori de sortida d'icones."
 
 #. TRANSLATORS: ascompose flag description for: --media-dir
 #: tools/appstream-compose.c:261
-#, fuzzy
-msgid ""
-"Set the media output directory (for media data to be served by a webserver)."
-msgstr ""
-"Defineix el directori de sortida multimèdia (perquè un servidor web serveixi "
-"dades multimèdia)"
+msgid "Set the media output directory (for media data to be served by a webserver)."
+msgstr "Defineix el directori de sortida multimèdia (perquè un servidor web serveixi dades multimèdia)"
 
 #. TRANSLATORS: ascompose flag description for: --hints-dir
 #: tools/appstream-compose.c:268
-#, fuzzy
 msgid "Set a directory where HTML and text issue reports will be stored."
-msgstr ""
-"Defineix el directori on s'emmagatzemaran informes de problemes HTML i de "
-"text"
+msgstr "Defineix el directori on s'emmagatzemaran informes de problemes en HTML i en text."
 
 #. TRANSLATORS: ascompose flag description for: --origin
 #: tools/appstream-compose.c:275
@@ -3379,37 +2838,28 @@ msgstr "Defineix el nom d'origen"
 
 #. TRANSLATORS: ascompose flag description for: --media-baseurl
 #: tools/appstream-compose.c:282
-#, fuzzy
 msgid "Set the URL where the exported media content will be hosted."
-msgstr "Defineix l'URL on s'allotjarà el contingut multimèdia exportat"
+msgstr "Defineix l'URL on s'allotjarà el contingut multimèdia exportat."
 
 #. TRANSLATORS: ascompose flag description for: --no-partial-urls
 #: tools/appstream-compose.c:289
-msgid ""
-"Makes all URLs in output data complete URLs and avoids the use of a shared "
-"URL prefix for all metadata."
-msgstr ""
+msgid "Makes all URLs in output data complete URLs and avoids the use of a shared URL prefix for all metadata."
+msgstr "Fa que tots els URL de les dades de sortida siguin completes i evita l'ús d'un prefix compartit per a totes les metadades."
 
 #. TRANSLATORS: ascompose flag description for: --icon-policy
 #: tools/appstream-compose.c:296
-msgid ""
-"An icon-policy string to set how icon sizes should be handled (refer to the "
-"man page for details)."
-msgstr ""
+msgid "An icon-policy string to set how icon sizes should be handled (refer to the man page for details)."
+msgstr "Una cadena de text per la política d'icones per a definir com s'han de gestionar les mides de les icones (per a més detalls, consulteu la pàgina del manual)."
 
 #. TRANSLATORS: ascompose flag description for: --allow-custom
 #: tools/appstream-compose.c:303
-#, fuzzy
-msgid ""
-"A comma-separated list of custom keys that should be propagated to the "
-"output data."
-msgstr "Una llista separada per comes de components d'ID a acceptar"
+msgid "A comma-separated list of custom keys that should be propagated to the output data."
+msgstr "Una llista de claus personalitzades separada per comes que haurien de ser propagades a les dades de sortida."
 
 #. TRANSLATORS: ascompose flag description for: --components
 #: tools/appstream-compose.c:310
-#, fuzzy
 msgid "A comma-separated list of component-IDs to accept."
-msgstr "Una llista separada per comes de components d'ID a acceptar"
+msgstr "Una llista separada per comes de components d'identificació."
 
 #. TRANSLATORS: Error message of appstream-compose
 #: tools/appstream-compose.c:327
@@ -3442,8 +2892,7 @@ msgid ""
 msgstr ""
 "El valor no és vàlid per a l'opció «—print-report»: %s\n"
 "Els valors possibles són:\n"
-"«on-error» - només imprimeix un informe curt si l'execució ha fallat (per "
-"defecte)\n"
+"«on-error» - només imprimeix un informe curt si l'execució ha fallat (per defecte)\n"
 "«short» - genera un informe abreujat\n"
 "«full» - s'imprimirà un informe detallat"
 
@@ -3454,18 +2903,15 @@ msgstr "Selecciona automàticament «%s» com a ubicació de sortida de dades."
 
 #: tools/appstream-compose.c:399
 msgid "No destination directory set, please provide a data output location!"
-msgstr ""
-"No hi ha cap directori de destinació definit, proporcioneu una ubicació de "
-"sortida de dades!"
+msgstr "No hi ha cap directori de destinació definit, proporcioneu una ubicació de sortida de dades!"
 
 #: tools/appstream-compose.c:412 tools/appstream-compose.c:414
 msgid "WARNING"
 msgstr "AVÍS"
 
 #: tools/appstream-compose.c:446
-#, fuzzy
 msgid "Unable to set icon policy"
-msgstr "No es pot llegir el fitxer."
+msgstr "No s'ha pogut establir la política d'icones"
 
 #. TRANSLATORS: Information about as-compose allowlist
 #: tools/appstream-compose.c:473
@@ -3514,12 +2960,8 @@ msgid "Errors were raised during this compose run:"
 msgstr "S'han produït errors durant aquesta operació de composició:"
 
 #: tools/appstream-compose.c:522
-msgid ""
-"Refer to the generated issue report data for details on the individual "
-"problems."
-msgstr ""
-"Consulteu les dades de l'informe de problemes generats per a obtenir més "
-"detalls sobre els problemes individuals."
+msgid "Refer to the generated issue report data for details on the individual problems."
+msgstr "Consulteu les dades de l'informe de problemes generats per a obtenir més detalls sobre els problemes individuals."
 
 #: tools/appstream-compose.c:526
 msgid "Overview of generated hints:"
@@ -3538,55 +2980,55 @@ msgstr "Ubicació seleccionada manualment de la memòria cau d'AppStream."
 #. TRANSLATORS: ascli flag description for: --datapath
 #: tools/appstreamcli.c:69
 msgid "Manually selected location of AppStream metadata to scan."
-msgstr ""
-"Ubicació seleccionada manualment de les metadades d'AppStream a explorar."
+msgstr "Ubicació seleccionada manualment de les metadades d'AppStream a explorar."
 
 #. TRANSLATORS: ascli flag description for: --no-cache
 #: tools/appstreamcli.c:75
 msgid "Ignore cache age and build a fresh cache before performing the query."
-msgstr ""
-"Ignora l’antiguitat de la memòria cau i construeix una memòria cau nova "
-"abans de realitzar la consulta."
+msgstr "Ignora l’antiguitat de la memòria cau i construeix una memòria cau nova abans de realitzar la consulta."
 
 #. TRANSLATORS: ascli flag description for: --format
 #: tools/appstreamcli.c:91
 msgid "Default metadata format (valid values are 'xml' and 'yaml')."
-msgstr ""
-"Format predeterminat de les metadades (els valors vàlids són «xml» «yaml»)."
+msgstr "Format predeterminat de les metadades (els valors vàlids són «xml» «yaml»)."
 
 #. TRANSLATORS: ascli flag description for: --details
 #: tools/appstreamcli.c:107
 msgid "Print detailed output about found components."
 msgstr "Imprimeix la sortida detallada quant als components trobats."
 
-#. TRANSLATORS: ascli flag description for: --pedantic (used by the "validate" command)
+#. TRANSLATORS: ascli flag description for: --pedantic (used by the "validate"
+#. command)
 #: tools/appstreamcli.c:128
 msgid "Also show pedantic hints."
 msgstr "Mostra també els consells redundants."
 
-#. TRANSLATORS: ascli flag description for: --explain (used by the "validate" command)
+#. TRANSLATORS: ascli flag description for: --explain (used by the "validate"
+#. command)
 #: tools/appstreamcli.c:135
 msgid "Print detailed explanation for found issues."
 msgstr "Imprimeix una explicació detallada dels problemes trobats."
 
-#. TRANSLATORS: ascli flag description for: --no-net (used by the "validate" command)
+#. TRANSLATORS: ascli flag description for: --no-net (used by the "validate"
+#. command)
 #: tools/appstreamcli.c:142
 msgid "Do not use network access."
 msgstr "No utilitzeu l'accés a la xarxa."
 
-#. TRANSLATORS: ascli flag description for: --strict (used by the "validate" command)
+#. TRANSLATORS: ascli flag description for: --strict (used by the "validate"
+#. command)
 #: tools/appstreamcli.c:149
-msgid ""
-"Fail validation if any issue is emitted that is not of pedantic severity."
-msgstr ""
-"Fallar la validació si s'emet algun problema que no sigui de gravetat pedant."
+msgid "Fail validation if any issue is emitted that is not of pedantic severity."
+msgstr "Fallar la validació si s'emet algun problema que no sigui de gravetat pedant."
 
-#. TRANSLATORS: ascli flag description for: --format  when validating XML files
+#. TRANSLATORS: ascli flag description for: --format  when validating XML
+#. files
 #: tools/appstreamcli.c:155
 msgid "Format of the generated report (valid values are 'text' and 'yaml')."
 msgstr "Format de l'informe generat (els valors vàlids són «text» i «yaml»)."
 
-#. TRANSLATORS: ascli flag description for: --override  when validating XML files
+#. TRANSLATORS: ascli flag description for: --override  when validating XML
+#. files
 #: tools/appstreamcli.c:161
 msgid "Override the severities of selected issue tags."
 msgstr "Substituir la gravetat de les etiquetes de problemes seleccionades."
@@ -3610,176 +3052,128 @@ msgstr "L’opció «%s» és desconeguda."
 #: tools/appstreamcli.c:223 tools/appstreamcli.c:1574
 #, c-format
 msgid "Run '%s --help' to see a full list of available command line options."
-msgstr ""
-"Executeu «%s --help» per a veure una llista completa de les opcions "
-"disponibles de la línia d'ordres."
+msgstr "Executeu «%s --help» per a veure una llista completa de les opcions disponibles de la línia d'ordres."
 
 #: tools/appstreamcli.c:227
 #, c-format
-msgid ""
-"Run '%s --help' to see a list of available commands and options, and '%s %s "
-"--help' to see a list of options specific for this subcommand."
-msgstr ""
-"Executeu «%s --help» per a veure una llista completa de les ordres i opcions "
-"disponibles, i «%s %s --help» per a veure les opcions específiques d’aquesta "
-"subordre."
+msgid "Run '%s --help' to see a list of available commands and options, and '%s %s --help' to see a list of options specific for this subcommand."
+msgstr "Executeu «%s --help» per a veure una llista completa de les ordres i opcions disponibles, i «%s %s --help» per a veure les opcions específiques d’aquesta subordre."
 
 #. TRANSLATORS: ascli flag description for: --force
 #: tools/appstreamcli.c:282
 msgid "Enforce a cache refresh."
 msgstr "Força una actualització de la memòria cau."
 
-#. TRANSLATORS: ascli flag description for: --source in a refresh action. Don't translate strings in backticks: `name`
+#. TRANSLATORS: ascli flag description for: --source in a refresh action.
+#. Don't translate strings in backticks: `name`
 #: tools/appstreamcli.c:288
-msgid ""
-"Limit cache refresh to data from a specific source, e.g. `os` or `flatpak`. "
-"May be specified multiple times."
-msgstr ""
-"Limiteu l'actualització de la memòria cau a dades d'una font específica, per "
-"exemple, «os» o «flatpak». Es pot especificar diverses vegades."
+msgid "Limit cache refresh to data from a specific source, e.g. `os` or `flatpak`. May be specified multiple times."
+msgstr "Limiteu l'actualització de la memòria cau a dades d'una font específica, per exemple, `os` o `flatpak`. Es pot especificar diverses vegades."
 
 #: tools/appstreamcli.c:547
-msgid ""
-"No license, license expression or license exception string was provided."
-msgstr ""
-"No s'ha proporcionat cap llicència ni cap expressió de llicència, ni cap "
-"cadena d’excepció de llicència."
+msgid "No license, license expression or license exception string was provided."
+msgstr "No s'ha proporcionat cap llicència ni cap expressió de llicència, ni cap cadena d’excepció de llicència."
 
-#. TRANSLATORS: ascli flag description for: --details (part of the "check-syscompat" subcommand)
+#. TRANSLATORS: ascli flag description for: --details (part of the "check-
+#. syscompat" subcommand)
 #: tools/appstreamcli.c:596
-#, fuzzy
 msgid "Print more detailed output on why incompatibilities exist."
-msgstr "Imprimeix la sortida detallada quant als components trobats."
+msgstr "Imprimeix la sortida detallada sobre el perquè de l'existència de les incompatibilitats."
 
-#. TRANSLATORS: ascli flag description for: --origin (part of the "put" subcommand)
+#. TRANSLATORS: ascli flag description for: --origin (part of the "put"
+#. subcommand)
 #: tools/appstreamcli.c:633
-#, fuzzy
 msgid "Set the data origin for the installed metadata catalog file."
-msgstr ""
-"Defineix l'origen de les dades per al fitxer de la col·lecció de metadades "
-"instal·lat."
+msgstr "Defineix l'origen de les dades per al fitxer de la col·lecció de metadades instal·lat."
 
-#. TRANSLATORS: ascli flag description for: --user (part of the "put" subcommand)
+#. TRANSLATORS: ascli flag description for: --user (part of the "put"
+#. subcommand)
 #: tools/appstreamcli.c:639
 msgid "Install the file for the current user, instead of globally."
 msgstr "Instal·la el fitxer per a l'usuari actual, en comptes de globalment."
 
-#. TRANSLATORS: ascli flag description for: --bundle-type (part of the "remove" and "install" subcommands)
+#. TRANSLATORS: ascli flag description for: --bundle-type (part of the
+#. "remove" and "install" subcommands)
 #: tools/appstreamcli.c:667
-msgid ""
-"Limit the command to use only components from the given bundling system "
-"(`flatpak` or `package`)."
-msgstr ""
-"Limita l'ordre per a utilitzar només components del sistema d'empaquetat "
-"donat (flatpak o package)."
+msgid "Limit the command to use only components from the given bundling system (`flatpak` or `package`)."
+msgstr "Limita l'ordre per a utilitzar només components del sistema d'empaquetat donat (flatpak o package)."
 
-#. TRANSLATORS: ascli flag description for: --first (part of the "remove" and "install" subcommands)
+#. TRANSLATORS: ascli flag description for: --first (part of the "remove" and
+#. "install" subcommands)
 #: tools/appstreamcli.c:674
-msgid ""
-"Do not ask for which software component should be used and always choose the "
-"first entry."
-msgstr ""
-"No pregunteu pel component de programari que cal utilitzar i triar sempre la "
-"primera entrada."
+msgid "Do not ask for which software component should be used and always choose the first entry."
+msgstr "No pregunteu pel component de programari que cal utilitzar i triar sempre la primera entrada."
 
-#. TRANSLATORS: ascli install currently only supports two values for --bundle-type.
+#. TRANSLATORS: ascli install currently only supports two values for --bundle-
+#. type.
 #: tools/appstreamcli.c:708 tools/appstreamcli.c:743
-msgid ""
-"No valid bundle kind was specified. Only `package` and `flatpak` are "
-"currently recognized."
-msgstr ""
-"No s'ha especificat cap mena de paquet vàlid. Actualment només es reconeixen "
-"els tipus `package` i `flatpak`."
+msgid "No valid bundle kind was specified. Only `package` and `flatpak` are currently recognized."
+msgstr "No s'ha especificat cap mena de paquet vàlid. Actualment només es reconeixen els tipus `package` i `flatpak`."
 
 #: tools/appstreamcli.c:837
-msgid ""
-"You need to provide at least two version numbers to compare as parameters."
-msgstr ""
-"Heu de proporcionar almenys dos números de versió per a comparar-los com a "
-"paràmetres."
+msgid "You need to provide at least two version numbers to compare as parameters."
+msgstr "Heu de proporcionar almenys dos números de versió per a comparar-los com a paràmetres."
 
-#. * TRANSLATORS: The user tried to compare version numbers, but the comparison operator (greater-then, equal, etc.) was invalid.
+#. * TRANSLATORS: The user tried to compare version numbers, but the
+#. comparison operator (greater-then, equal, etc.) was invalid.
 #: tools/appstreamcli.c:866
 #, c-format
 msgid "Unknown compare relation '%s'. Valid values are:"
 msgstr "Relació de comparació desconeguda «%s». Els valors vàlids són:"
 
 #: tools/appstreamcli.c:907
-msgid ""
-"Too many parameters: Need two version numbers or version numbers and a "
-"comparison operator."
-msgstr ""
-"Massa paràmetres: necessiteu dos números de versió o números de versió i un "
-"operador de comparació."
+msgid "Too many parameters: Need two version numbers or version numbers and a comparison operator."
+msgstr "Massa paràmetres: necessiteu dos números de versió o números de versió i un operador de comparació."
 
-#. TRANSLATORS: ascli flag description for: --from-desktop (part of the new-template subcommand)
+#. TRANSLATORS: ascli flag description for: --from-desktop (part of the new-
+#. template subcommand)
 #: tools/appstreamcli.c:933
-msgid ""
-"Use the given .desktop file to fill in the basic values of the metainfo file."
-msgstr ""
-"Utilitza el fitxer .desktop que s'indica com a base per a omplir els valors "
-"del fitxer metainfo."
+msgid "Use the given .desktop file to fill in the basic values of the metainfo file."
+msgstr "Utilitza el fitxer .desktop que s'indica com a base per a omplir els valors del fitxer metainfo."
 
 #: tools/appstreamcli.c:941
-msgid ""
-"This command takes optional TYPE and FILE positional arguments, FILE being a "
-"file to write to (or \"-\" for standard output)."
-msgstr ""
-"Aquesta ordre pren els arguments posicionals i opcionals TIPUS i FITXER, en "
-"aquest FITXER és on s'hi escriu (o «-» per a emetre sortida estàndard)."
+msgid "This command takes optional TYPE and FILE positional arguments, FILE being a file to write to (or \"-\" for standard output)."
+msgstr "Aquesta ordre pren els arguments posicionals i opcionals TIPUS i FITXER, en aquest FITXER és on s'hi escriu (o «-» per a emetre sortida estàndard)."
 
 #: tools/appstreamcli.c:945
 #, c-format
 msgid "The TYPE must be a valid component-type, such as: %s"
 msgstr "El TIPUS ha de ser un tipus de component vàlid, com ara: %s"
 
-#. TRANSLATORS: ascli flag description for: --exec (part of the make-desktop-file subcommand)
+#. TRANSLATORS: ascli flag description for: --exec (part of the make-desktop-
+#. file subcommand)
 #: tools/appstreamcli.c:983
 msgid "Use the specified line for the 'Exec=' key of the desktop-entry file."
-msgstr ""
-"Utilitzeu la línia especificada per a la tecla «Exec=» del fitxer d'entrada "
-"d'escriptori."
+msgstr "Utilitzeu la línia especificada per a la tecla «Exec=» del fitxer d'entrada d'escriptori."
 
-#. TRANSLATORS: ascli flag description for: --format as part of the news-to-metainfo command
+#. TRANSLATORS: ascli flag description for: --format as part of the news-to-
+#. metainfo command
 #: tools/appstreamcli.c:1023
-#, fuzzy
-msgid ""
-"Assume the input file is in the selected format ('yaml', 'text' or "
-"'markdown')."
-msgstr ""
-"Assumiu que el fitxer d'entrada està en el format seleccionat («yalm» o "
-"«text»)."
+msgid "Assume the input file is in the selected format ('yaml', 'text' or 'markdown')."
+msgstr "Assumiu que el fitxer d'entrada està en el format seleccionat («yaml», «text» o «markdown»)."
 
-#. TRANSLATORS: ascli flag description for: --limit as part of the news-to-metainfo command
+#. TRANSLATORS: ascli flag description for: --limit as part of the news-to-
+#. metainfo command
 #: tools/appstreamcli.c:1030
-msgid ""
-"Limit the number of release entries that end up in the metainfo file (<= 0 "
-"for unlimited)."
-msgstr ""
-"Limiteu el nombre d'entrades de versió que acaben al fitxer metainfo (<= 0 "
-"per a il·limitat)."
+msgid "Limit the number of release entries that end up in the metainfo file (<= 0 for unlimited)."
+msgstr "Limiteu el nombre d'entrades de versió que acaben al fitxer metainfo (<= 0 per a il·limitat)."
 
-#. TRANSLATORS: ascli flag description for: --translatable-count as part of the news-to-metainfo command
+#. TRANSLATORS: ascli flag description for: --translatable-count as part of
+#. the news-to-metainfo command
 #: tools/appstreamcli.c:1037
-msgid ""
-"Set the number of releases that should have descriptions marked for "
-"translation (latest releases are translated first, -1 for unlimited)."
-msgstr ""
-"Defineix el nombre de versions que haurien de tenir descripcions marcades "
-"per a la traducció (les últimes versions es tradueixen primer, -1 per a "
-"il·limitades)."
+msgid "Set the number of releases that should have descriptions marked for translation (latest releases are translated first, -1 for unlimited)."
+msgstr "Defineix el nombre de versions que haurien de tenir descripcions marcades per a la traducció (les últimes versions es tradueixen primer, -1 per a il·limitades)."
 
-#. TRANSLATORS: ascli flag description for: --format as part of the metainfo-to-news command
+#. TRANSLATORS: ascli flag description for: --format as part of the metainfo-
+#. to-news command
 #: tools/appstreamcli.c:1082
-#, fuzzy
-msgid ""
-"Generate the output in the selected format ('yaml', 'text' or 'markdown')."
-msgstr "Genera la sortida en el format seleccionat («yaml» o «text»)."
+msgid "Generate the output in the selected format ('yaml', 'text' or 'markdown')."
+msgstr "Genera la sortida en el format seleccionat («yaml», «text» o «markdown»)."
 
 #: tools/appstreamcli.c:1127
-#, fuzzy, c-format
+#, c-format
 msgid "AppStream Compose binary '%s' was not found! Can not continue."
-msgstr "No s'ha trobat el binari «%s». No es pot continuar."
+msgstr "No s'ha trobat el binari d'AppStream Compose «%s»!. No es pot continuar."
 
 #: tools/appstreamcli.c:1131
 #, c-format
@@ -3791,18 +3185,20 @@ msgstr "Podeu instal·lar el complement AppStream Compose mitjançant: `%s`"
 msgid "Invalid number of parameters"
 msgstr "El número de paràmetres no es vàlid"
 
-#. TRANSLATORS: "Compose" is a command of appstreamcli to build metadata catalogs.
+#. TRANSLATORS: "Compose" is a command of appstreamcli to build metadata
+#. catalogs.
 #: tools/appstreamcli.c:1158
-#, fuzzy, c-format
+#, c-format
 msgid "Compose operation failed to execute: %s"
-msgstr "Ha fallat la validació: %s"
+msgstr "L'operació «compose» ha fallat: %s"
 
 #: tools/appstreamcli.c:1168
-#, fuzzy, c-format
+#, c-format
 msgid "Compose failed: %s"
-msgstr "Ha fallat la validació: %s"
+msgstr "Ha fallat «compose»: %s"
 
-#. TRANSLATORS: this is a (usually shorter) command alias, shown after the command summary text
+#. TRANSLATORS: this is a (usually shorter) command alias, shown after the
+#. command summary text
 #: tools/appstreamcli.c:1225
 #, c-format
 msgid "(Alias: '%s')"
@@ -3814,20 +3210,13 @@ msgid "Subcommands:"
 msgstr "Subordres:"
 
 #: tools/appstreamcli.c:1309
-msgid ""
-"You can find information about subcommand-specific options by passing \"--"
-"help\" to the subcommand."
-msgstr ""
-"Podeu trobar informació sobre les opcions específiques de la subordre en "
-"passar «—help» a la subordre."
+msgid "You can find information about subcommand-specific options by passing \"--help\" to the subcommand."
+msgstr "Podeu trobar informació sobre les opcions específiques de la subordre en passar «—help» a la subordre."
 
 #: tools/appstreamcli.c:1333
 #, c-format
-msgid ""
-"Command '%s' is unknown. Run '%s --help' for a list of available commands."
-msgstr ""
-"L'ordre «%s» és desconeguda. Executeu «%s --help» per a obtenir una llista "
-"de les ordres disponibles."
+msgid "Command '%s' is unknown. Run '%s --help' for a list of available commands."
+msgstr "L'ordre «%s» és desconeguda. Executeu «%s --help» per a obtenir una llista de les ordres disponibles."
 
 #. TRANSLATORS: ascli flag description for: --profile
 #: tools/appstreamcli.c:1375
@@ -3846,24 +3235,18 @@ msgstr "Obté la informació sobre un component amb el seu id."
 
 #. TRANSLATORS: `appstreamcli what-provides` command description.
 #: tools/appstreamcli.c:1404
-msgid ""
-"Get components which provide the given item. Needs an item type (e.g. lib, "
-"bin, python3, …) and item value as parameter."
-msgstr ""
-"Obteniu components que proporcionin l'element donat. Necessita un tipus "
-"d'element (per exemple, lib, bin, python3, ...) i el valor de l'element com "
-"a paràmetre."
+msgid "Get components which provide the given item. Needs an item type (e.g. lib, bin, python3, …) and item value as parameter."
+msgstr "Obteniu components que proporcionin l'element donat. Necessita un tipus d'element (per exemple, lib, bin, python3, ...) i el valor de l'element com a paràmetre."
 
 #. TRANSLATORS: `appstreamcli list-categories` command description.
 #: tools/appstreamcli.c:1412
 msgid "List components that are part of the specified categories."
-msgstr ""
+msgstr "Llista els components que formen part de les categories especificades."
 
 #. TRANSLATORS: `appstreamcli dump` command description.
 #: tools/appstreamcli.c:1421
 msgid "Dump raw XML metadata for a component matching the ID."
-msgstr ""
-"Bolca les metadades XML en pla per a un component que coincideixi amb l'id."
+msgstr "Bolca les metadades XML en pla per a un component que coincideixi amb l'id."
 
 #. TRANSLATORS: `appstreamcli refresh-cache` command description.
 #: tools/appstreamcli.c:1429
@@ -3878,29 +3261,22 @@ msgstr "Valida els fitxers XML d'AppStream per a problemes."
 #. TRANSLATORS: `appstreamcli validate-tree` command description.
 #: tools/appstreamcli.c:1444
 msgid "Validate an installed file-tree of an application for valid metadata."
-msgstr ""
-"Valida un arbre de fitxers instal·lats d'una aplicació per a validar-ne les "
-"metadades."
+msgstr "Valida un arbre de fitxers instal·lats d'una aplicació per a validar-ne les metadades."
 
 #. TRANSLATORS: `appstreamcli `check-license` command description.
 #: tools/appstreamcli.c:1452
 msgid "Check license string for validity and print details about it."
-msgstr ""
-"Comproveu la validesa de la cadena de llicència i imprimiu-ne els detalls."
+msgstr "Comproveu la validesa de la cadena de llicència i imprimiu-ne els detalls."
 
 #. TRANSLATORS: `appstreamcli `check-license` command description.
 #: tools/appstreamcli.c:1460
-msgid ""
-"Check if requirements of a component (via its ID or MetaInfo file) are "
-"satisfied on this system."
-msgstr ""
+msgid "Check if requirements of a component (via its ID or MetaInfo file) are satisfied on this system."
+msgstr "Comproveu si els requisits d'un component (a través del seu identificador o fitxer MetaInfo) es compleixen en aquest sistema."
 
 #. TRANSLATORS: `appstreamcli `check-syscompat` command description.
 #: tools/appstreamcli.c:1468
-msgid ""
-"Check compatibility of a component (via its ID or MetaInfo file) with common "
-"system and chassis types."
-msgstr ""
+msgid "Check compatibility of a component (via its ID or MetaInfo file) with common system and chassis types."
+msgstr "Comprova la compatibilitat d'un component (a través del seu identificador o fitxer MetaInfo) amb els tipus de sistema i xassís habituals."
 
 #. TRANSLATORS: `appstreamcli install` command description.
 #: tools/appstreamcli.c:1477
@@ -3915,27 +3291,23 @@ msgstr "Suprimeix el programari que coincideixi amb «component-ID»."
 #. TRANSLATORS: `appstreamcli status` command description.
 #: tools/appstreamcli.c:1492
 msgid "Display status information about available AppStream metadata."
-msgstr ""
-"Mostra informació de l'estat sobre les metadades disponibles d'AppStream."
+msgstr "Mostra informació de l'estat sobre les metadades disponibles d'AppStream."
 
 #. TRANSLATORS: `appstreamcli sysinfo` command description.
 #: tools/appstreamcli.c:1500
-#, fuzzy
 msgid "Show information about the current device and used operating system."
-msgstr ""
-"Mostra informació sobre el sistema operatiu actual des de l'índex de "
-"metadades."
+msgstr "Mostra informació sobre el dispositiu actual i el sistema operatiu en ús."
 
 #. TRANSLATORS: `appstreamcli put` command description.
 #: tools/appstreamcli.c:1508
 msgid "Install a metadata file into the right location."
 msgstr "Instal·la un fitxer de metadades al lloc correcte."
 
-#. TRANSLATORS: `appstreamcli convert` command description. "Catalog XML" is a term describing a specific type of AppStream XML data.
+#. TRANSLATORS: `appstreamcli convert` command description. "Catalog XML" is a
+#. term describing a specific type of AppStream XML data.
 #: tools/appstreamcli.c:1516
-#, fuzzy
 msgid "Convert metadata catalog XML to YAML or vice versa."
-msgstr "Converteix la col·lecció XML a YAML o viceversa."
+msgstr "Converteix la col·lecció de metadades d'XML a YAML o viceversa."
 
 #. TRANSLATORS: `appstreamcli vercmp` command description.
 #: tools/appstreamcli.c:1523
@@ -3944,38 +3316,28 @@ msgstr "Compara dos números de versió."
 
 #. TRANSLATORS: `appstreamcli new-template` command description.
 #: tools/appstreamcli.c:1532
-msgid ""
-"Create a template for a metainfo file (to be filled out by the upstream "
-"project)."
-msgstr ""
-"Crea una plantilla per a un fitxer metainfo (per a ser omplert pel projecte "
-"de desenvolupament)."
+msgid "Create a template for a metainfo file (to be filled out by the upstream project)."
+msgstr "Crea una plantilla per a un fitxer metainfo (per a ser omplert pel projecte de desenvolupament)."
 
 #. TRANSLATORS: `appstreamcli make-desktop-file` command description.
 #: tools/appstreamcli.c:1540
 msgid "Create a desktop-entry file from a metainfo file."
-msgstr ""
-"Crea un fitxer d'entrada d'escriptori des d'un fitxer de metainformació."
+msgstr "Crea un fitxer d'entrada d'escriptori des d'un fitxer de metainformació."
 
 #. TRANSLATORS: `appstreamcli news-to-metainfo` command description.
 #: tools/appstreamcli.c:1548
 msgid "Convert a YAML or text NEWS file into metainfo releases."
-msgstr ""
-"Converteix un fitxer YALM o un fitxer de text NEWS en versions de "
-"metainformació."
+msgstr "Converteix un fitxer YALM o un fitxer de text NEWS en versions de metainformació."
 
 #. TRANSLATORS: `appstreamcli metainfo-to-news` command description.
 #: tools/appstreamcli.c:1556
 msgid "Write NEWS text or YAML file with information from a metainfo file."
-msgstr ""
-"Escriu un fitxer de text NEWS o YAML amb informació d'un fitxer de metainfo."
+msgstr "Escriu un fitxer de text NEWS o YAML amb informació d'un fitxer de metainfo."
 
 #. TRANSLATORS: `appstreamcli compose` command description.
 #: tools/appstreamcli.c:1564
-#, fuzzy
 msgid "Compose AppStream metadata catalog from directory trees."
-msgstr ""
-"Compon les metadades de la col·lecció d’AppStream dels arbres de directoris."
+msgstr "Composa les metadades de la col·lecció d’AppStream des dels arbres dels directoris."
 
 #. TRANSLATORS: ascli has been run without command.
 #: tools/appstreamcli.c:1572
@@ -3984,19 +3346,15 @@ msgstr "Heu d'especificar una ordre."
 
 #: tools/ascli-actions-mdata.c:49
 msgid "Only refreshing metadata cache specific to the current user."
-msgstr ""
-"Només s'actualitza la memòria cau de metadades específica de l'usuari actual."
+msgstr "Només s'actualitza la memòria cau de metadades específica de l'usuari actual."
 
 #: tools/ascli-actions-mdata.c:62
 msgid "Updating software metadata cache for the operating system."
-msgstr ""
-"S'està actualitzant la memòria cau de metadades de programari per al sistema "
-"operatiu."
+msgstr "S'està actualitzant la memòria cau de metadades de programari per al sistema operatiu."
 
 #: tools/ascli-actions-mdata.c:66
 msgid "Updating software metadata cache for Flatpak."
-msgstr ""
-"S'està actualitzant la memòria cau de metadades de programari per a Flatpak."
+msgstr "S'està actualitzant la memòria cau de metadades de programari per a Flatpak."
 
 #: tools/ascli-actions-mdata.c:68
 #, c-format
@@ -4005,30 +3363,28 @@ msgstr "No existeix el fitxer de metadades «%s»!"
 
 #: tools/ascli-actions-mdata.c:97
 msgid "You might need superuser permissions to perform this action."
-msgstr ""
-"És probable que es necessitin els permisos de superusuari per a realitzar "
-"aquesta acció."
+msgstr "És probable que es necessitin els permisos de superusuari per a realitzar aquesta acció."
 
 #. TRANSLATORS: Updating the metadata cache succeeded
 #: tools/ascli-actions-mdata.c:105
 msgid "Metadata cache was updated successfully."
 msgstr "La memòria cau de metadades s’ha actualitzat correctament."
 
-#. TRANSLATORS: Metadata cache was not updated, likely because it was recent enough
+#. TRANSLATORS: Metadata cache was not updated, likely because it was recent
+#. enough
 #: tools/ascli-actions-mdata.c:108
 msgid "Metadata cache update is not necessary."
 msgstr "L’actualització de la memòria cau de metadades no és necessària."
 
-#. TRANSLATORS: An AppStream component-id is missing in the command-line arguments
-#. TRANSLATORS: ascli was told to find a software component by its ID, but no component-id was specified.
-#: tools/ascli-actions-mdata.c:131 tools/ascli-actions-mdata.c:297
-#: tools/ascli-actions-pkgmgr.c:114
+#. TRANSLATORS: An AppStream component-id is missing in the command-line
+#. arguments
+#. TRANSLATORS: ascli was told to find a software component by its ID, but no
+#. component-id was specified.
+#: tools/ascli-actions-mdata.c:131 tools/ascli-actions-mdata.c:297 tools/ascli-actions-pkgmgr.c:114
 msgid "You need to specify a component-ID."
 msgstr "Heu d'especificar un ID-component."
 
-#: tools/ascli-actions-mdata.c:143 tools/ascli-actions-mdata.c:309
-#: tools/ascli-actions-mdata.c:734 tools/ascli-actions-mdata.c:866
-#: tools/ascli-actions-pkgmgr.c:127
+#: tools/ascli-actions-mdata.c:143 tools/ascli-actions-mdata.c:309 tools/ascli-actions-mdata.c:734 tools/ascli-actions-mdata.c:866 tools/ascli-actions-pkgmgr.c:127
 #, c-format
 msgid "Unable to find component with ID '%s'!"
 msgstr "No s'ha pogut trobar el component amb l'id. «%s»!"
@@ -4049,9 +3405,7 @@ msgstr "No s'ha definit cap valor per a l'element a cercar."
 
 #: tools/ascli-actions-mdata.c:213
 msgid "Invalid type for provided item selected. Valid values are:"
-msgstr ""
-"Tipus no vàlid per a l’element proporcionat que s'ha seleccionat. Els valors "
-"vàlids són:"
+msgstr "Tipus no vàlid per a l’element proporcionat que s'ha seleccionat. Els valors vàlids són:"
 
 #: tools/ascli-actions-mdata.c:229
 #, c-format
@@ -4059,15 +3413,14 @@ msgid "Could not find component providing '%s::%s'."
 msgstr "No s'ha pogut trobar el component que proporciona «%s::%s»."
 
 #: tools/ascli-actions-mdata.c:255
-#, fuzzy
 msgid "You need to specify categories to list."
-msgstr "Heu d'especificar un terme per a la cerca."
+msgstr "Heu d'especificar les categories a llistar."
 
 #. TRANSLATORS: We got no category list results
 #: tools/ascli-actions-mdata.c:269
 #, c-format
 msgid "No component found in categories %s."
-msgstr ""
+msgstr "No s'ha trobat cap component a les categories %s."
 
 #: tools/ascli-actions-mdata.c:352
 msgid "You need to specify a metadata file."
@@ -4088,30 +3441,19 @@ msgid "Metadata file '%s' does not exist."
 msgstr "No existeix el fitxer de metadades «%s»."
 
 #: tools/ascli-actions-mdata.c:432
-msgid ""
-"Unable to convert file: Could not determine output format, please set it "
-"explicitly using '--format='."
-msgstr ""
-"No es pot convertir el fitxer: No s'ha pogut determinar el format de "
-"sortida, establiu-ho de forma explícita amb «—format=»."
+msgid "Unable to convert file: Could not determine output format, please set it explicitly using '--format='."
+msgstr "No es pot convertir el fitxer: No s'ha pogut determinar el format de sortida, establiu-ho de forma explícita amb «—format=»."
 
 #: tools/ascli-actions-mdata.c:481
-msgid ""
-"You need to give an AppStream software component type to generate a "
-"template. Possible values are:"
-msgstr ""
-"Heu d'indicar un tipus de component de programari d'AppStream per a generar "
-"una plantilla. Els valors possibles són:"
+msgid "You need to give an AppStream software component type to generate a template. Possible values are:"
+msgstr "Heu d'indicar un tipus de component de programari d'AppStream per a generar una plantilla. Els valors possibles són:"
 
-#. TRANSLATORS: The user tried to create a new template, but supplied a wrong component-type string
+#. TRANSLATORS: The user tried to create a new template, but supplied a wrong
+#. component-type string
 #: tools/ascli-actions-mdata.c:484
 #, c-format
-msgid ""
-"The software component type '%s' is not valid in AppStream. Possible values "
-"are:"
-msgstr ""
-"El tipus de component de programari «%s» no és vàlid a AppStream. Els valors "
-"possibles són:"
+msgid "The software component type '%s' is not valid in AppStream. Possible values are:"
+msgstr "El tipus de component de programari «%s» no és vàlid a AppStream. Els valors possibles són:"
 
 #: tools/ascli-actions-mdata.c:504
 #, c-format
@@ -4134,100 +3476,99 @@ msgid "Unable to save the template metainfo file: %s"
 msgstr "No es pot desar el fitxer metainfo de plantilla: %s"
 
 #: tools/ascli-actions-mdata.c:650
-msgid ""
-"Unable to check display size: Can not read information without GUI toolkit "
-"access."
-msgstr ""
+msgid "Unable to check display size: Can not read information without GUI toolkit access."
+msgstr "No s'ha pogut comprovar la mida de la pantalla: no es pot llegir la informació sense accés a la interfície gràfica d'usuari."
 
 #: tools/ascli-actions-mdata.c:658 tools/ascli-actions-mdata.c:914
 msgid "ERROR"
-msgstr ""
+msgstr "ERROR"
 
 #: tools/ascli-actions-mdata.c:695 tools/ascli-actions-mdata.c:826
-#, fuzzy
 msgid "You need to specify a MetaInfo filename or component ID."
-msgstr "Heu d'especificar un fitxer de metainfo com a entrada."
+msgstr "Heu d'especificar un fitxer de MetaInfo o l'identificador d'un component com a entrada."
 
-#: tools/ascli-actions-mdata.c:714 tools/ascli-actions-mdata.c:838
-#: tools/ascli-actions-misc.c:133 tools/ascli-actions-misc.c:402
-#: tools/ascli-actions-misc.c:474
+#: tools/ascli-actions-mdata.c:714 tools/ascli-actions-mdata.c:838 tools/ascli-actions-misc.c:133 tools/ascli-actions-misc.c:402 tools/ascli-actions-misc.c:474
 #, c-format
 msgid "Metainfo file '%s' does not exist."
 msgstr "No existeix el fitxer de metainfo «%s»."
 
-#. TRANSLATORS: We are testing the relations (requires, recommends & supports data) for being satisfied on the current system.
+#. TRANSLATORS: We are testing the relations (requires, recommends & supports
+#. data) for being satisfied on the current system.
 #: tools/ascli-actions-mdata.c:743
 #, c-format
 msgid "Relation check for: %s"
-msgstr ""
+msgstr "Comprovació de la relació per a: %s"
 
 #: tools/ascli-actions-mdata.c:754
 msgid "Requirements:"
-msgstr ""
+msgstr "Requisits:"
 
 #: tools/ascli-actions-mdata.c:756
 msgid "No required items are set for this software."
-msgstr ""
+msgstr "No s'ha establert cap ítem necessari per a aquest programari."
 
 #: tools/ascli-actions-mdata.c:761
 msgid "Recommendations:"
-msgstr ""
+msgstr "Recomanacions:"
 
 #: tools/ascli-actions-mdata.c:763
 msgid "No recommended items are set for this software."
-msgstr ""
+msgstr "No s'ha establert cap ítem recomanat per a aquest programari."
 
 #: tools/ascli-actions-mdata.c:768
-#, fuzzy
 msgid "Supported:"
-msgstr "Esports"
+msgstr "Compatible amb:"
 
 #: tools/ascli-actions-mdata.c:770
 msgid "No supported items are set for this software."
-msgstr ""
+msgstr "No s'ha establert cap ítem compatible per a aquest programari."
 
 #. TRANSLATORS: This represents a computer chassis type.
 #: tools/ascli-actions-mdata.c:794
 msgid "Desktop"
-msgstr ""
+msgstr "Escriptori"
 
 #. TRANSLATORS: This represents a computer chassis type.
 #: tools/ascli-actions-mdata.c:797
 msgid "Laptop"
-msgstr ""
+msgstr "Portàtil"
 
 #. TRANSLATORS: This represents a computer chassis type.
 #: tools/ascli-actions-mdata.c:800
 msgid "Server"
-msgstr ""
+msgstr "Servidor"
 
 #. TRANSLATORS: This represents a computer chassis type.
 #: tools/ascli-actions-mdata.c:803
 msgid "Tablet"
-msgstr ""
+msgstr "Tauleta"
 
+# This is unclear. Note states "computer chassis" yet it's a "handset".
 #. TRANSLATORS: This represents a computer chassis type.
 #: tools/ascli-actions-mdata.c:806
+#, fuzzy
 msgid "Handset"
-msgstr ""
+msgstr "Handset"
 
 #: tools/ascli-actions-mdata.c:808
 msgid "Unknown"
-msgstr ""
+msgstr "Desconegut"
 
-#. TRANSLATORS: We are testing compatibility of a component with a common representation of hardware for a specific chassis (phone/tablet/desktop, etc.)
+#. TRANSLATORS: We are testing compatibility of a component with a common
+#. representation of hardware for a specific chassis (phone/tablet/desktop,
+#. etc.)
 #: tools/ascli-actions-mdata.c:875
 #, c-format
 msgid "Chassis compatibility check for: %s"
-msgstr ""
+msgstr "Comprovació de compatibilitat del xassís per a: %s"
 
 #: tools/ascli-actions-mdata.c:894
 msgid "Incompatible"
-msgstr ""
+msgstr "No compatible"
 
 #: tools/ascli-actions-mdata.c:929
 msgid "Compatible"
-msgstr ""
+msgstr "Compatible"
 
 #. TRANSLATORS: In the status report of ascli: Header
 #: tools/ascli-actions-misc.c:47
@@ -4239,7 +3580,8 @@ msgstr "Estat d'AppStream:"
 msgid "Version: %s"
 msgstr "Versió: %s"
 
-#. TRANSLATORS: In the status report of ascli: Refers to the metadata shipped by distributions
+#. TRANSLATORS: In the status report of ascli: Refers to the metadata shipped
+#. by distributions
 #: tools/ascli-actions-misc.c:55
 msgid "OS metadata sources:"
 msgstr "Fonts de metadades del sistema operatiu:"
@@ -4249,12 +3591,14 @@ msgstr "Fonts de metadades del sistema operatiu:"
 msgid "No OS metadata found. This is unusual."
 msgstr "No s'ha trobat cap metadada del SO. Això és inusual."
 
-#. TRANSLATORS: In the status report of ascli: Refers to the metadata that isn't shipped by the OS (e.g. Flatpak)
+#. TRANSLATORS: In the status report of ascli: Refers to the metadata that
+#. isn't shipped by the OS (e.g. Flatpak)
 #: tools/ascli-actions-misc.c:62
 msgid "Other metadata sources:"
 msgstr "Altres fonts de metadades:"
 
-#. TRANSLATORS: In ascli status, no additional metadata sources have been found
+#. TRANSLATORS: In ascli status, no additional metadata sources have been
+#. found
 #: tools/ascli-actions-misc.c:69
 msgid "No metadata."
 msgstr "Sense metadades."
@@ -4272,53 +3616,38 @@ msgstr "Tenim informació sobre %i components de programari."
 #: tools/ascli-actions-misc.c:91
 #, c-format
 msgid "Error while loading the metadata pool: %s"
-msgstr ""
-"S'ha produït un error mentre es carregava l'agrupació de les metadades: %s"
+msgstr "S'ha produït un error mentre es carregava l'agrupació de les metadades: %s"
 
 #: tools/ascli-actions-misc.c:118 tools/ascli-actions-misc.c:463
 msgid "You need to specify a metainfo file as input."
 msgstr "Heu d'especificar un fitxer de metainfo com a entrada."
 
 #: tools/ascli-actions-misc.c:123
-msgid ""
-"You need to specify a desktop-entry file to create or augment as output."
-msgstr ""
-"Heu d'especificar un fitxer d'entrada d'escriptori per a crear o augmentar "
-"com a sortida."
+msgid "You need to specify a desktop-entry file to create or augment as output."
+msgstr "Heu d'especificar un fitxer d'entrada d'escriptori per a crear o augmentar com a sortida."
 
 #: tools/ascli-actions-misc.c:152
 #, c-format
 msgid "Augmenting existing desktop-entry file '%s' with data from '%s'."
-msgstr ""
-"Augmentant el fitxer existent d'entrada a l'escriptori «%s» amb dades de "
-"«%s»."
+msgstr "Augmentant el fitxer existent d'entrada a l'escriptori «%s» amb dades de «%s»."
 
 #: tools/ascli-actions-misc.c:161
 #, c-format
 msgid "Unable to load existing desktop-entry file template: %s"
-msgstr ""
-"No es pot carregar la plantilla de fitxer d'entrada d'escriptori existent: %s"
+msgstr "No es pot carregar la plantilla de fitxer d'entrada d'escriptori existent: %s"
 
 #: tools/ascli-actions-misc.c:166
 #, c-format
 msgid "Creating new desktop-entry file '%s' using data from '%s'"
-msgstr ""
-"Creant un fitxer nou d'entrada d'escriptori «%s» utilitzant dades de «%s»"
+msgstr "Creant un fitxer nou d'entrada d'escriptori «%s» utilitzant dades de «%s»"
 
 #: tools/ascli-actions-misc.c:226
 msgid "No stock icon name was provided in the metainfo file. Can not continue."
-msgstr ""
-"No s'ha proporcionat cap nom d'icona d'estoc al fitxer metainfo. No es pot "
-"continuar."
+msgstr "No s'ha proporcionat cap nom d'icona d'estoc al fitxer metainfo. No es pot continuar."
 
 #: tools/ascli-actions-misc.c:250
-msgid ""
-"No provided binary specified in metainfo file, and no exec command specified "
-"via '--exec'. Can not create 'Exec=' key."
-msgstr ""
-"No s'ha especificat cap binari proporcionat en el fitxer metainfo, i no "
-"s'especifica cap ordre exec a través de «-exec». No es pot crear la clau "
-"«Exec=»."
+msgid "No provided binary specified in metainfo file, and no exec command specified via '--exec'. Can not create 'Exec=' key."
+msgstr "No s'ha especificat cap binari proporcionat en el fitxer metainfo, i no s'especifica cap ordre exec a través de «-exec». No es pot crear la clau «Exec=»."
 
 #: tools/ascli-actions-misc.c:330
 #, c-format
@@ -4330,23 +3659,16 @@ msgid "You need to specify a NEWS file as input."
 msgstr "Heu d'especificar un fitxer NEWS com a entrada."
 
 #: tools/ascli-actions-misc.c:362
-msgid ""
-"You need to specify a metainfo file to augment, or '-' to print to stdout."
-msgstr ""
-"Heu d'especificar un fitxer de metainfo per a augmentar, o «-» per a "
-"imprimir a la sortida estàndard."
+msgid "You need to specify a metainfo file to augment, or '-' to print to stdout."
+msgstr "Heu d'especificar un fitxer de metainfo per a augmentar, o «-» per a imprimir a la sortida estàndard."
 
 #: tools/ascli-actions-misc.c:368
 msgid "No output filename specified, modifying metainfo file directly."
-msgstr ""
-"No s'ha especificat el nom del fitxer de sortida, modificant directament el "
-"fitxer metainfo."
+msgstr "No s'ha especificat el nom del fitxer de sortida, modificant directament el fitxer metainfo."
 
 #: tools/ascli-actions-misc.c:468
 msgid "You need to specify a NEWS file as output, or '-' to print to stdout."
-msgstr ""
-"Heu d'especificar un fitxer NEWS com a sortida, o «-» per a imprimir a la "
-"sortida estàndard."
+msgstr "Heu d'especificar un fitxer NEWS com a sortida, o «-» per a imprimir a la sortida estàndard."
 
 #: tools/ascli-actions-misc.c:496
 msgid "You need to specify a NEWS format to write the output in."
@@ -4354,7 +3676,7 @@ msgstr "Heu d'especificar un format NEWS per a escriure a la sortida."
 
 #: tools/ascli-actions-misc.c:551
 msgid "Operating System Details"
-msgstr ""
+msgstr "Detalls del sistema operatiu"
 
 #: tools/ascli-actions-misc.c:555
 #, c-format
@@ -4362,12 +3684,10 @@ msgid "Unable to find operating system component '%s'!"
 msgstr "No s'ha pogut trobar el component del sistema operatiu «%s»!"
 
 #: tools/ascli-actions-misc.c:562
-#, fuzzy
 msgid "ID"
-msgstr "Entorns de desenvolupament integrat"
+msgstr "Identificador"
 
-#: tools/ascli-actions-misc.c:563 tools/ascli-actions-misc.c:590
-#: tools/ascli-utils.c:304
+#: tools/ascli-actions-misc.c:563 tools/ascli-actions-misc.c:590 tools/ascli-utils.c:304
 msgid "Name"
 msgstr "Nom"
 
@@ -4390,7 +3710,7 @@ msgstr "Descripció"
 
 #: tools/ascli-actions-misc.c:589
 msgid "Kernel"
-msgstr ""
+msgstr "Nucli"
 
 #: tools/ascli-actions-misc.c:591
 msgid "Version"
@@ -4398,42 +3718,35 @@ msgstr "Versió"
 
 #: tools/ascli-actions-misc.c:594
 msgid "Hardware"
-msgstr ""
+msgstr "Maquinari"
 
 #: tools/ascli-actions-misc.c:597
 msgid "Physical Memory"
-msgstr ""
+msgstr "Memòria física"
 
 #: tools/ascli-actions-misc.c:601
-#, fuzzy
 msgid "Devices with Modaliases"
-msgstr "Modàlies"
+msgstr "Dispositius amb modàlies"
 
 #: tools/ascli-actions-misc.c:630
 msgid "User Input Controls"
-msgstr ""
+msgstr "Controls d'entrada de l'usuari"
 
 #: tools/ascli-actions-misc.c:633
 msgid "unknown"
-msgstr ""
+msgstr "desconegut"
 
-#: tools/ascli-actions-misc.c:640 tools/ascli-actions-validate.c:700
-#: tools/ascli-actions-validate.c:706
+#: tools/ascli-actions-misc.c:640 tools/ascli-actions-validate.c:700 tools/ascli-actions-validate.c:706
 msgid "yes"
 msgstr "sí"
 
-#: tools/ascli-actions-misc.c:642 tools/ascli-actions-validate.c:701
-#: tools/ascli-actions-validate.c:707
+#: tools/ascli-actions-misc.c:642 tools/ascli-actions-validate.c:701 tools/ascli-actions-validate.c:707
 msgid "no"
 msgstr "no"
 
 #: tools/ascli-actions-pkgmgr.c:53
-msgid ""
-"No suitable package manager CLI found. Please make sure that e.g. \"pkcon\" "
-"(part of PackageKit) is available."
-msgstr ""
-"No s'ha trobat cap interfície de línia d'ordres adequada. Si us plau, "
-"assegureu-vos que p. ex. «pkcon» (part de PackageKit) estigui disponible."
+msgid "No suitable package manager CLI found. Please make sure that e.g. \"pkcon\" (part of PackageKit) is available."
+msgstr "No s'ha trobat cap interfície de línia d'ordres adequada. Si us plau, assegureu-vos que p. ex. «pkcon» (part de PackageKit) estigui disponible."
 
 #: tools/ascli-actions-pkgmgr.c:67
 #, c-format
@@ -4452,16 +3765,16 @@ msgstr "No se ha podido iniciar el proceso Flatpak: %s"
 #: tools/ascli-actions-pkgmgr.c:154
 #, c-format
 msgid "Unable to find component with ID '%s' and the selected filter criteria!"
-msgstr ""
-"No s'ha pogut trobar el component amb l'identificador '%s' i els criteris de "
-"filtre seleccionats!"
+msgstr "No s'ha pogut trobar el component amb l'identificador '%s' i els criteris de filtre seleccionats!"
 
-#. TRANSLATORS: We found multiple components to remove, a list of them is printed below this text.
+#. TRANSLATORS: We found multiple components to remove, a list of them is
+#. printed below this text.
 #: tools/ascli-actions-pkgmgr.c:165
 msgid "Multiple candidates were found for removal:"
 msgstr "S'han trobat diversos candidats per a l'eliminació:"
 
-#. TRANSLATORS: We found multiple components to install, a list of them is printed below this text.
+#. TRANSLATORS: We found multiple components to install, a list of them is
+#. printed below this text.
 #: tools/ascli-actions-pkgmgr.c:168
 msgid "Multiple candidates were found for installation:"
 msgstr "S'han trobat diversos candidats per a la instal·lació:"
@@ -4479,16 +3792,14 @@ msgstr "Si us plau, introduïu el número del component a instal·lar:"
 msgid "Component '%s' has no installation candidate."
 msgstr "El component «%s» no té cap candidat d'instal·lació."
 
-#. TRANSLATORS: User-supplied overrides string for appstreamcli was badly formatted
-#. (tag is an issue tag, severity is the desired severity that it should be set to).
+#. TRANSLATORS: User-supplied overrides string for appstreamcli was badly
+#. formatted
+#. (tag is an issue tag, severity is the desired severity that it should be
+#. set to).
 #: tools/ascli-actions-validate.c:259
 #, c-format
-msgid ""
-"The format of validator issue override '%s' is invalid (should be "
-"'tag=severity')"
-msgstr ""
-"El format de la substitució del problema del validador «%s» no és vàlid "
-"(hauria de ser «tag=severity»)"
+msgid "The format of validator issue override '%s' is invalid (should be 'tag=severity')"
+msgstr "El format de la substitució del problema del validador «%s» no és vàlid (hauria de ser «tag=severity»)"
 
 #: tools/ascli-actions-validate.c:268
 #, c-format
@@ -4500,25 +3811,29 @@ msgstr "No es pot substituir l'etiqueta del problema: %s"
 msgid "File '%s' does not exist."
 msgstr "No existeix el fitxer «%s»."
 
-#. TRANSLATORS: Used for small issue-statistics in appstreamcli-validate, shows amount of "error"-type hints
+#. TRANSLATORS: Used for small issue-statistics in appstreamcli-validate,
+#. shows amount of "error"-type hints
 #: tools/ascli-actions-validate.c:348
 #, c-format
 msgid "errors: %lu"
 msgstr "errors: %lu"
 
-#. TRANSLATORS: Used for small issue-statistics in appstreamcli-validate, shows amount of "warning"-type hints
+#. TRANSLATORS: Used for small issue-statistics in appstreamcli-validate,
+#. shows amount of "warning"-type hints
 #: tools/ascli-actions-validate.c:355
 #, c-format
 msgid "warnings: %lu"
 msgstr "advertències: %lu"
 
-#. TRANSLATORS: Used for small issue-statistics in appstreamcli-validate, shows amount of "info"-type hints
+#. TRANSLATORS: Used for small issue-statistics in appstreamcli-validate,
+#. shows amount of "info"-type hints
 #: tools/ascli-actions-validate.c:362
 #, c-format
 msgid "infos: %lu"
 msgstr "informació: %lu"
 
-#. TRANSLATORS: Used for small issue-statistics in appstreamcli-validate, shows amount of "pedantic"-type hints
+#. TRANSLATORS: Used for small issue-statistics in appstreamcli-validate,
+#. shows amount of "pedantic"-type hints
 #: tools/ascli-actions-validate.c:369
 #, c-format
 msgid "pedantic: %lu"
@@ -4529,16 +3844,17 @@ msgid "You need to specify at least one file to validate!"
 msgstr "Heu d’especificar almenys un fitxer per a validar!"
 
 #: tools/ascli-actions-validate.c:406
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to add release metadata file: %s"
-msgstr "No es pot instal·lar el fitxer de metadades: %s"
+msgstr "No es pot afegir el fitxer de metadades del llançament: %s"
 
 #: tools/ascli-actions-validate.c:416
 msgid ""
 "You need to specify at least one MetaInfo file to validate.\n"
-"Release metadata files can currently not be validated without their "
-"accompanying MetaInfo file."
+"Release metadata files can currently not be validated without their accompanying MetaInfo file."
 msgstr ""
+"Heu d'especificar almenys un fitxer MetaInfo per a validar.\n"
+"Els fitxers de metadades de llançaments no es poden validar sense el fitxer MetaInfo que els acompanya."
 
 #: tools/ascli-actions-validate.c:444 tools/ascli-actions-validate.c:577
 msgid "Validation was successful."
@@ -4556,38 +3872,39 @@ msgstr "Ha fallat la validació: %s"
 
 #: tools/ascli-actions-validate.c:526 tools/ascli-actions-validate.c:647
 #, c-format
-msgid ""
-"The validator can not create reports in the '%s' format. You may select "
-"'yaml' or 'text' instead."
-msgstr ""
-"El validador no pot crear informes en el format «%s». Podeu seleccionar "
-"«yaml» o «text»."
+msgid "The validator can not create reports in the '%s' format. You may select 'yaml' or 'text' instead."
+msgstr "El validador no pot crear informes en el format «%s». Podeu seleccionar «yaml» o «text»."
 
 #: tools/ascli-actions-validate.c:551 tools/ascli-actions-validate.c:633
 msgid "You need to specify a root directory to start validation!"
 msgstr "Heu d'especificar un directori arrel per a iniciar la validació!"
 
-#. TRANSLATORS: A plain license ID (used as value in a key-value pair, like "Type: license")
+#. TRANSLATORS: A plain license ID (used as value in a key-value pair, like
+#. "Type: license")
 #: tools/ascli-actions-validate.c:675
 msgid "license"
 msgstr "llicència"
 
-#. TRANSLATORS: A license exception (used as value in a key-value pair, like "Type: exception")
+#. TRANSLATORS: A license exception (used as value in a key-value pair, like
+#. "Type: exception")
 #: tools/ascli-actions-validate.c:678
 msgid "license exception"
 msgstr "excepció de llicència"
 
-#. TRANSLATORS: A complex license expression (used as value in a key-value pair, like "Type: exception")
+#. TRANSLATORS: A complex license expression (used as value in a key-value
+#. pair, like "Type: exception")
 #: tools/ascli-actions-validate.c:681
 msgid "license expression"
 msgstr "expressió de llicència"
 
-#. TRANSLATORS: An invalid license (used as value in a key-value pair, like "Type: invalid")
+#. TRANSLATORS: An invalid license (used as value in a key-value pair, like
+#. "Type: invalid")
 #: tools/ascli-actions-validate.c:685
 msgid "invalid"
 msgstr "no és vàlid"
 
-#. TRANSLATORS: The license string type (single license, expression, exception, invalid)
+#. TRANSLATORS: The license string type (single license, expression,
+#. exception, invalid)
 #: tools/ascli-actions-validate.c:690
 msgid "License Type"
 msgstr "Tipus de llicència"
@@ -4602,7 +3919,8 @@ msgstr "ID canònic"
 msgid "Suitable for AppStream metadata"
 msgstr "Adequat per a metadades d'AppStream"
 
-#. TRANSLATORS: Whether a license considered suitable for Free and Open Source software
+#. TRANSLATORS: Whether a license considered suitable for Free and Open Source
+#. software
 #: tools/ascli-actions-validate.c:704
 msgid "Free and Open Source"
 msgstr "Codi lliure i obert"
@@ -4657,7 +3975,8 @@ msgstr "Categories"
 msgid "Compulsory for"
 msgstr "Obligatori per a"
 
-#. TRANSLATORS: Other software or interfaces that this software component provides
+#. TRANSLATORS: Other software or interfaces that this software component
+#. provides
 #: tools/ascli-utils.c:426
 msgid "Provided Items"
 msgstr "Elements proporcionats"
@@ -5153,37 +4472,20 @@ msgstr "Si us plau, introduïu un número de l'1 al %i: "
 #~ msgid "Unable to find components in %s!"
 #~ msgstr "No es pot trobar la coincidència del component %s!"
 
-#~ msgid ""
-#~ "Many components have been recognized as invalid. See debug output for "
-#~ "details."
-#~ msgstr ""
-#~ "S'han reconegut molts components com no vàlids. Consulteu la sortida de "
-#~ "depuració per obtenir més detalls."
+#~ msgid "Many components have been recognized as invalid. See debug output for details."
+#~ msgstr "S'han reconegut molts components com no vàlids. Consulteu la sortida de depuració per obtenir més detalls."
 
 #, fuzzy
-#~ msgid ""
-#~ "The AppStream system cache was updated, but some components were ignored. "
-#~ "Refer to the verbose log for more information."
-#~ msgstr ""
-#~ "S'ha actualitzat la memòria cau del sistema d'AppStream, però s'han "
-#~ "detectat alguns errors, aquests errors poden provocar la pèrdua de "
-#~ "metadades. Consulteu el registre per obtenir informació més detallada."
+#~ msgid "The AppStream system cache was updated, but some components were ignored. Refer to the verbose log for more information."
+#~ msgstr "S'ha actualitzat la memòria cau del sistema d'AppStream, però s'han detectat alguns errors, aquests errors poden provocar la pèrdua de metadades. Consulteu el registre per obtenir informació més detallada."
 
 #, fuzzy, c-format
-#~ msgid ""
-#~ "The AppStream system cache was updated, but problems were found which "
-#~ "resulted in metadata being ignored: %s"
-#~ msgstr ""
-#~ "S'ha actualitzat la memòria cau de sistema d'AppStream, però s'han trobat "
-#~ "problemes: %s"
+#~ msgid "The AppStream system cache was updated, but problems were found which resulted in metadata being ignored: %s"
+#~ msgstr "S'ha actualitzat la memòria cau de sistema d'AppStream, però s'han trobat problemes: %s"
 
 #, fuzzy, c-format
-#~ msgid ""
-#~ "AppStream system cache refresh failed. Turn on verbose mode to get "
-#~ "detailed issue information."
-#~ msgstr ""
-#~ "Ha fallat l'actualització de la memòria cau d'AppStream. Activeu el mode "
-#~ "detallat per obtenir informació detallada de la incidència."
+#~ msgid "AppStream system cache refresh failed. Turn on verbose mode to get detailed issue information."
+#~ msgstr "Ha fallat l'actualització de la memòria cau d'AppStream. Activeu el mode detallat per obtenir informació detallada de la incidència."
 
 #~ msgid "Make request without any caching."
 #~ msgstr "Fes la sol·licitud sense cap emmagatzematge en memòria cau."
@@ -5209,24 +4511,16 @@ msgstr "Si us plau, introduïu un número de l'1 al %i: "
 #~ msgstr "No es pot llegir el fitxer .desktop: %s"
 
 #, fuzzy
-#~ msgid ""
-#~ "AppStream is a cross-distribution specification to provide metadata about "
-#~ "software components."
-#~ msgstr ""
-#~ "AppStream és una especificació independent de la distribució que "
-#~ "proporciona metadades quant als components de programari."
+#~ msgid "AppStream is a cross-distribution specification to provide metadata about software components."
+#~ msgstr "AppStream és una especificació independent de la distribució que proporciona metadades quant als components de programari."
 
 #, c-format
 #~ msgid "Unable to write to '%s', can not install metainfo file."
 #~ msgstr "No es pot escriure a «%s», no es pot instal·lar el fitxer metainfo."
 
 #, c-format
-#~ msgid ""
-#~ "Can not copy '%s': File does not have a '.metainfo.xml' or '.appdata.xml' "
-#~ "suffix."
-#~ msgstr ""
-#~ "No es pot copiar «%s»: El fitxer no té un sufix «.metainfo.xml» o «."
-#~ "appdata.xml»."
+#~ msgid "Can not copy '%s': File does not have a '.metainfo.xml' or '.appdata.xml' suffix."
+#~ msgstr "No es pot copiar «%s»: El fitxer no té un sufix «.metainfo.xml» o «.appdata.xml»."
 
 #~ msgid "An item type (e.g. lib, bin, python3, …)"
 #~ msgstr "Un tipus d'element (p. ex. lib, bin, python3, ...)"


### PR DESCRIPTION
Translated from https://l10n.gnome.org/vertimus/appstream/main/po/ca/. I see some original strings are different from the last version of the ca.po file. Let me know if there is something else needed to be done.