### PR TITLE
desktop-style-ids: Remove Endless

### DIFF
--- a/data/desktop-style-ids.txt
+++ b/data/desktop-style-ids.txt
@@ -4,7 +4,6 @@
 cinnamon      Cinnamon
 dde           Deepin
 ede           EDE
-endless       Endless
 gnome         GNOME
 gnome:dark    GNOME (Dark)
 lxde          LXDE


### PR DESCRIPTION
Endless OS doesn't make sense as a distinct environment here:

- Our app platform is GNOME/GTK/Adwaita
- Our DE is GNOME Shell (with extensions)
- There's no practical difference between screenshots for Endless OS and screenshots for GNOME

There _are_ some minor default settings differences (Endless OS enables the always-visible-scrollbar accessibility setting and includes minimize/maximize buttons by default), but after discussing with @wjt, we're more comfortable just using the `gnome` IDs here rather than complicating things for a minuscule difference.

We do set the `XDG_CURRENT_DESKTOP` to `Endless:GNOME` on Endless OS, but if I'm understanding things correctly, we should still be able to have GNOME Software just show the GNOME screenshots first. :)