### PR TITLE
utils: Remove leftover g_chmod()

### DIFF
--- a/src/as-utils.c
+++ b/src/as-utils.c
@@ -2496,7 +2496,6 @@ as_utils_install_metadata_file_internal (const gchar *filename,
 			return FALSE;
 	}
 
-	g_chmod (path_dest, 0755);
 	return TRUE;
 }
 


### PR DESCRIPTION
The file has set the attributes after commit c6903ab9db7dc702fdff1e4964fab49a3d0de91c, thus this is not needed.

If it was meant to set the executable flag on the parent directory, then it is not needed either, at least according to my tests. The `path_dest` points to the installed file here, not to the parent directory.

Closes https://github.com/ximion/appstream/issues/681