### PR TITLE
Add support for elogind.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -202,7 +202,7 @@ else
     zstd_dep = dependency('', required: false)
 endif
 if get_option('systemd')
-    libsystemd_dep = dependency('libsystemd', required: get_option('systemd'))
+    libsystemd_dep = dependency('libsystemd', 'libelogind', required: get_option('systemd'))
 else
     libsystemd_dep = dependency('', required: false)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,7 +6,7 @@ option('stemming',
 option('systemd',
        type : 'boolean',
        value : true,
-       description : 'Build with systemd support'
+       description : 'Build with systemd/elogind support'
 )
 option('vapi',
        type : 'boolean',


### PR DESCRIPTION
Elogind provides the systemd/sd-device.h and systemd/sd-hwdb.h
headers, can be used as a drop-in replacement of systemd.

* meson.build ([systemd]): Add elogind alternative name for dependency check.
* meson_options.txt [systemd]: Mention elogind in description.
