### PR TITLE
qt: Expose markup conversion utils

### DIFF
--- a/qt/utils.cpp
+++ b/qt/utils.cpp
@@ -22,6 +22,8 @@
 #include "appstream.h"
 #include "chelpers.h"
 
+#include <QDebug>
+
 QString AppStream::Utils::currentAppStreamVersion()
 {
     return QString::fromUtf8(as_version_string());
@@ -30,4 +32,18 @@ QString AppStream::Utils::currentAppStreamVersion()
 int AppStream::Utils::vercmpSimple(const QString &a, const QString &b)
 {
     return as_vercmp(qPrintable(a), qPrintable(b), AS_VERCMP_FLAG_NONE);
+}
+
+QString AppStream::Utils::markupConvert(QStringView description, MarkupKind format)
+{
+    g_autoptr(GError) error = NULL;
+    g_autofree gchar *formatted =
+        as_markup_convert(description.toUtf8(), static_cast<AsMarkupKind>(format), &error);
+
+    if (error) {
+        qWarning() << "error converting description" << error->message;
+        return {};
+    }
+
+    return valueWrap(formatted);
 }

--- a/qt/utils.h
+++ b/qt/utils.h
@@ -29,10 +29,18 @@ namespace AppStream
 namespace Utils
 {
 
+enum APPSTREAMQT_EXPORT MarkupKind {
+    MarkupUnknown = 0,
+    MarkupXML,
+    MarkupText,
+    MarkupMarkdown,
+};
+
 APPSTREAMQT_EXPORT QString currentAppStreamVersion();
 
 APPSTREAMQT_EXPORT int vercmpSimple(const QString &a, const QString &b);
 
+APPSTREAMQT_EXPORT QString markupConvert(QStringView description, MarkupKind format);
 }
 
 }


### PR DESCRIPTION
Expose `as_markup_covert()` function and `AsMarkUpKind` enum, so Qt clients can use the description fields in other suitable formats, such as markdown or simple text