### PR TITLE
Add option to optional disable building appstreamcli

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -231,7 +231,9 @@ subdir('src/')
 if get_option('compose')
     subdir('compose/')
 endif
-subdir('tools/')
+if get_option('tools')
+    subdir('tools/')
+endif
 subdir('po/')
 subdir('data/')
 subdir('contrib/')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -48,6 +48,11 @@ option('zstd-support',
        value : true,
        description : 'Support Zstd for (de)compressing local / remote metadata'
 )
+option('tools',
+       type : 'boolean',
+       value : true,
+       description : 'Build appstreamcli'
+)
 
 #
 # For documentation


### PR DESCRIPTION
This useful in case someone only needs the libraries for consumption and not the appstreamcli app for
production.

More detailed:

In KDE we have kde-builder [1] that makes it easy to build the newest KDE (or parts of it) on your distro. When building discover on an older distro, like e.g. debian13, then kde-builder will notice that the systems appstreamqt_lib is to old and build the newest appstream itself [2] and install alongside your own KDE build into a installdir of your choice + provide scripts to setup the environment to use your own install alongside whatever is installed on your system.

Its possible to have different versions of the same libraries used and that works fine due to library versioning. Unfortunately thats not the case for commandaline applications since they are not versioned but its picked what comes in PATH first.

The problem we have now is that while discover only needs appstreamqt_lib the appstreamcli is installed too. flatpak-builder calls "appstreamcli compose" what then means appstreamcli drags in the compose dependency what drags in other dependencies again.

That also means that you are mixing your distros flatpak-builder with a newer appstreamcli IF you run your own compiled environment while when you use the system environment the system flatpak-builder will pick up the system appstreamcli.

This MR provides now a switch to optionally turn of building and installing the appstreamcli tool alongside the appstreamqt_lib. This would then optional enable consumers of appstream to decide if they only need the libs or also the tools. In our case this would also solved [3].

[1] https://kde-builder.kde.org
[2] https://invent.kde.org/sysadmin/repo-metadata/-/blob/master/build-configs/custom-qt6-libs.yaml?ref_type=heads#L117
[3] https://invent.kde.org/sysadmin/repo-metadata/-/merge_requests/700