### PR TITLE
desktop-style-ids: add pantheon:dark

### DIFF
--- a/data/desktop-style-ids.txt
+++ b/data/desktop-style-ids.txt
@@ -12,6 +12,7 @@ lxqt          LXQt
 macos         macOS
 mate          Mate
 pantheon      Pantheon
+pantheon:dark Pantheon (Dark)
 plasma        KDE Plasma
 plasma-mobile Plasma Mobile
 razor         Razor


### PR DESCRIPTION
Add Pantheon (Dark) to supported list of environment ids