### PR TITLE
validator: mark as_validator_issue_tag_list static

### DIFF
--- a/src/as-validator-issue-tag.h
+++ b/src/as-validator-issue-tag.h
@@ -36,7 +36,7 @@ typedef struct {
 } AsValidatorIssueTag;
 
 /* clang-format off */
-AsValidatorIssueTag as_validator_issue_tag_list[] =  {
+static AsValidatorIssueTag as_validator_issue_tag_list[] =  {
 	{ "type-property-required",
 	  AS_ISSUE_SEVERITY_ERROR,
 	  N_("This tag requires a type property.")


### PR DESCRIPTION
Otherwise, statically-linked builds fail, because this symbol is duplicated into the object file for every .c file that includes it, and they clash:

	/nix/store/jdn0xxjrqqppv2j5dmsspiykbal4ypam-x86_64-unknown-linux-musl-binutils-2.43.1/bin/x86_64-unknown-linux-musl-ld: src/libappstream.a(as-validator.c.o):(.data.rel.local+0x0): multiple definition of `as_validator_issue_tag_list'; compose/libappstream-compose.a(asc-globals.c.o):(.data.rel.local+0x0): first defined here