### PR TITLE
Revert "ci: Update to Ubuntu 24.04 for Debian Testing builds"

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,7 @@ jobs:
 
   build-debian-testing:
     name: Debian Testing
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
This reverts pull request #655, which explicitly updated the Ubuntu runner version for the Debian Testing builds in GitHub Actions to use 24.04 due to a syscall `seccomp.json` policy incompatibility.

~~:warning: Strictly speaking `ubuntu-latest` remains [scheduled](https://github.com/actions/runner-images/issues/10636) to become `ubuntu-24.04` on 2025-01-17, despite that issue tracker task being closed, so to be cautious it may make sense to wait until that date before merging this.~~

Edit: strikethrough the warning note in the description because we are comfortably past the migration date.