### PR TITLE
Add COSMIC to xdg-category-names.txt

### DIFF
--- a/data/xdg-category-names.txt
+++ b/data/xdg-category-names.txt
@@ -32,6 +32,7 @@ ConsoleOnly
 Construction
 ContactManagement
 Core
+COSMIC
 DDE
 DataVisualization
 Database


### PR DESCRIPTION
COSMIC is a desktop environment and a valid category name as part of the specification: https://specifications.freedesktop.org/menu-spec/latest/additional-category-registry.html