### PR TITLE
validator: Make sure we read an initialised variable

### DIFF
--- a/src/as-validator.c
+++ b/src/as-validator.c
@@ -3529,6 +3529,7 @@ as_validator_validate_component_node (AsValidator *validator, AsContext *ctx, xm
 	/* check if we have a homepage */
 	if (as_component_get_url (cpt, AS_URL_KIND_HOMEPAGE) == NULL) {
 		AsComponentKind ckind;
+		ckind = as_component_get_kind (cpt);
 
 		/* we require a homepage for anything but generic components and language packs */
 		if (ckind != AS_COMPONENT_KIND_GENERIC && ckind != AS_COMPONENT_KIND_LOCALIZATION)


### PR DESCRIPTION
We were not reading the kind so it was left undeclared.

src/as-validator.c:3534:7: warning: variable 'ckind' is uninitialized when used here [-Wuninitialized]