### PR TITLE
system-info: Avoid overflow in physical memory total on 32-bit systems.

### DIFF
--- a/src/as-system-info.c
+++ b/src/as-system-info.c
@@ -479,7 +479,7 @@ as_get_physical_memory_total (void)
 	struct sysinfo si = { 0 };
 	sysinfo (&si);
 	if (si.mem_unit > 0)
-		return (si.totalram * si.mem_unit) / MB_IN_BYTES;
+		return ((guint64) si.totalram * si.mem_unit) / MB_IN_BYTES;
 	return 0;
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 	unsigned long physmem;


### PR DESCRIPTION
* src/as-system-info.c (as_get_physical_memory_total): Add a guint64
cast to ensure the multiplication is done using 64-bit arithmetic.
