### PR TITLE
sysinfo: make uname() usage POSIX compliant

### DIFF
--- a/src/as-system-info.c
+++ b/src/as-system-info.c
@@ -396,7 +396,7 @@ as_system_info_read_kernel_details (AsSystemInfo *sysinfo)
 	if (priv->kernel_name != NULL)
 		return;
 
-	if (uname (&utsbuf) != 0) {
+	if (uname (&utsbuf) < 0) {
 		g_warning ("Unable to read kernel information via uname: %s", g_strerror (errno));
 		return;
 	}


### PR DESCRIPTION
The [POSIX specifies](https://pubs.opengroup.org/onlinepubs/9799919799/functions/uname.html) that `uname()` returns non-negative value on success.

This PR makes the `uname()` failure checking more POSIX compliant to make it working properly on platforms like illumos or Solaris.