### PR TITLE
compose: Trim substring when truncating font sample text

### DIFF
--- a/compose/asc-font.c
+++ b/compose/asc-font.c
@@ -161,10 +161,15 @@ asc_font_read_sfnt_data (AscFont *font)
 		switch (sname.name_id) {
 		case TT_NAME_ID_SAMPLE_TEXT:
 			g_free (priv->sample_icon_text);
-			if (g_utf8_strlen (val, -1) > 3)
-				priv->sample_icon_text = g_utf8_substring (val, 0, 3);
-			else
+			if (!as_is_empty (val))
+				g_strchug (val);
+			if (g_utf8_strlen (val, -1) > 3) {
+				g_autofree gchar *substr = g_strchomp ( g_utf8_substring (val, 0, 3));
+				if (!as_is_empty (substr))
+					priv->sample_icon_text = g_steal_pointer (&substr);
+			} else {
 				priv->sample_icon_text = g_steal_pointer (&val);
+			}
 			break;
 		case TT_NAME_ID_DESCRIPTION:
 			g_free (priv->description);


### PR DESCRIPTION
This is to avoid alignment issues when presenting text, e.g. font icons

Before:
![install-_overpass-regular](https://github.com/user-attachments/assets/66c54069-0aec-4723-8882-436ca3552bdf)

After:
![install-_overpass-regular](https://github.com/user-attachments/assets/7977919e-1014-4305-ade6-73a5f4265f20)

Part of #717
