### PR TITLE
docs: Make docs load in 'devhelp' app

### DIFF
--- a/docs/api/compose/meson.build
+++ b/docs/api/compose/meson.build
@@ -15,7 +15,7 @@ custom_target('doc-api-appstream-compose',
       ascdoc_toml,
       asc_gir,
     ],
-    output: 'compose-api',
+    output: 'appstream-compose',
     command: [
       gidocgen_exe,
       'generate',
@@ -39,6 +39,6 @@ custom_target('doc-api-appstream-compose',
 # make Devhelp work
 install_symlink(
     'appstream-compose',
-    pointing_to: '..' / '..' / '..' / as_doc_html_target_dir / 'compose-api',
+    pointing_to: '..' / '..' / '..' / as_doc_html_target_dir / 'appstream-compose',
     install_dir: gtk_doc_root
 )

--- a/docs/api/meson.build
+++ b/docs/api/meson.build
@@ -23,7 +23,7 @@ custom_target('doc-api-appstream',
       asdoc_toml,
       as_gir,
     ],
-    output: 'api',
+    output: 'appstream',
     command: [
       gidocgen_exe,
       'generate',
@@ -48,7 +48,7 @@ custom_target('doc-api-appstream',
 gtk_doc_root = join_paths(get_option('prefix'), get_option('datadir'), 'gtk-doc', 'html')
 install_symlink(
     'appstream',
-    pointing_to: '..' / '..' / '..' / as_doc_html_target_dir / 'api',
+    pointing_to: '..' / '..' / '..' / as_doc_html_target_dir / 'appstream',
     install_dir: gtk_doc_root
 )
 


### PR DESCRIPTION
docs: Make docs load in 'devhelp' app

`devhelp` app expects `.devhelp` index files in one of the following locations:

```
/usr/share/doc/appstream/appstream.devhelp2
/usr/share/doc/appstream/appstream.devhelp2.gz
/usr/share/doc/appstream/appstream.devhelp
/usr/share/doc/appstream/appstream.devhelp.gz

/usr/share/gtk-doc/html/appstream/appstream.devhelp2
/usr/share/gtk-doc/html/appstream/appstream.devhelp2.gz
/usr/share/gtk-doc/html/appstream/appstream.devhelp
/usr/share/gtk-doc/html/appstream/appstream.devhelp.gz
```

but we have the index file in the following locations, which doesn't work.

```
/usr/share/doc/appstream/html/api/api.devhelp2
/usr/share/gtk-doc/html/appstream/api.devhelp2 (symlink to above)
```

Refer following comment in https://github.com/GNOME/devhelp/commit/72f8e5f60.

```
/* The name of the directory the index file is in and the name of
the index file (minus the extension) must match. */
```