### PR TITLE
Explicitly add fcfreetype.h include to asc-font.c

### DIFF
--- a/compose/asc-font.c
+++ b/compose/asc-font.c
@@ -29,6 +29,7 @@
 
 #include <glib/gstdio.h>
 #include <fontconfig/fontconfig.h>
+#include <fontconfig/fcfreetype.h>
 #include FT_SFNT_NAMES_H
 #include FT_TRUETYPE_IDS_H
 #include <pango/pango-language.h>


### PR DESCRIPTION
As of https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/b4b753d66dea17d645166adca239a0fba84d03a9 first included in 2.18.0 FcFreeTypeQuery has been moved to fcfreetype.h

Without this:

```
       ../compose/asc-font.c: In function ‘asc_font_load_fontconfig_data_from_file’:
        ../compose/asc-font.c:207:20: error: implicit declaration of function ‘FcFreeTypeQuery’ [-Wimplicit-function-declaration]
          207 |         fpattern = FcFreeTypeQuery ((const guchar *) fname, 0, NULL, &c);
              |                    ^~~~~~~~~~~~~~~
```