### PR TITLE
Various fixes related to Appstream data installation and ZSTD support

### DIFF
--- a/src/as-metadata.c
+++ b/src/as-metadata.c
@@ -88,9 +88,13 @@ as_metadata_file_guess_style (const gchar *filename)
 		return AS_FORMAT_STYLE_CATALOG;
 	if (g_str_has_suffix (filename, ".yml.gz"))
 		return AS_FORMAT_STYLE_CATALOG;
+	if (g_str_has_suffix (filename, ".yml.zst"))
+		return AS_FORMAT_STYLE_CATALOG;
 	if (g_str_has_suffix (filename, ".yaml"))
 		return AS_FORMAT_STYLE_CATALOG;
 	if (g_str_has_suffix (filename, ".yaml.gz"))
+		return AS_FORMAT_STYLE_CATALOG;
+	if (g_str_has_suffix (filename, ".yaml.zst"))
 		return AS_FORMAT_STYLE_CATALOG;
 	if (g_str_has_suffix (filename, ".appdata.xml"))
 		return AS_FORMAT_STYLE_METAINFO;
@@ -105,6 +109,8 @@ as_metadata_file_guess_style (const gchar *filename)
 	if (g_str_has_suffix (filename, ".xml"))
 		return AS_FORMAT_STYLE_CATALOG;
 	if (g_str_has_suffix (filename, ".xml.gz"))
+		return AS_FORMAT_STYLE_CATALOG;
+	if (g_str_has_suffix (filename, ".xml.zst"))
 		return AS_FORMAT_STYLE_CATALOG;
 	return AS_FORMAT_STYLE_UNKNOWN;
 }

--- a/src/as-metadata.c
+++ b/src/as-metadata.c
@@ -84,11 +84,13 @@ G_DEFINE_TYPE_WITH_PRIVATE (AsMetadata, as_metadata, G_TYPE_OBJECT)
 AsFormatStyle
 as_metadata_file_guess_style (const gchar *filename)
 {
-	if (g_str_has_suffix (filename, ".xml.gz"))
-		return AS_FORMAT_STYLE_CATALOG;
 	if (g_str_has_suffix (filename, ".yml"))
 		return AS_FORMAT_STYLE_CATALOG;
 	if (g_str_has_suffix (filename, ".yml.gz"))
+		return AS_FORMAT_STYLE_CATALOG;
+	if (g_str_has_suffix (filename, ".yaml"))
+		return AS_FORMAT_STYLE_CATALOG;
+	if (g_str_has_suffix (filename, ".yaml.gz"))
 		return AS_FORMAT_STYLE_CATALOG;
 	if (g_str_has_suffix (filename, ".appdata.xml"))
 		return AS_FORMAT_STYLE_METAINFO;
@@ -101,6 +103,8 @@ as_metadata_file_guess_style (const gchar *filename)
 	if (g_str_has_suffix (filename, ".metainfo.xml.in.in"))
 		return AS_FORMAT_STYLE_METAINFO;
 	if (g_str_has_suffix (filename, ".xml"))
+		return AS_FORMAT_STYLE_CATALOG;
+	if (g_str_has_suffix (filename, ".xml.gz"))
 		return AS_FORMAT_STYLE_CATALOG;
 	return AS_FORMAT_STYLE_UNKNOWN;
 }

--- a/src/as-utils.c
+++ b/src/as-utils.c
@@ -2656,7 +2656,7 @@ as_utils_install_metadata_file (AsMetadataLocation location,
 			}
 
 			/* guess origin */
-			tmp2 = g_strdup_printf ("_icons-%s.tar.gz", icons_size_id);
+			tmp2 = g_strdup_printf ("-icons-%s.tar.gz", icons_size_id);
 			tmp = g_strstr_len (basename, -1, tmp2);
 			if (tmp != NULL) {
 				*tmp = '\0';

--- a/src/as-utils.c
+++ b/src/as-utils.c
@@ -2580,8 +2580,10 @@ as_utils_install_metadata_file (AsMetadataLocation location,
 	case AS_FORMAT_STYLE_CATALOG:
 		if (g_str_has_suffix (filename, ".yml") ||
 		    g_str_has_suffix (filename, ".yml.gz") ||
+		    g_str_has_suffix (filename, ".yml.zst") ||
 		    g_str_has_suffix (filename, ".yaml") ||
-		    g_str_has_suffix (filename, ".yaml.gz")) {
+		    g_str_has_suffix (filename, ".yaml.gz") ||
+		    g_str_has_suffix (filename, ".yaml.zst")) {
 			path = g_build_filename (as_metadata_location_get_prefix (location),
 						 "swcatalog",
 						 "yaml",
@@ -2628,7 +2630,8 @@ as_utils_install_metadata_file (AsMetadataLocation location,
 	default:
 		basename = g_path_get_basename (filename);
 
-		if (g_str_has_suffix (basename, ".tar.gz")) {
+		if (g_str_has_suffix (basename, ".tar.gz") ||
+		    g_str_has_suffix (basename, ".tar.zst")) {
 			gchar *tmp;
 			g_autofree gchar *tmp2 = NULL;
 			/* we may have an icon tarball */
@@ -2659,7 +2662,10 @@ as_utils_install_metadata_file (AsMetadataLocation location,
 			}
 
 			/* guess origin */
-			tmp2 = g_strdup_printf ("-icons-%s.tar.gz", icons_size_id);
+			if (g_str_has_suffix (basename, ".tar.gz"))
+				tmp2 = g_strdup_printf ("-icons-%s.tar.gz", icons_size_id);
+			else
+				tmp2 = g_strdup_printf ("-icons-%s.tar.zst", icons_size_id);
 			tmp = g_strstr_len (basename, -1, tmp2);
 			if (tmp != NULL) {
 				*tmp = '\0';

--- a/src/as-utils.c
+++ b/src/as-utils.c
@@ -2578,7 +2578,10 @@ as_utils_install_metadata_file (AsMetadataLocation location,
 
 	switch (as_metadata_file_guess_style (filename)) {
 	case AS_FORMAT_STYLE_CATALOG:
-		if (g_strstr_len (filename, -1, ".yml.gz") != NULL) {
+		if (g_str_has_suffix (filename, ".yml") ||
+		    g_str_has_suffix (filename, ".yml.gz") ||
+		    g_str_has_suffix (filename, ".yaml") ||
+		    g_str_has_suffix (filename, ".yaml.gz")) {
 			path = g_build_filename (as_metadata_location_get_prefix (location),
 						 "swcatalog",
 						 "yaml",

--- a/src/as-zstd-decompressor.c
+++ b/src/as-zstd-decompressor.c
@@ -116,8 +116,11 @@ as_zstd_decompressor_convert (GConverter *converter,
 	size_t res;
 
 	res = ZSTD_decompressStream (self->zstdstream, &output, &input);
-	if (res == 0)
+	if (res == 0) {
+		*bytes_read = input.pos;
+		*bytes_written = output.pos;
 		return G_CONVERTER_FINISHED;
+	}
 	if (ZSTD_isError (res)) {
 		g_set_error (error,
 			     G_IO_ERROR,


### PR DESCRIPTION
There is already the ZSTD compression support built in, but it was not extended into the appstream data installation, which is the place the code will reach it first, because the ZSTD can be used in the repositories.

See the respective commits for the various fixes done along the way.