### PR TITLE
bundle: Add AS_BUNDLE_KIND_SYSUPDATE

### DIFF
--- a/docs/xml/catalog-xmldata.xml
+++ b/docs/xml/catalog-xmldata.xml
@@ -598,6 +598,7 @@
 							<listitem><para><code>tarball</code> - For plain and possibly compressed tarballs.</para></listitem>
 							<listitem><para><code>cabinet</code> - For cabinet firmware deployments.</para></listitem>
 							<listitem><para><code>linglong</code> - For <ulink url="https://linglong.dev/">Linglong</ulink> bundles.</para></listitem>
+							<listitem><para><code>sysupdate</code> - For <ulink url="https://www.freedesktop.org/software/systemd/man/latest/systemd-sysupdate.html">systemd-sysupdate</ulink> bundles.</para></listitem>
 						</itemizedlist>
 					</para>
 					<para>

--- a/src/as-bundle.c
+++ b/src/as-bundle.c
@@ -70,6 +70,8 @@ as_bundle_kind_to_string (AsBundleKind kind)
 		return "cabinet";
 	if (kind == AS_BUNDLE_KIND_LINGLONG)
 		return "linglong";
+	if (kind == AS_BUNDLE_KIND_SYSUPDATE)
+		return "sysupdate";
 	return "unknown";
 }
 
@@ -100,6 +102,8 @@ as_bundle_kind_from_string (const gchar *bundle_str)
 		return AS_BUNDLE_KIND_CABINET;
 	if (g_strcmp0 (bundle_str, "linglong") == 0)
 		return AS_BUNDLE_KIND_LINGLONG;
+	if (g_strcmp0 (bundle_str, "sysupdate") == 0)
+		return AS_BUNDLE_KIND_SYSUPDATE;
 	return AS_BUNDLE_KIND_UNKNOWN;
 }
 

--- a/src/as-bundle.h
+++ b/src/as-bundle.h
@@ -54,6 +54,7 @@ struct _AsBundleClass {
  * @AS_BUNDLE_KIND_TARBALL:	A (maybe compressed) tarball.
  * @AS_BUNDLE_KIND_CABINET:	Cabinet firmware deployment
  * @AS_BUNDLE_KIND_LINGLONG:	A Linglong bundle
+ * @AS_BUNDLE_KIND_SYSUPDATE:	A systemd-sysupdate bundle
  *
  * The bundle type.
  **/
@@ -67,6 +68,7 @@ typedef enum {
 	AS_BUNDLE_KIND_TARBALL,
 	AS_BUNDLE_KIND_CABINET,
 	AS_BUNDLE_KIND_LINGLONG,
+	AS_BUNDLE_KIND_SYSUPDATE,
 	/*< private >*/
 	AS_BUNDLE_KIND_LAST
 } AsBundleKind;


### PR DESCRIPTION
This is needed for GNOME Software to have a correct bundle type for systemd-sysupdate.