### PR TITLE
meson: don't override appstreamcli when cross-building

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -11,7 +11,7 @@ install_data('its/metainfo.loc',
 if meson.is_cross_build()
     dependency('appstream', version: '>=' + as_version, native: true,
                not_found_message: 'Native appstream required for cross-building')
-    ascli_exe = find_program('appstreamcli')
+    ascli_exe = find_program('appstreamcli', native: true)
 endif
 
 # NOTE: We do not translate the release notes on purpose here.

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -17,7 +17,9 @@ ascli_exe = executable('appstreamcli',
     install: true
 )
 
-meson.override_find_program('appstreamcli', ascli_exe)
+if not meson.is_cross_build()
+  meson.override_find_program('appstreamcli', ascli_exe)
+endif
 
 if get_option('compose')
     ascompose_src = [


### PR DESCRIPTION
Using the target build require an exe-wrapper.