### PR TITLE
compose: Redetermine sample icon text if sample is too long

### DIFF
--- a/compose/asc-font.c
+++ b/compose/asc-font.c
@@ -805,7 +805,7 @@ const gchar *
 asc_font_get_sample_icon_text (AscFont *font)
 {
 	AscFontPrivate *priv = GET_PRIVATE (font);
-	if (as_is_empty (priv->sample_icon_text))
+	if (as_is_empty (priv->sample_icon_text) || g_utf8_strlen (priv->sample_icon_text, -1) > 3)
 		asc_font_determine_sample_texts (font);
 	return priv->sample_icon_text;
 }


### PR DESCRIPTION
Some fonts are set with a sample text that is way to long to be legible, redetermine the icon text if length > 3.