### PR TITLE
compose: Insert screenshot tags for auto-generated font screenshots

### DIFF
--- a/compose/asc-utils-fonts.c
+++ b/compose/asc-utils-fonts.c
@@ -158,6 +158,9 @@ asc_render_font_screenshots (AscResult *cres,
 
 			as_screenshot_add_image (scr, img);
 		}
+
+		if (as_screenshot_is_valid (scr))
+			as_component_add_screenshot (cpt, scr);
 	}
 
 	return TRUE;


### PR DESCRIPTION
Previously, compose would generate screenshot thumbnails for fonts in the media directory but not actually insert screenshot tags into the resulting font component.

Resolves #710.