### PR TITLE
Fix some tests on Windows

### DIFF
--- a/tests/test-basics.c
+++ b/tests/test-basics.c
@@ -916,8 +916,10 @@ test_system_info (void)
 	g_assert_cmpstr (as_system_info_get_os_id (sysinfo), ==, "debian");
 	g_assert_cmpstr (as_system_info_get_os_cid (sysinfo), ==, "org.debian.debian");
 
+#ifndef G_OS_WIN32
 	g_assert_nonnull (as_system_info_get_kernel_name (sysinfo));
 	g_assert_nonnull (as_system_info_get_kernel_version (sysinfo));
+#endif
 
 	g_assert_cmpint (as_system_info_get_memory_total (sysinfo), >=, 128);
 

--- a/tests/test-misc.c
+++ b/tests/test-misc.c
@@ -346,6 +346,7 @@ test_relation_satisfy_check (void)
 			 AS_RELATION_STATUS_NOT_SATISFIED);
 	g_clear_pointer (&rcr, g_object_unref);
 
+#ifndef G_OS_WIN32
 	/* test kernel */
 	as_relation_set_kind (relation, AS_RELATION_KIND_REQUIRES);
 	as_relation_set_item_kind (relation, AS_RELATION_ITEM_KIND_KERNEL);
@@ -376,6 +377,7 @@ test_relation_satisfy_check (void)
 			 ==,
 			 AS_RELATION_STATUS_NOT_SATISFIED);
 	g_clear_pointer (&rcr, g_object_unref);
+#endif
 
 	/* test display length */
 	as_relation_set_kind (relation, AS_RELATION_KIND_RECOMMENDS);


### PR DESCRIPTION
As of https://github.com/ximion/appstream/pull/510, fetching the Kernel version is not supported on Windows.